### PR TITLE
RATIS-991. Fix Failed UT: testRestartLogAppender

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -247,7 +247,7 @@ class LeaderElection implements Runnable {
             server.changeToFollowerAndPersistMetadata(term, Result.DISCOVERED_A_NEW_TERM);
             return;
           case TIMEOUT: // should start another election
-            return;
+            continue;
           default: throw new IllegalArgumentException("Unable to process result " + r.result);
         }
       }


### PR DESCRIPTION
**What's the problem ?**
Can not elect a leader after a long time.
![image](https://user-images.githubusercontent.com/51938049/80474429-06b8a100-897a-11ea-9753-005a8d5b04cb.png)

**What's the reason ?**
[RATIS-773](https://github.com/apache/incubator-ratis/commit/14927c7527afe13efb949065bbac0042ad82932f) has a change, as the image shows, cause this bug. 
The following switch statement is in  [while](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java#L197) loop.
If Timeout, the origin logic is continue, . But the new logic is return.
![image](https://user-images.githubusercontent.com/51938049/80474608-3cf62080-897a-11ea-82a5-94417c09bee9.png)


