### PR TITLE
RATIS-818. New releases not listed in website.

### DIFF
--- a/content/post/0.2.0.md
+++ b/content/post/0.2.0.md
@@ -2,7 +2,7 @@
 title: Release 0.2.0 is available
 date: 2018-07-15
 type: release
-linked: true
+sourceonly: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");

--- a/content/post/0.4.0.md
+++ b/content/post/0.4.0.md
@@ -1,6 +1,6 @@
 ---
-title: Release 0.3.0 is available
-date: 2019-04-21
+title: Release 0.4.0 is available
+date: 2019-09-12
 type: release
 sourceonly: true
 ---
@@ -20,8 +20,8 @@ sourceonly: true
 
 [Download](https://ratis.incubator.apache.org/#download)
 
-It contains new features such as multi-raft and watch request, as well contains 73 improvements and 72 bug fixes.
-See the [changes between 0.2.0 and 0.3.0](https://github.com/apache/incubator-ratis/compare/ratis-0.2.0...ratis-0.3.0) releases. 
+It contains more than 89 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
+See the [changes between 0.3.0 and 0.4.0](https://github.com/apache/incubator-ratis/compare/0.3.0...ratis-0.4.0-rc4) releases. 
 
 It has been tested with [Apache Hadoop Ozone](https://hadoop.apache.org/ozone/) where Apache Ratis is used to replicate raw data. 
 

--- a/content/post/0.5.0.md
+++ b/content/post/0.5.0.md
@@ -1,8 +1,8 @@
 ---
-title: Release 0.3.0 is available
-date: 2019-04-21
+title: Release 0.5.0 is available
+date: 2020-02-04
 type: release
-sourceonly: true
+linked: true
 ---
 <!---
   Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,8 +20,8 @@ sourceonly: true
 
 [Download](https://ratis.incubator.apache.org/#download)
 
-It contains new features such as multi-raft and watch request, as well contains 73 improvements and 72 bug fixes.
-See the [changes between 0.2.0 and 0.3.0](https://github.com/apache/incubator-ratis/compare/ratis-0.2.0...ratis-0.3.0) releases. 
+It contains more than 94 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
+See the [changes between 0.4.0 and 0.5.0](https://github.com/apache/incubator-ratis/compare/0.4.0-rc4...ratis-0.5.0-rc0) releases. 
 
 It has been tested with [Apache Hadoop Ozone](https://hadoop.apache.org/ozone/) where Apache Ratis is used to replicate raw data. 
 


### PR DESCRIPTION
https://issues.apache.org/jira/projects/RATIS/issues/RATIS-818


Adding release post for 0.4.0 and 0.5.0 for asf-site-source branch.


Tested with build.sh and hugo serve.
