### PR TITLE
RATIS-881. Fix Failed unit test because test before MiniRaftCluster ready

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -460,6 +460,20 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
     return null;
   }
 
+  @VisibleForTesting
+  public boolean isLeaderReady() {
+    if (!isLeader()) {
+      return false;
+    }
+
+    final LeaderState leaderState = role.getLeaderState().orElse(null);
+    if (leaderState == null || !leaderState.isReady()) {
+      return false;
+    }
+
+    return true;
+  }
+
   NotLeaderException generateNotLeaderException() {
     if (lifeCycle.getCurrentState() != RUNNING) {
       return new NotLeaderException(getMemberId(), null, null);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -447,8 +447,8 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
       final RaftClientReply reply = new RaftClientReply(request, exception, getCommitInfos());
       return RetryCache.failWithReply(reply, entry);
     }
-    final LeaderState leaderState = role.getLeaderState().orElse(null);
-    if (leaderState == null || !leaderState.isReady()) {
+
+    if (!isLeaderReady()) {
       RetryCache.CacheEntry cacheEntry = retryCache.get(request.getClientId(), request.getCallId());
       if (cacheEntry != null && cacheEntry.isCompletedNormally()) {
         return cacheEntry.getReplyFuture();
@@ -462,16 +462,8 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
 
   @VisibleForTesting
   public boolean isLeaderReady() {
-    if (!isLeader()) {
-      return false;
-    }
-
     final LeaderState leaderState = role.getLeaderState().orElse(null);
-    if (leaderState == null || !leaderState.isReady()) {
-      return false;
-    }
-
-    return true;
+    return leaderState != null && leaderState.isReady();
   }
 
   NotLeaderException generateNotLeaderException() {

--- a/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
@@ -97,9 +97,13 @@ public interface RaftTestUtil {
       exception.set(ise);
     };
 
-    final RaftServerImpl leader = JavaUtils.attemptRepeatedly(
-        () -> cluster.getLeader(groupId, handleNoLeaders, handleMultipleLeaders),
-        numAttempts, sleepTime, name, LOG);
+    final RaftServerImpl leader = JavaUtils.attemptRepeatedly(() -> {
+      RaftServerImpl l = cluster.getLeader(groupId, handleNoLeaders, handleMultipleLeaders);
+      if (l != null && !l.isLeaderReady()) {
+        throw new IllegalStateException("Leader: "+ l.getMemberId() +  " not ready");
+      }
+      return l;
+    }, numAttempts, sleepTime, name, LOG);
 
     LOG.info(cluster.printServers(groupId));
     if (expectLeader) {


### PR DESCRIPTION
**What's the probelm ?**
![image](https://user-images.githubusercontent.com/51938049/80347050-57f36280-889e-11ea-944d-f4ae0353a249.png)

**What's the reason ?**
The root cause is [RaftServerMetrics::getPeerCommitIndexGauge](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerMetrics.java#L141) happens before [RaftServerMetrics::addPeerCommitIndexGauge](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerMetrics.java#L122).  
When some RaftServerImpl [setRole(RaftPeerRole.LEADER, "changeToLeader")](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L345), the statement [waitForLeader](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java#L446) succ to get leader and test begin, but [role.startLeaderState](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L349) ->
 [new LeaderState](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java#L94) ->
[LeaderState::addSenders](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java#L409)->[RaftServerMetrics::addFollower](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerMetrics.java#L106) -> [RaftServerMetrics::addPeerCommitIndexGauge](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerMetrics.java#L122) has not finished.