### PR TITLE
RATIS-885. Fix Failed UT because error use of attemptRepeatedly to check boolean condition

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -136,8 +136,10 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       LOG.info("nextIndex = {}", nextIndex);
       final List<File> snapshotFiles = RaftSnapshotBaseTest.getSnapshotFiles(cluster,
           nextIndex - SNAPSHOT_TRIGGER_THRESHOLD, nextIndex);
-      JavaUtils.attemptRepeatedly(() -> snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists),
-          10, ONE_SECOND, "snapshotFile.exist", LOG);
+      JavaUtils.attemptRepeatedly(() -> {
+        Assert.assertTrue(snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists));
+        return null;
+      }, 10, ONE_SECOND, "snapshotFile.exist", LOG);
       logs = storageDirectory.getLogSegmentFiles();
     } finally {
       cluster.shutdown();
@@ -212,8 +214,10 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
       LOG.info("{}: oldLeaderNextIndex = {}", leaderId, oldLeaderNextIndex);
       final List<File> snapshotFiles = RaftSnapshotBaseTest.getSnapshotFiles(cluster,
           oldLeaderNextIndex - SNAPSHOT_TRIGGER_THRESHOLD, oldLeaderNextIndex);
-      JavaUtils.attemptRepeatedly(() -> snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists),
-          10, ONE_SECOND, "snapshotFile.exist", LOG);
+      JavaUtils.attemptRepeatedly(() -> {
+        Assert.assertTrue(snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists));
+        return null;
+      }, 10, ONE_SECOND, "snapshotFile.exist", LOG);
     }
 
     final RaftPeerId followerId = cluster.getFollowers().get(0).getId();

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -532,8 +532,10 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
       }, 10, sleepTime, "confIndex", LOG);
 
       // wait till the old leader persist the new conf
-      JavaUtils.attemptRepeatedly(() -> log.getFlushIndex() >= confIndex,
-          10, sleepTime, "FLUSH", LOG);
+      JavaUtils.attemptRepeatedly(() -> {
+        Assert.assertTrue(log.getFlushIndex() >= confIndex);
+        return null;
+      }, 10, sleepTime, "FLUSH", LOG);
       final long committed = log.getLastCommittedIndex();
       Assert.assertTrue(committed < confIndex);
 
@@ -546,8 +548,10 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
       Assert.assertTrue(gotNotLeader.get());
 
       // the old leader should have truncated the setConf from the log
-      JavaUtils.attemptRepeatedly(() -> log.getLastCommittedIndex() >= confIndex,
-          10, ONE_SECOND, "COMMIT", LOG);
+      JavaUtils.attemptRepeatedly(() -> {
+        Assert.assertTrue(log.getLastCommittedIndex() >= confIndex);
+        return null;
+      }, 10, ONE_SECOND, "COMMIT", LOG);
       Assert.assertTrue(log.get(confIndex).hasConfigurationEntry());
       log2 = null;
     } finally {

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
@@ -149,8 +149,10 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
     LOG.info("nextIndex = {}", nextIndex);
     // wait for the snapshot to be done
     final List<File> snapshotFiles = getSnapshotFiles(cluster, nextIndex - SNAPSHOT_TRIGGER_THRESHOLD, nextIndex);
-    JavaUtils.attemptRepeatedly(() -> snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists),
-        10, ONE_SECOND, "snapshotFile.exist", LOG);
+    JavaUtils.attemptRepeatedly(() -> {
+      Assert.assertTrue(snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists));
+      return null;
+    }, 10, ONE_SECOND, "snapshotFile.exist", LOG);
 
     // restart the peer and check if it can correctly load snapshot
     cluster.restart(false);
@@ -197,8 +199,10 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
       final long nextIndex = cluster.getLeader().getState().getLog().getNextIndex();
       LOG.info("nextIndex = {}", nextIndex);
       final List<File> snapshotFiles = getSnapshotFiles(cluster, nextIndex - SNAPSHOT_TRIGGER_THRESHOLD, nextIndex);
-      JavaUtils.attemptRepeatedly(() -> snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists),
-          10, ONE_SECOND, "snapshotFile.exist", LOG);
+      JavaUtils.attemptRepeatedly(() -> {
+        Assert.assertTrue(snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists));
+        return null;
+      }, 10, ONE_SECOND, "snapshotFile.exist", LOG);
       logs = storageDirectory.getLogSegmentFiles();
     } finally {
       cluster.shutdown();


### PR DESCRIPTION
**What's the problem ?**
![image](https://user-images.githubusercontent.com/51938049/80349974-a440a180-88a2-11ea-966b-6509665b4049.png)

**What's the reason ?**
I think the author of following code want to try 10 seconds until `followerState.getLastAppliedIndex() >= leaderLastIndex`, but actually `JavaUtils.attemptRepeatedly` will not retry unless the statement throw exception as the image shows.
```
    // make sure the restarted follower can catchup
    final ServerState followerState = cluster.getRaftServerImpl(followerId).getState();
    JavaUtils.attemptRepeatedly(() -> followerState.getLastAppliedIndex() >= leaderLastIndex,
        10, ONE_SECOND, "follower catchup", LOG);
```

![image](https://user-images.githubusercontent.com/51938049/80350070-c4706080-88a2-11ea-8758-f6681e21af7e.png)

**How to fix ?**
I fix all the error use of JavaUtils.attemptRepeatedly to check boolean condition.

Maybe we have another method to avoid the error use of JavaUtils.attemptRepeatedly.  
