### PR TITLE
RATIS-832. Add Metrics for retry cache

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -25,6 +25,7 @@ import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.RaftServerMXBean;
 import org.apache.ratis.server.RaftServerRpc;
 import org.apache.ratis.server.metrics.LeaderElectionMetrics;
+import org.apache.ratis.server.metrics.RetryCacheMetrics;
 import org.apache.ratis.server.protocol.RaftServerAsynchronousProtocol;
 import org.apache.ratis.server.protocol.RaftServerProtocol;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -89,6 +90,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
   private final RaftServerJmxAdapter jmxAdapter;
   private final LeaderElectionMetrics leaderElectionMetrics;
   private final RaftServerMetrics raftServerMetrics;
+  private final RetryCacheMetrics retryCacheMetrics;
 
   private AtomicReference<TermIndex> inProgressInstallSnapshotRequest;
 
@@ -116,6 +118,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
     this.jmxAdapter = new RaftServerJmxAdapter();
     this.leaderElectionMetrics = LeaderElectionMetrics.getLeaderElectionMetrics(this);
     this.raftServerMetrics = RaftServerMetrics.getRaftServerMetrics(this);
+    this.retryCacheMetrics = RetryCacheMetrics.getRetryCacheMetrics(this);
   }
 
   private RetryCache initRetryCache(RaftProperties prop) {
@@ -274,6 +277,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
       }
       leaderElectionMetrics.unregister();
       raftServerMetrics.unregister();
+      retryCacheMetrics.unregister();
       if (deleteDirectory) {
         final RaftStorageDirectory dir = state.getStorage().getStorageDir();
         try {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RetryCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RetryCache.java
@@ -26,6 +26,7 @@ import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.thirdparty.com.google.common.cache.Cache;
 import org.apache.ratis.thirdparty.com.google.common.cache.CacheBuilder;
+import org.apache.ratis.thirdparty.com.google.common.cache.CacheStats;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
@@ -154,6 +155,7 @@ public class RetryCache implements Closeable {
    */
   RetryCache(TimeDuration expirationTime) {
     cache = CacheBuilder.newBuilder()
+        .recordStats()
         .expireAfterWrite(expirationTime.getDuration(), expirationTime.getUnit())
         .build();
   }
@@ -209,8 +211,12 @@ public class RetryCache implements Closeable {
   }
 
   @VisibleForTesting
-  long size() {
+  public long size() {
     return cache.size();
+  }
+
+  public CacheStats stats() {
+    return cache.stats();
   }
 
   @VisibleForTesting

--- a/ratis-server/src/main/java/org/apache/ratis/server/metrics/RetryCacheMetrics.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/metrics/RetryCacheMetrics.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ratis.server.metrics;
+
+import org.apache.ratis.metrics.MetricRegistryInfo;
+import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.server.impl.RaftServerImpl;
+
+/**
+ * Class to update the metrics related to retry cache.
+ */
+public final class RetryCacheMetrics extends RatisMetrics {
+
+  public static final String RATIS_RETRY_CACHE_METRICS = "retry_cache";
+  public static final String RATIS_RETRY_CACHE_METRICS_DESC = "Metrics for Ratis Retry Cache.";
+
+  public static final String RETRY_CACHE_ENTRY_COUNT_METRIC = "retryCacheEntryCount";
+  public static final String RETRY_CACHE_HIT_COUNT_METRIC = "retryCacheHitCount";
+  public static final String RETRY_CACHE_HIT_RATE_METRIC = "retryCacheHitRate";
+  public static final String RETRY_CACHE_MISS_COUNT_METRIC = "retryCacheMissCount";
+  public static final String RETRY_CACHE_MISS_RATE_METRIC = "retryCacheMissRate";
+
+  private RetryCacheMetrics(RaftServerImpl raftServer) {
+    this.registry = getMetricRegistryForRetryCache(raftServer.getMemberId().toString());
+    registry.gauge(RETRY_CACHE_ENTRY_COUNT_METRIC, () -> () -> raftServer.getRetryCache().size());
+    registry.gauge(RETRY_CACHE_HIT_COUNT_METRIC, () -> () -> raftServer.getRetryCache().stats().hitCount());
+    registry.gauge(RETRY_CACHE_HIT_RATE_METRIC, () -> () -> raftServer.getRetryCache().stats().hitRate());
+    registry.gauge(RETRY_CACHE_MISS_COUNT_METRIC, () -> () -> raftServer.getRetryCache().stats().missCount());
+    registry.gauge(RETRY_CACHE_MISS_RATE_METRIC, () -> () -> raftServer.getRetryCache().stats().missRate());
+  }
+
+  private RatisMetricRegistry getMetricRegistryForRetryCache(String serverId) {
+    return create(new MetricRegistryInfo(serverId,
+        RATIS_APPLICATION_NAME_METRICS, RATIS_RETRY_CACHE_METRICS,
+        RATIS_RETRY_CACHE_METRICS_DESC));
+  }
+
+  public static RetryCacheMetrics getRetryCacheMetrics(RaftServerImpl raftServer) {
+    return new RetryCacheMetrics(raftServer);
+  }
+}

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRetryCacheMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRetryCacheMetrics.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ratis.server.impl;
+
+import static org.apache.ratis.server.metrics.RetryCacheMetrics.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.ratis.metrics.RatisMetricRegistry;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftGroupMemberId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.metrics.RetryCacheMetrics;
+import org.apache.ratis.util.TimeDuration;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Test for RetryCacheMetrics.
+ */
+public class TestRetryCacheMetrics {
+    private static RatisMetricRegistry ratisMetricRegistry;
+    private static RetryCache retryCache;
+
+    @BeforeClass
+    public static void setUp() {
+      RaftServerImpl raftServer = mock(RaftServerImpl.class);
+
+      RaftGroupId raftGroupId = RaftGroupId.randomId();
+      RaftPeerId raftPeerId = RaftPeerId.valueOf("TestId");
+      RaftGroupMemberId raftGroupMemberId = RaftGroupMemberId
+          .valueOf(raftPeerId, raftGroupId);
+      when(raftServer.getMemberId()).thenReturn(raftGroupMemberId);
+
+      retryCache = new RetryCache(TimeDuration.valueOf(60, TimeUnit.SECONDS));
+      when(raftServer.getRetryCache()).thenReturn(retryCache);
+
+      RetryCacheMetrics retryCacheMetrics = RetryCacheMetrics
+          .getRetryCacheMetrics(raftServer);
+      ratisMetricRegistry = retryCacheMetrics.getRegistry();
+    }
+
+    @Test
+    public void testRetryCacheEntryCount() {
+      checkEntryCount(0);
+
+      ClientId clientId = ClientId.randomId();
+      RetryCache.CacheKey key = new RetryCache.CacheKey(clientId, 1);
+      RetryCache.CacheEntry entry = new RetryCache.CacheEntry(key);
+
+      retryCache.refreshEntry(entry);
+      checkEntryCount(1);
+
+      retryCache.close();
+      checkEntryCount(0);
+    }
+
+    @Test
+    public void testRetryCacheHitMissCount() {
+      checkHit(0, 1.0);
+      checkMiss(0, 0.0);
+
+      ClientId clientId = ClientId.randomId();
+      retryCache.getOrCreateEntry(clientId, 2);
+
+      checkHit(0, 0.0);
+      checkMiss(1, 1.0);
+
+      retryCache.getOrCreateEntry(clientId, 2);
+
+      checkHit(1, 0.5);
+      checkMiss(1, 0.5);
+    }
+
+    private static void checkHit(long count, double rate) {
+      Long hitCount = (Long) ratisMetricRegistry.getGauges((s, metric) ->
+          s.contains(RETRY_CACHE_HIT_COUNT_METRIC)).values().iterator().next().getValue();
+      assertEquals(hitCount.longValue(), count);
+
+      Double hitRate = (Double) ratisMetricRegistry.getGauges((s, metric) ->
+          s.contains(RETRY_CACHE_HIT_RATE_METRIC)).values().iterator().next().getValue();
+      assertEquals(hitRate.doubleValue(), rate, 0.0);
+    }
+
+    private static void checkMiss(long count, double rate) {
+      Long missCount = (Long) ratisMetricRegistry.getGauges((s, metric) ->
+          s.contains(RETRY_CACHE_MISS_COUNT_METRIC)).values().iterator().next().getValue();
+      assertEquals(missCount.longValue(), count);
+
+      Double missRate = (Double) ratisMetricRegistry.getGauges((s, metric) ->
+          s.contains(RETRY_CACHE_MISS_RATE_METRIC)).values().iterator().next().getValue();
+      assertEquals(missRate.doubleValue(), rate, 0.0);
+    }
+
+    private static void checkEntryCount(long count) {
+      Long entryCount = (Long) ratisMetricRegistry.getGauges((s, metric) ->
+          s.contains(RETRY_CACHE_ENTRY_COUNT_METRIC)).values().iterator().next().getValue();
+      assertEquals(entryCount.longValue(), count);
+    }
+}


### PR DESCRIPTION
I did not implement metric for cache size in bytes. Because `com.google.common.cache.Cache` does not  have the API to get the cache size. If I implement it myself,  it will not be accurate, because the cache size depends on the data structure used by `com.google.common.cache.Cache`.
