### PR TITLE
RATIS-758. Illegal state transition in LeaderElection: RUNNING to CLOSED

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -23,6 +23,7 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.statemachine.SnapshotInfo;
+import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.Daemon;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.LogUtils;
@@ -118,16 +119,27 @@ class LeaderElection implements Runnable {
 
   void start() {
     lifeCycle.transition(LifeCycle.State.STARTING);
-    lifeCycle.transition(LifeCycle.State.RUNNING);
     daemon.start();
+  }
+
+  @VisibleForTesting
+  void startInForeground() {
+    lifeCycle.transition(LifeCycle.State.STARTING);
+    run();
   }
 
   void shutdown() {
     lifeCycle.checkStateAndClose();
   }
 
+  @VisibleForTesting
+  LifeCycle.State getCurrentState() {
+    return lifeCycle.getCurrentState();
+  }
+
   @Override
   public void run() {
+    lifeCycle.transition(LifeCycle.State.RUNNING);
     Timestamp electionStartTime = Timestamp.currentTime();
     try {
       askForVotes();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -160,7 +160,7 @@ class LeaderElection implements Runnable {
     } finally {
       // Update leader election completion metric(s).
       server.getLeaderElectionMetricsRegistry().onLeaderElectionCompletion(electionStartTime.elapsedTimeMs());
-      lifeCycle.transition(LifeCycle.State.CLOSED);
+      lifeCycle.checkStateAndClose(() -> {});
     }
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -23,12 +23,17 @@ import org.apache.ratis.MiniRaftCluster;
 import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.metrics.LeaderElectionMetrics;
 import org.apache.ratis.server.metrics.RatisMetrics;
 import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogTestUtils;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.Log4jUtils;
+import org.apache.ratis.util.LogUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.Timestamp;
 import org.junit.Assert;
@@ -45,7 +50,11 @@ import static org.apache.ratis.RaftTestUtil.waitForLeader;
 import static org.apache.ratis.server.metrics.RatisMetricNames.LEADER_ELECTION_COUNT_METRIC;
 import static org.apache.ratis.server.metrics.RatisMetricNames.LEADER_ELECTION_LATENCY;
 import static org.apache.ratis.server.metrics.RatisMetricNames.LEADER_ELECTION_TIMEOUT_COUNT_METRIC;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     extends BaseTest
@@ -166,5 +175,24 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     Long leaderElectionLatency = (Long) ratisMetricRegistry.getGauges((s, metric) ->
         s.contains(LEADER_ELECTION_LATENCY)).values().iterator().next().getValue();
     assertTrue(leaderElectionLatency > 0 && leaderElectionLatency < timestamp.elapsedTimeMs());
+  }
+
+  @Test
+  public void testImmediatelyRevertedToFollower() {
+    RaftServerImpl server = mock(RaftServerImpl.class);
+    when(server.isAlive()).thenReturn(true);
+    when(server.isCandidate()).thenReturn(false);
+    when(server.getMemberId()).thenReturn(RaftGroupMemberId.valueOf(RaftPeerId.valueOf("any"), RaftGroupId.randomId()));
+    LeaderElectionMetrics leaderElectionMetrics = LeaderElectionMetrics.getLeaderElectionMetrics(server);
+    when(server.getLeaderElectionMetricsRegistry()).thenReturn(leaderElectionMetrics);
+
+    LeaderElection subject = new LeaderElection(server);
+    try {
+      subject.startInForeground();
+      assertEquals(LifeCycle.State.CLOSED, subject.getCurrentState());
+    } catch (Exception e) {
+      LOG.info("Error starting LeaderElection", e);
+      fail(e.getMessage());
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure `LeaderElection` is transitioned to `CLOSED` via `CLOSING`.  Even if `askForVotes` has no chance for any iteration due to already being changed to follower.

The first commit contains repro code, and can be dropped or reworked, eg. if mocking or exposing some methods only for testing is not desirable.

The second commit is the fix itself.

https://issues.apache.org/jira/browse/RATIS-758

## How was this patch tested?

Added unit test case to reproduce the problem and verify the fix.  Currently running all tests to check for regressions.