### PR TITLE
RATIS-629. Vagrant loadgen does not run

### DIFF
--- a/dev-support/vagrant/bin/start_ratis_load_gen.sh
+++ b/dev-support/vagrant/bin/start_ratis_load_gen.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -22,8 +21,9 @@ peers=$1
 
 cd ${HOME}/incubator-ratis
 
+export QUORUM_OPTS="--peers $peers"
 # run the load generator
-./ratis-examples/src/main/bin/client.sh filestore loadgen --size 1048576 --numFiles 100 --peers $peers 2>&1 | \
+./ratis-examples/src/main/bin/client.sh filestore loadgen --size 1048576 --numFiles 100 2>&1 | \
   tee ${HOME}/loadgen.log
 
 # verify all logs checksum the same

--- a/dev-support/vagrant/bin/start_ratis_server.sh
+++ b/dev-support/vagrant/bin/start_ratis_server.sh
@@ -23,5 +23,5 @@ id=$2
 peers=$3
 
 cd ${HOME}/incubator-ratis/
-java -jar `find ./ -name 'ratis-examples*-SNAPSHOT.jar'` filestore server --storage $storage --id $id --peers $peers 2>&1 | \
+./ratis-examples/src/main/bin/server.sh filestore server --storage $storage --id $id --peers $peers 2>&1 | \
   tee ${HOME}/server_${id}.log


### PR DESCRIPTION
This updates the start-up scripts the Vagrant test-harness uses to match those in ratis-examples better after RATIS-480.