### PR TITLE
RATIS-574. Configured sleep interval in RetryPolicy should not be used on NotLeaderException

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -173,7 +173,7 @@ class OrderedAsync {
       e = JavaUtils.unwrapCompletionException(e);
       if (e instanceof NotLeaderException) {
         RetryPolicy noLeaderRetry = ((NotLeaderException) e).getSuggestedLeader() != null ?
-            RetryPolicies.retryUpToMaximumCountWithNoSleep(pending.getAttemptCount()) : retryPolicy;
+            RetryPolicies.retryForeverNoSleep() : retryPolicy;
         scheduleWithTimeout(pending, request, noLeaderRetry);
         return null;
       }

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/OrderedAsync.java
@@ -172,8 +172,9 @@ class OrderedAsync {
     }).exceptionally(e -> {
       e = JavaUtils.unwrapCompletionException(e);
       if (e instanceof NotLeaderException) {
-        scheduleWithTimeout(pending, request,
-            RetryPolicies.retryUpToMaximumCountWithNoSleep(pending.getAttemptCount()));
+        RetryPolicy noLeaderRetry = ((NotLeaderException) e).getSuggestedLeader() != null ?
+            RetryPolicies.retryUpToMaximumCountWithNoSleep(pending.getAttemptCount()) : retryPolicy;
+        scheduleWithTimeout(pending, request, noLeaderRetry);
         return null;
       }
       f.completeExceptionally(e);

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
@@ -359,7 +359,7 @@ final class RaftClientImpl implements RaftClient {
       newLeader = CollectionUtils.random(oldLeader,
           CollectionUtils.as(peers, RaftPeer::getId));
     }
-    LOG.debug("{}: oldLeader={},  curLeader={}, newLeader{}", clientId, oldLeader, curLeader, newLeader);
+    LOG.debug("{}: oldLeader={},  curLeader={}, newLeader={}", clientId, oldLeader, curLeader, newLeader);
 
     final boolean changeLeader = newLeader != null && stillLeader;
     if (changeLeader) {

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/UnorderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/UnorderedAsync.java
@@ -100,7 +100,7 @@ public interface UnorderedAsync {
             if (e instanceof NotLeaderException) {
               client.handleNotLeaderException(request, (NotLeaderException) e, null);
               retryPolicy = ((NotLeaderException) e).getSuggestedLeader() != null ?
-                  RetryPolicies.retryUpToMaximumCountWithNoSleep(pending.getAttemptCount()) : retryPolicy;
+                  RetryPolicies.retryForeverNoSleep() : retryPolicy;
             } else if (e instanceof GroupMismatchException) {
               f.completeExceptionally(e);
               return;

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/UnorderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/UnorderedAsync.java
@@ -99,7 +99,8 @@ public interface UnorderedAsync {
           if (e instanceof IOException) {
             if (e instanceof NotLeaderException) {
               client.handleNotLeaderException(request, (NotLeaderException) e, null);
-              retryPolicy = RetryPolicies.retryUpToMaximumCountWithNoSleep(pending.getAttemptCount());
+              retryPolicy = ((NotLeaderException) e).getSuggestedLeader() != null ?
+                  RetryPolicies.retryUpToMaximumCountWithNoSleep(pending.getAttemptCount()) : retryPolicy;
             } else if (e instanceof GroupMismatchException) {
               f.completeExceptionally(e);
               return;

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/UnorderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/UnorderedAsync.java
@@ -24,6 +24,7 @@ import org.apache.ratis.protocol.NotLeaderException;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftException;
+import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.util.JavaUtils;
 import org.slf4j.Logger;
@@ -80,7 +81,7 @@ public interface UnorderedAsync {
           f.complete(reply);
           return;
         }
-        final RetryPolicy retryPolicy = client.getRetryPolicy();
+        RetryPolicy retryPolicy = client.getRetryPolicy();
         if (!retryPolicy.shouldRetry(attemptCount, request)) {
           f.completeExceptionally(
               client.noMoreRetries(request, attemptCount, replyException != null? replyException: e));
@@ -98,6 +99,7 @@ public interface UnorderedAsync {
           if (e instanceof IOException) {
             if (e instanceof NotLeaderException) {
               client.handleNotLeaderException(request, (NotLeaderException) e, null);
+              retryPolicy = RetryPolicies.retryUpToMaximumCountWithNoSleep(pending.getAttemptCount());
             } else if (e instanceof GroupMismatchException) {
               f.completeExceptionally(e);
               return;

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
@@ -39,7 +39,7 @@ public class RaftClientReply extends RaftClientMessage {
    * 1. NotLeaderException if the server is not leader
    * 2. StateMachineException if the server's state machine returns an exception
    */
-  private RaftException exception;
+  private final RaftException exception;
   private final Message message;
 
   /**

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
@@ -39,7 +39,7 @@ public class RaftClientReply extends RaftClientMessage {
    * 1. NotLeaderException if the server is not leader
    * 2. StateMachineException if the server's state machine returns an exception
    */
-  private final RaftException exception;
+  private RaftException exception;
   private final Message message;
 
   /**

--- a/ratis-common/src/main/java/org/apache/ratis/retry/RetryPolicies.java
+++ b/ratis-common/src/main/java/org/apache/ratis/retry/RetryPolicies.java
@@ -51,6 +51,10 @@ public interface RetryPolicies {
     return new RetryLimited(maxAttempts, sleepTime);
   }
 
+  static RetryLimited retryUpToMaximumCountWithNoSleep(int maxAttempts) {
+    return new RetryLimited(maxAttempts, RetryPolicy.ZERO_MILLIS);
+  }
+
   class Constants {
     private static final RetryForeverNoSleep RETRY_FOREVER_NO_SLEEP = new RetryForeverNoSleep();
     private static final NoRetry NO_RETRY = new NoRetry();
@@ -131,7 +135,7 @@ public interface RetryPolicies {
 
     @Override
     public TimeDuration getSleepTime(int attemptCount, RaftClientRequest request) {
-      return shouldRetry(attemptCount, request)? sleepTime: ZERO_MILLIS;
+      return shouldRetry(attemptCount, request) ? sleepTime: ZERO_MILLIS;
     }
 
     public int getMaxAttempts() {

--- a/ratis-common/src/main/java/org/apache/ratis/retry/RetryPolicies.java
+++ b/ratis-common/src/main/java/org/apache/ratis/retry/RetryPolicies.java
@@ -50,11 +50,7 @@ public interface RetryPolicies {
   static RetryLimited retryUpToMaximumCountWithFixedSleep(int maxAttempts, TimeDuration sleepTime) {
     return new RetryLimited(maxAttempts, sleepTime);
   }
-
-  static RetryLimited retryUpToMaximumCountWithNoSleep(int maxAttempts) {
-    return new RetryLimited(maxAttempts, RetryPolicy.ZERO_MILLIS);
-  }
-
+  
   class Constants {
     private static final RetryForeverNoSleep RETRY_FOREVER_NO_SLEEP = new RetryForeverNoSleep();
     private static final NoRetry NO_RETRY = new NoRetry();


### PR DESCRIPTION
While doing performance tests with Ozone, it was observed that the client always waits for retry timeout when a NotLeaderException is logged. This bears a performance penalty for the client who cannot try the next Ratis server in the ring.