### PR TITLE
RATIS-639. Inconsistent pattern for variable names in Arithmetic example

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/UnaryExpression.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/UnaryExpression.java
@@ -17,20 +17,21 @@
  */
 package org.apache.ratis.examples.arithmetic.expression;
 
-import org.apache.ratis.util.Preconditions;
-
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.DoubleFunction;
 import java.util.function.UnaryOperator;
 
+import org.apache.ratis.util.Preconditions;
+
 public class UnaryExpression implements Expression {
   static final BiFunction<Op, Expression, String> PREFIX_OP_TO_STRING = (op, e) -> op + "" + e;
   static final BiFunction<Op, Expression, String> POSTFIX_OP_TO_STRING = (op, e) -> e + "" + op;
 
   public enum Op implements UnaryOperator<Expression>, DoubleFunction<Expression> {
-    NEG("~"), SQRT("√"), SQUARE("^2", POSTFIX_OP_TO_STRING);
+    NEG("~"), SQRT("√"), SQUARE("^2", POSTFIX_OP_TO_STRING),
+    MINUS("-"), ;
 
     final String symbol;
     final BiFunction<Op, Expression, String> stringFunction;
@@ -109,6 +110,7 @@ public class UnaryExpression implements Expression {
   public Double evaluate(Map<String, Double> variableMap) {
     final double value = expression.evaluate(variableMap);
     switch (op) {
+      case MINUS:
       case NEG:
         return -value;
       case SQRT:

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/Variable.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/Variable.java
@@ -25,8 +25,7 @@ import org.apache.ratis.util.Preconditions;
 
 public class Variable implements Expression {
   static final int LENGTH_LIMIT = 32;
-  static final String REGEX = "[a-zA-Z]\\w*";
-  static final Pattern PATTERN = Pattern.compile(REGEX);
+  public static final Pattern PATTERN = Pattern.compile("[a-zA-Z]\\w*");
 
   static byte[] string2bytes(String s) {
     final byte[] stringBytes = s.getBytes(AssignmentMessage.UTF8);

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/cli/TestAssignCli.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/cli/TestAssignCli.java
@@ -17,14 +17,17 @@
  */
 package org.apache.ratis.examples.arithmetic.cli;
 
+import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.ADD;
+import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.MULT;
+import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.SUBTRACT;
+import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op.MINUS;
+import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op.NEG;
+import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op.SQRT;
+
 import org.apache.ratis.examples.arithmetic.expression.DoubleValue;
 import org.apache.ratis.examples.arithmetic.expression.Variable;
 import org.junit.Assert;
 import org.junit.Test;
-
-import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.ADD;
-import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.MULT;
-import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op.SQRT;
 
 public class TestAssignCli {
   @Test
@@ -34,23 +37,51 @@ public class TestAssignCli {
         new Assign().createExpression("2.0"));
 
     Assert.assertEquals(
+        new DoubleValue(42.0),
+        new Assign().createExpression("42"));
+
+    Assert.assertEquals(
         MULT.apply(2.0, new Variable("a")),
         new Assign().createExpression("2*a"));
+
+    Assert.assertEquals(
+        MULT.apply(new Variable("v1"), 2.0),
+        new Assign().createExpression("v1 * 2"));
 
     Assert.assertEquals(
         ADD.apply(2.0, 1.0),
         new Assign().createExpression("2+1"));
 
     Assert.assertEquals(
-        ADD.apply(new Variable("a"), new Variable("b")),
-        new Assign().createExpression("a+b"));
+        SUBTRACT.apply(1.0, 6.0),
+        new Assign().createExpression("1 - 6"));
+
+    Assert.assertEquals(
+        ADD.apply(new Variable("a"), new Variable("v2")),
+        new Assign().createExpression("a+v2"));
+
+    Assert.assertEquals(
+        ADD.apply(new Variable("v1"), new Variable("b")),
+        new Assign().createExpression("v1 + b"));
 
     Assert.assertEquals(
         SQRT.apply(new Variable("a")),
         new Assign().createExpression("√a"));
 
     Assert.assertEquals(
+        SQRT.apply(new Variable("ABC")),
+        new Assign().createExpression("√ABC"));
+
+    Assert.assertEquals(
         SQRT.apply(2.0),
         new Assign().createExpression("√2"));
+
+    Assert.assertEquals(
+        NEG.apply(2.0),
+        new Assign().createExpression("~2.0"));
+
+    Assert.assertEquals(
+        MINUS.apply(6.0),
+        new Assign().createExpression("-6.0"));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Allow variable names like `v1` in expressions, too
2. Allow expressions like `0.1 + 0.2`
3. Fix `NumberFormatException` for expression like `-5`

https://issues.apache.org/jira/browse/RATIS-639

## How was this patch tested?

Added test cases in unit test.  Also tested manually via CLI.