### PR TITLE
RATIS-817. Bump the copyright year of the NOTICE.txt.

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Ratis
-Copyright 2017-2019 The Apache Software Foundation
+Copyright 2017-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/ratis-assembly/src/main/resources/NOTICE
+++ b/ratis-assembly/src/main/resources/NOTICE
@@ -1,5 +1,5 @@
 Apache Ratis
-Copyright 2017-2019 The Apache Software Foundation
+Copyright 2017-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
https://issues.apache.org/jira/browse/RATIS-817
