### PR TITLE
RATIS-390. Fix java package structure.

### DIFF
--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogServiceClient.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogServiceClient.java
@@ -15,15 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.apache.ratis.logservice.client;
+package org.apache.ratis.logservice.api;
 
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.logservice.api.LogInfo;
-import org.apache.ratis.logservice.api.LogName;
-import org.apache.ratis.logservice.api.LogServiceConfiguration;
-import org.apache.ratis.logservice.api.LogStream;
 import org.apache.ratis.logservice.api.LogStream.State;
 import org.apache.ratis.logservice.common.Constants;
 import org.apache.ratis.logservice.impl.ArchivedLogStreamImpl;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/Command.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/Command.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ratis.logservice.shell;
 
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;
 

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/LogServiceShell.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/LogServiceShell.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.Map.Entry;
 import java.util.Objects;
 
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.commands.ExitCommand;
 import org.jline.reader.EndOfFileException;
 import org.jline.reader.History;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ArchiveLogCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ArchiveLogCommand.java
@@ -18,7 +18,7 @@
 package org.apache.ratis.logservice.shell.commands;
 
 import org.apache.ratis.logservice.api.LogName;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/CreateLogCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/CreateLogCommand.java
@@ -19,7 +19,7 @@ package org.apache.ratis.logservice.shell.commands;
 
 import org.apache.ratis.logservice.api.LogName;
 import org.apache.ratis.logservice.api.LogStream;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/DeleteLogCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/DeleteLogCommand.java
@@ -20,7 +20,7 @@ package org.apache.ratis.logservice.shell.commands;
 import java.io.IOException;
 
 import org.apache.ratis.logservice.api.LogName;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ExitCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ExitCommand.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ratis.logservice.shell.commands;
 
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ExportLogCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ExportLogCommand.java
@@ -18,7 +18,7 @@
 package org.apache.ratis.logservice.shell.commands;
 
 import org.apache.ratis.logservice.api.LogName;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/HelpCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/HelpCommand.java
@@ -17,7 +17,7 @@
  */
 package org.apache.ratis.logservice.shell.commands;
 
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.apache.ratis.logservice.shell.CommandFactory;
 import org.jline.reader.LineReader;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ListLogsCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ListLogsCommand.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.ratis.logservice.api.LogInfo;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/PutToLogCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/PutToLogCommand.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.ratis.logservice.api.LogName;
 import org.apache.ratis.logservice.api.LogStream;
 import org.apache.ratis.logservice.api.LogWriter;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ReadLogCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ReadLogCommand.java
@@ -24,7 +24,7 @@ import java.util.List;
 import org.apache.ratis.logservice.api.LogName;
 import org.apache.ratis.logservice.api.LogReader;
 import org.apache.ratis.logservice.api.LogStream;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.shell.Command;
 import org.jline.reader.LineReader;
 import org.jline.terminal.Terminal;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/tool/VerificationTool.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/tool/VerificationTool.java
@@ -34,7 +34,7 @@ import org.apache.ratis.logservice.api.LogName;
 import org.apache.ratis.logservice.api.LogReader;
 import org.apache.ratis.logservice.api.LogStream;
 import org.apache.ratis.logservice.api.LogWriter;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.common.LogNotFoundException;
 import org.apache.ratis.logservice.server.LogStateMachine;
 import org.slf4j.Logger;

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
@@ -20,7 +20,7 @@ package org.apache.ratis.logservice.server;
 
 import org.apache.ratis.logservice.api.*;
 import org.apache.ratis.logservice.api.LogStream.State;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.common.LogAlreadyExistException;
 import org.apache.ratis.logservice.common.LogNotFoundException;
 import org.apache.ratis.logservice.metrics.LogServiceMetricsRegistry;

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/tool/TestVerificationTool.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/tool/TestVerificationTool.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
 import java.nio.ByteBuffer;
 
 import org.apache.ratis.logservice.api.LogName;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.tool.VerificationTool.Operation;
 import org.junit.Test;
 

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/util/LogServiceCluster.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/util/LogServiceCluster.java
@@ -22,7 +22,7 @@ package org.apache.ratis.logservice.util;
 import org.apache.ratis.BaseTest;
 import org.apache.ratis.logservice.api.LogName;
 import org.apache.ratis.logservice.api.LogStream;
-import org.apache.ratis.logservice.client.LogServiceClient;
+import org.apache.ratis.logservice.api.LogServiceClient;
 import org.apache.ratis.logservice.server.LogServer;
 import org.apache.ratis.logservice.server.MetadataServer;
 


### PR DESCRIPTION
This patch modifies the package of LogServiceClient as description of RATIS-390.
But the package of LogStateMachine is changed to server, so I don't modify it.