### PR TITLE
RATIS-848. Fix Failed UT: TestRaftSnapshotWithGrpc.testBasicInstallSnapshot

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
@@ -203,6 +203,7 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
         Assert.assertTrue(snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists));
         return null;
       }, 10, ONE_SECOND, "snapshotFile.exist", LOG);
+      verifyTakeSnapshotMetric(cluster.getLeader());
       logs = storageDirectory.getLogSegmentFiles();
     } finally {
       cluster.shutdown();
@@ -237,7 +238,6 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
       // restart the peer and check if it can correctly handle conf change
       cluster.restartServer(cluster.getLeader().getId(), false);
       assertLeaderContent(cluster);
-      verifyTakeSnapshotMetric(cluster.getLeader());
     } finally {
       cluster.shutdown();
     }


### PR DESCRIPTION
**Why unit test TestRaftSnapshotWithGrpc.testBasicInstallSnapshot failed?**
In the test, leader take snapshot, then add two followers, then leader restart, then verifyTakeSnapshotMetric. 
It must be failed when verifyTakeSnapshotMetric after restarting leader. Because restart leader will create a new instance of RaftServer, the metric of take snapshot is clean.

