### PR TITLE
RATIS-564. Add raft group Id to install snapshot notification.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
@@ -525,7 +525,7 @@ public class LogAppender {
 
   protected void checkSlowness() {
     if (follower.isSlow()) {
-      server.getStateMachine().notifySlowness(server.getGroup(), server.getRoleInfoProto());
+      server.getStateMachine().notifySlowness(server.getRoleInfoProto());
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -457,7 +457,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
     role.shutdownFollowerState();
     setRole(RaftPeerRole.CANDIDATE, "changeToCandidate");
     if (state.checkForExtendedNoLeader()) {
-      stateMachine.notifyExtendedNoLeader(getGroup(), getRoleInfoProto());
+      stateMachine.notifyExtendedNoLeader(getRoleInfoProto());
     }
     // start election
     role.startLeaderElection(this);
@@ -1190,9 +1190,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
                 "index is {} but the leader's first available log index is {}.",
             getId(), state.getLog().getNextIndex(), firstAvailableLogIndex);
 
-        stateMachine.notifyInstallSnapshotFromLeader(getGroup(),
-            getRoleInfoProto(),
-            firstAvailableLogTermIndex)
+        stateMachine.notifyInstallSnapshotFromLeader(getRoleInfoProto(), firstAvailableLogTermIndex)
             .whenComplete((reply, exception) -> {
               if (exception != null) {
                 LOG.error(getId() + ": State Machine failed to install snapshot", exception);

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -260,10 +260,15 @@ public interface StateMachine extends Closeable {
    * to install the latest snapshot.
    * @param firstTermIndexInLog TermIndex of the first append entry available
    *                           in the Leader's log.
+   * @param group raft group information
+   * @param roleInfoProto information about the current node role and
+   *                            rpc delay information
    * @return After the snapshot installation is complete, return the last
    * included term index in the snapshot.
    */
-  default CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(TermIndex firstTermIndexInLog) {
+  default CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
+      RaftGroup group, RoleInfoProto roleInfoProto,
+      TermIndex firstTermIndexInLog) {
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -218,7 +218,7 @@ public interface StateMachine extends Closeable {
    * @param group raft group information
    * @param roleInfoProto information about the current node role and rpc delay information
    */
-  default void notifySlowness(RaftGroup group, RoleInfoProto roleInfoProto) {
+  default void notifySlowness(RoleInfoProto roleInfoProto) {
 
   }
 
@@ -229,7 +229,7 @@ public interface StateMachine extends Closeable {
    * @param group raft group information
    * @param roleInfoProto information about the current node role and rpc delay information
    */
-  default void notifyExtendedNoLeader(RaftGroup group, RoleInfoProto roleInfoProto) {
+  default void notifyExtendedNoLeader(RoleInfoProto roleInfoProto) {
 
   }
 
@@ -267,8 +267,7 @@ public interface StateMachine extends Closeable {
    * included term index in the snapshot.
    */
   default CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
-      RaftGroup group, RoleInfoProto roleInfoProto,
-      TermIndex firstTermIndexInLog) {
+      RoleInfoProto roleInfoProto, TermIndex firstTermIndexInLog) {
     return CompletableFuture.completedFuture(null);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -215,7 +215,6 @@ public interface StateMachine extends Closeable {
    * Notify the Leader's state machine that one of the followers is slow
    * this notification is based on "raft.server.rpc.slowness.timeout"
    *
-   * @param group raft group information
    * @param roleInfoProto information about the current node role and rpc delay information
    */
   default void notifySlowness(RoleInfoProto roleInfoProto) {
@@ -226,7 +225,6 @@ public interface StateMachine extends Closeable {
    * Notify the Leader's state machine that a leader has not been elected for a long time
    * this notification is based on "raft.server.leader.election.timeout"
    *
-   * @param group raft group information
    * @param roleInfoProto information about the current node role and rpc delay information
    */
   default void notifyExtendedNoLeader(RoleInfoProto roleInfoProto) {
@@ -260,7 +258,6 @@ public interface StateMachine extends Closeable {
    * to install the latest snapshot.
    * @param firstTermIndexInLog TermIndex of the first append entry available
    *                           in the Leader's log.
-   * @param group raft group information
    * @param roleInfoProto information about the current node role and
    *                            rpc delay information
    * @return After the snapshot installation is complete, return the last

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
@@ -159,6 +159,8 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   private volatile RoleInfoProto slownessInfo = null;
   private volatile RoleInfoProto leaderElectionTimeoutInfo = null;
 
+  private RaftGroupId groupId;
+
   public SimpleStateMachine4Testing() {
     checkpointer = new Daemon(() -> {
       while (running) {
@@ -200,6 +202,7 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   public synchronized void initialize(RaftServer server, RaftGroupId groupId,
       RaftStorage raftStorage) throws IOException {
     LOG.info("Initializing " + this);
+    this.groupId = groupId;
     lifeCycle.startAndTransition(() -> {
       super.initialize(server, groupId, raftStorage);
       storage.init(raftStorage);
@@ -402,14 +405,14 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   }
 
   @Override
-  public void notifySlowness(RaftGroup group, RoleInfoProto roleInfoProto) {
-    LOG.info("{}: notifySlowness {}, {}", this, group, roleInfoProto);
+  public void notifySlowness(RoleInfoProto roleInfoProto) {
+    LOG.info("{}: notifySlowness {}, {}", this, groupId, roleInfoProto);
     slownessInfo = roleInfoProto;
   }
 
   @Override
-  public void notifyExtendedNoLeader(RaftGroup group, RoleInfoProto roleInfoProto) {
-    LOG.info("{}: notifyExtendedNoLeader {}, {}", this, group, roleInfoProto);
+  public void notifyExtendedNoLeader(RoleInfoProto roleInfoProto) {
+    LOG.info("{}: notifyExtendedNoLeader {}, {}", this, groupId, roleInfoProto);
     leaderElectionTimeoutInfo = roleInfoProto;
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestInstallSnapshotWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestInstallSnapshotWithGrpc.java
@@ -22,7 +22,9 @@ import org.apache.ratis.MiniRaftCluster;
 import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.impl.RaftServerImpl;
@@ -93,7 +95,9 @@ public class TestInstallSnapshotWithGrpc {
   private static class StateMachineForGRpcTest extends
       SimpleStateMachine4Testing {
     @Override
-    public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(TermIndex termIndex) {
+    public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
+        RaftGroup group, RaftProtos.RoleInfoProto roleInfoProto,
+        TermIndex termIndex) {
       try {
         Path leaderSnapshotFile = leaderSnapshotInfo.getFile().getPath();
         File followerSnapshotFilePath = new File(getSMdir(),

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestInstallSnapshotWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestInstallSnapshotWithGrpc.java
@@ -96,7 +96,7 @@ public class TestInstallSnapshotWithGrpc {
       SimpleStateMachine4Testing {
     @Override
     public CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
-        RaftGroup group, RaftProtos.RoleInfoProto roleInfoProto,
+        RaftProtos.RoleInfoProto roleInfoProto,
         TermIndex termIndex) {
       try {
         Path leaderSnapshotFile = leaderSnapshotInfo.getFile().getPath();


### PR DESCRIPTION
The current API: org.apache.ratis.statemachine.StateMachine#notifyInstallSnapshotFromLeader, only provides the term index.