### PR TITLE
[RATIS-311] DeadLock between AppendEntries request and RaftLogWorker

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1053,9 +1053,11 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
         groupId, term, lastEntry);
   }
 
-  public synchronized void submitLocalSyncEvent() {
+  public void submitLocalSyncEvent() {
     if (isLeader() && leaderState != null) {
-      leaderState.submitUpdateStateEvent(LeaderState.UPDATE_COMMIT_EVENT);
+      synchronized (leaderState) {
+        leaderState.submitUpdateStateEvent(LeaderState.UPDATE_COMMIT_EVENT);
+      }
     }
   }
 


### PR DESCRIPTION
How to reproduce the issue?
Launch 3 servers, kill Server-1, and use a client send large requests.
Restart Server-1, the Server-1 will be in stuck.

What's the root cause?
Look at the two operations below:
1. The appendEntries request will submit a WirteLog request to a BlockingQueue. 
2. And another thread named rateLogWorker will poll the queue and do something.

Both  Operation-1 and Operation-2 need to hold the sync lock of RaftServer. 

If the Operation-1 is more faster than Operation-2, the BlockingQueue will get full, and Operation -1 will be blocked by BlockingQueue with holding the RaftServer Lock.
But the Operation-2 need to hold the lock to poll the queue.
Then the dead lock will happen.

![image](https://user-images.githubusercontent.com/8434428/45205358-7e711e00-b2b4-11e8-9127-0e93bc6569ac.png)

![image](https://user-images.githubusercontent.com/8434428/45205370-84ff9580-b2b4-11e8-87e3-0b073c13f618.png)


More details could be found in https://issues.apache.org/jira/browse/RATIS-311