### PR TITLE
RATIS-889. Fix TestRaftSnapshotWithGrpc and TestRaftSnapshotWithSimulatedRpc

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
@@ -203,6 +203,7 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
         Assert.assertTrue(snapshotFiles.stream().anyMatch(RaftSnapshotBaseTest::exists));
         return null;
       }, 10, ONE_SECOND, "snapshotFile.exist", LOG);
+      verifyTakeSnapshotMetric(cluster.getLeader());
       logs = storageDirectory.getLogSegmentFiles();
     } finally {
       cluster.shutdown();
@@ -234,10 +235,15 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
       verifyInstallSnapshotMetric(cluster.getLeader());
       RaftServerTestUtil.waitAndCheckNewConf(cluster, change.allPeersInNewConf, 0, null);
 
+      Timer timer = getTakeSnapshotTimer(cluster.getLeader());
+      long count = timer.getCount();
+
       // restart the peer and check if it can correctly handle conf change
       cluster.restartServer(cluster.getLeader().getId(), false);
       assertLeaderContent(cluster);
-      verifyTakeSnapshotMetric(cluster.getLeader());
+
+      // verify that snapshot was taken when stopping the server
+      Assert.assertTrue(count < timer.getCount());
     } finally {
       cluster.shutdown();
     }
@@ -250,6 +256,11 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
   }
 
   private static void verifyTakeSnapshotMetric(RaftServerImpl leader) {
+    Timer timer = getTakeSnapshotTimer(leader);
+    Assert.assertTrue(timer.getCount() > 0);
+  }
+
+  private static Timer getTakeSnapshotTimer(RaftServerImpl leader) {
     MetricRegistryInfo info = new MetricRegistryInfo(leader.getMemberId().toString(),
         RATIS_APPLICATION_NAME_METRICS,
         RATIS_STATEMACHINE_METRICS, RATIS_STATEMACHINE_METRICS_DESC);
@@ -257,7 +268,6 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
     Assert.assertTrue(opt.isPresent());
     RatisMetricRegistry metricRegistry = opt.get();
     Assert.assertNotNull(metricRegistry);
-    Timer timer = metricRegistry.timer(STATEMACHINE_TAKE_SNAPSHOT_TIMER);
-    Assert.assertTrue(timer.getCount() > 0);
+    return metricRegistry.timer(STATEMACHINE_TAKE_SNAPSHOT_TIMER);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix TestRaftSnapshotWithGrpc and TestRaftSnapshotWithSimulatedRpc: `StateMachineUpdater` [unregisters metrics from the registry](https://github.com/apache/incubator-ratis/blob/56e2073515804cc70f64b215f971d547070ed38f/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java#L129) during stop, so the timer after restart is not the same instance as before.  Thus, to verify that snapshot is taken during stop, we need to obtain the pre-stop timer.

Also verify the metric right after snapshot file is created.

https://issues.apache.org/jira/browse/RATIS-889

## How was this patch tested?

Executed `TestRaftSnapshot*` multiple times.  Also passed in CI:

https://github.com/adoroszlai/incubator-ratis/runs/633049769