### PR TITLE
RATIS-880. Update github description and disable merge options apart from Squash and merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+github:
+  description: "Open source Java implementation for Raft consensus protocol."
+  homepage: http://ratis.incubator.apache.org/
+  labels:
+    - Raft
+    - Consensus Protocol
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  false

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,8 +16,10 @@ github:
   description: "Open source Java implementation for Raft consensus protocol."
   homepage: http://ratis.incubator.apache.org/
   labels:
-    - Raft
-    - Consensus Protocol
+    - raft
+    - consensus-protocol
+    - consensus
+    - java
   enabled_merge_buttons:
     squash:  true
     merge:   false


### PR DESCRIPTION
This PR update github description and disable merge options apart from Squash and merge.