### PR TITLE
RATIS-913. Fix remaining (new) checkstyle violations

### DIFF
--- a/dev-support/checkstyle.xml
+++ b/dev-support/checkstyle.xml
@@ -55,6 +55,11 @@
 
     <property name="fileExtensions" value="java, properties, xml"/>
 
+    <module name="BeforeExecutionExclusionFileFilter">
+        <!-- these files will be removed in RATIS-757 -->
+        <property name="fileNamePattern" value="nativeio/.*\.java"/>
+    </module>
+
     <module name="SuppressWarningsFilter"/>
 
     <!-- Checks that a package-info.java file exists for each package.     -->

--- a/ratis-common/src/main/java/org/apache/ratis/retry/ExponentialBackoffRetry.java
+++ b/ratis-common/src/main/java/org/apache/ratis/retry/ExponentialBackoffRetry.java
@@ -30,9 +30,9 @@ import java.util.concurrent.ThreadLocalRandom;
  * If sleep time calculated using the progression is s then randomness is added
  * in the range [s*0.5, s*1.5).
  */
-public class ExponentialBackoffRetry implements RetryPolicy {
+public final class ExponentialBackoffRetry implements RetryPolicy {
 
-  public static class Builder {
+  public static final class Builder {
 
     private Builder() {}
 

--- a/ratis-common/src/main/java/org/apache/ratis/util/PlatformUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/PlatformUtils.java
@@ -23,7 +23,7 @@ package org.apache.ratis.util;
 /**
  * Platform and architecture related utility methods.
  */
-public class PlatformUtils {
+public final class PlatformUtils {
 
   private PlatformUtils() {
     // Utility class, cannot instantiate
@@ -35,14 +35,14 @@ public class PlatformUtils {
    * Get the type of the operating system, as determined from parsing
    * the <code>os.name</code> property.
    */
-  private static final OSType osType = getOSType();
-  public static final boolean OTHER   = (osType == OSType.OS_TYPE_OTHER);
-  public static final boolean LINUX   = (osType == OSType.OS_TYPE_LINUX);
-  public static final boolean FREEBSD = (osType == OSType.OS_TYPE_FREEBSD);
-  public static final boolean MAC     = (osType == OSType.OS_TYPE_MAC);
-  public static final boolean SOLARIS = (osType == OSType.OS_TYPE_SOLARIS);
+  private static final OSType OS_TYPE = getOSType();
+  public static final boolean OTHER   = (OS_TYPE == OSType.OS_TYPE_OTHER);
+  public static final boolean LINUX   = (OS_TYPE == OSType.OS_TYPE_LINUX);
+  public static final boolean FREEBSD = (OS_TYPE == OSType.OS_TYPE_FREEBSD);
+  public static final boolean MAC     = (OS_TYPE == OSType.OS_TYPE_MAC);
+  public static final boolean SOLARIS = (OS_TYPE == OSType.OS_TYPE_SOLARIS);
   // Helper static vars for each platform
-  public static final boolean WINDOWS = (osType == OSType.OS_TYPE_WIN);
+  public static final boolean WINDOWS = (OS_TYPE == OSType.OS_TYPE_WIN);
 
   private static OSType getOSType() {
     String osName = System.getProperty("os.name");

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -96,6 +96,7 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
         tlsConfig);
   }
 
+  @SuppressWarnings("checkstyle:ParameterNumber") // private constructor
   private GrpcService(RaftServer raftServer, Supplier<RaftPeerId> idSupplier, int port,
       SizeInBytes grpcMessageSizeMax, SizeInBytes appenderBufferSize,
       SizeInBytes flowControlWindow,TimeDuration requestTimeoutDuration, GrpcTlsConfig tlsConfig) {

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/metrics/LogServiceMetricsRegistry.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/metrics/LogServiceMetricsRegistry.java
@@ -22,7 +22,7 @@ import org.apache.ratis.metrics.MetricRegistries;
 import org.apache.ratis.metrics.MetricRegistryInfo;
 import org.apache.ratis.metrics.RatisMetricRegistry;
 
-public class LogServiceMetricsRegistry {
+public final class LogServiceMetricsRegistry {
   public static final String RATIS_LOG_STATEMACHINE_METRICS = "log_statemachine";
   public static final String RATIS_LOG_SERVICE_METRICS = "ratis_log_service";
   public static final String RATIS_LOG_SERVICE_METRICS_DESC = "Ratis log service metrics";
@@ -56,6 +56,10 @@ public class LogServiceMetricsRegistry {
   private static RatisMetricRegistry create(MetricRegistryInfo info) {
     RatisMetricRegistry registry = MetricRegistries.global().create(info);
     return registry;
+  }
+
+  private LogServiceMetricsRegistry() {
+    throw new UnsupportedOperationException("no instances");
   }
 
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -50,7 +50,7 @@ import java.util.function.Consumer;
  *
  * This class will be protected by the {@link SegmentedRaftLog}'s read-write lock.
  */
-public class LogSegment implements Comparable<Long> {
+public final class LogSegment implements Comparable<Long> {
 
   //TODO: This class needs to be made final to address checkstyle issue. However, TestCacheEviction fails as Mockito
   // cannot spy final class. This problem can be fixed when stable version of Mockito 2.x is available which provides


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Ignore violations in `NativeIO`-related classes, as these will be removed in [RATIS-757](https://issues.apache.org/jira/browse/RATIS-757).
2. Apply @dineshchitlangia's fix for `PlatformUtils` from aca98ffd3c94ca9e2f9c0798897631b726b381dd, which was lost between patches [001](https://issues.apache.org/jira/secure/attachment/12985021/RATIS-740.001.patch) and [002](https://issues.apache.org/jira/secure/attachment/12986074/RATIS-740.002.patch) in [RATIS-740](https://issues.apache.org/jira/browse/RATIS-740).
3. Fix few remaining violations.

https://issues.apache.org/jira/browse/RATIS-913

## How was this patch tested?

```
$ ./dev-support/checks/checkstyle.sh
...
INFO] BUILD SUCCESS
```

https://github.com/adoroszlai/incubator-ratis/runs/629340756