### PR TITLE
RATIS-884. Fix Failed UT: TestRaftLogMetrics.testRaftLogMetrics

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/TestRaftLogMetrics.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/TestRaftLogMetrics.java
@@ -127,7 +127,11 @@ public class TestRaftLogMetrics extends BaseTest
     final MetricsStateMachine stateMachine = MetricsStateMachine.get(server);
     final int expectedFlush = stateMachine.getFlushCount();
 
-    Assert.assertEquals(expectedFlush, tm.getCount());
+    JavaUtils.attemptRepeatedly(() -> {
+      Assert.assertEquals(expectedFlush, tm.getCount());
+      return null;
+    }, 50, HUNDRED_MILLIS, "expectedFlush == tm.getCount()", null);
+
     Assert.assertTrue(tm.getMeanRate() > 0);
 
     // Test jmx


### PR DESCRIPTION
**What's the problem ?**
![image](https://user-images.githubusercontent.com/51938049/80348528-807c5c00-88a0-11ea-9069-78f7f56b02f7.png)

**What's the reason ?**
As the images shows, `flushCount.incrementAndGet() `happens in the 1st statement: `stateMachine.flushStateMachineData(lastWrittenIndex)`, `ratisMetricRegistry.get(RAFT_LOG_FLUSH_TIME)` increase after the 2nd statement: `timerContext.stop()`. If the test `Assert.assertEquals(expectedFlush, tm.getCount())` happens between 1st and 2nd statement, then the expectedFlush will be tm.getCount() + 1, so the test fail.

![image](https://user-images.githubusercontent.com/51938049/80348569-8eca7800-88a0-11ea-8d19-f2965c94a584.png)

**How to fix ?**
Retry check expectedFlush == tm.getCount()