### PR TITLE
RATIS-900. Fix Failed UT: RaftExceptionBaseTest.testHandleNotLeaderAndIOException

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
@@ -63,7 +63,7 @@ public abstract class RaftExceptionBaseTest<CLUSTER extends MiniRaftCluster>
    */
   @Test
   public void testHandleNotLeaderAndIOException() throws Exception {
-    runWithNewCluster(NUM_PEERS, cluster -> runTestHandleNotLeaderException(true, cluster));
+    runWithNewCluster(NUM_PEERS, cluster -> runTestHandleNotLeaderException(false, cluster));
   }
 
   void runTestHandleNotLeaderException(boolean killNewLeader, CLUSTER cluster) throws Exception {


### PR DESCRIPTION
![](https://issues.apache.org/jira/secure/attachment/13001388/13001388_screenshot-1.png)

**Why the ut failed ?**
In the test, the cluster first select an oldLeader, then force change to newLeader, and **kill newLeader**. Then client connect to oldLeader and expect the oldLeader return the real leader i.e. newLeader, in the NotLeaderException. But the new leader has been killed, so the test failed. 

![image](https://user-images.githubusercontent.com/51938049/80784530-e7a35480-8baf-11ea-93a8-b6c905646958.png)




**How to fix ?**
Do not kill newLeader if we want to return it as a leader in NotLeaderException.