### PR TITLE
RATIS-807. ratis-tools subproject is not included in the release jar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,18 @@
        <scope>test</scope>
       </dependency>
       <dependency>
+        <artifactId>ratis-tools</artifactId>
+        <groupId>org.apache.ratis</groupId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <artifactId>ratis-tools</artifactId>
+        <groupId>org.apache.ratis</groupId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <artifactId>ratis-grpc</artifactId>
         <groupId>org.apache.ratis</groupId>
         <version>${project.version}</version>

--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -283,6 +283,10 @@
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-metrics</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-tools</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/ratis-assembly/src/main/assembly/bin.xml
+++ b/ratis-assembly/src/main/assembly/bin.xml
@@ -41,6 +41,7 @@
         <include>org.apache.ratis:ratis-server</include>
         <include>org.apache.ratis:ratis-test</include>
         <include>org.apache.ratis:ratis-metrics</include>
+        <include>org.apache.ratis:ratis-tools</include>
         <include>org.apache.ratis:ratis-resource-bundle</include>
       </includes>
       <binaries>

--- a/ratis-assembly/src/main/assembly/src.xml
+++ b/ratis-assembly/src/main/assembly/src.xml
@@ -42,6 +42,7 @@
         <include>org.apache.ratis:ratis-server</include>
         <include>org.apache.ratis:ratis-test</include>
         <include>org.apache.ratis:ratis-metrics</include>
+        <include>org.apache.ratis:ratis-tools</include>
         <include>org.apache.ratis:ratis-resource-bundle</include>
       </includes>
       <sources>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/RATIS-807


How is this tested:

Test with the release script dev-support/make-rc.sh prepare_src and prepare_bin

prepare_bin will fail without the change.