### PR TITLE
RATIS-821. Fix high processor load for ScheduledThreadPoolExecutor with 0 core threads

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/TimeoutScheduler.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/TimeoutScheduler.java
@@ -85,7 +85,7 @@ public final class TimeoutScheduler implements Closeable {
 
     private static ScheduledThreadPoolExecutor newExecutor() {
       LOG.debug("new ScheduledThreadPoolExecutor");
-      final ScheduledThreadPoolExecutor e = new ScheduledThreadPoolExecutor(0, (ThreadFactory) Daemon::new);
+      final ScheduledThreadPoolExecutor e = new ScheduledThreadPoolExecutor(1, (ThreadFactory) Daemon::new);
       e.setRemoveOnCancelPolicy(true);
       return e;
     }


### PR DESCRIPTION
1. This bug is related to the bug of JDK8: https://bugs.openjdk.java.net/browse/JDK-8129861. When create a thread pool with size 0,  it will causing 100% CPU load forever when schedule a shutdown task.
2. This bug was triggered in hadoop-ozone, the related PR is: https://github.com/apache/hadoop-ozone/pull/611. The triggered stack is as the image shows.
![image](https://user-images.githubusercontent.com/51938049/75652448-06f83100-5c96-11ea-9ca2-488826ba352c.png)
