### PR TITLE
RATIS-901. Fix Failed UT: WatchRequestTests.testWatchRequestClientTimeout

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
@@ -23,12 +23,12 @@ import org.apache.ratis.client.RaftClientConfigKeys;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
-import org.apache.ratis.protocol.NotLeaderException;
+import org.apache.ratis.protocol.AlreadyClosedException;
 import org.apache.ratis.protocol.NotReplicatedException;
 import org.apache.ratis.protocol.RaftClientReply;
-import org.apache.ratis.protocol.RaftRetryFailureException;
 import org.apache.ratis.protocol.TimeoutIOException;
 import org.apache.ratis.retry.RetryPolicies;
+import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
@@ -114,13 +114,11 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
       }
     }
 
-    CompletableFuture<RaftClientReply> sendWatchRequest(long logIndex)
+    CompletableFuture<RaftClientReply> sendWatchRequest(long logIndex, RetryPolicy policy)
         throws Exception {
 
       try (final RaftClient watchClient =
-          cluster.createClient(RaftTestUtil.waitForLeader(cluster).getId(),
-          RetryPolicies.retryUpToMaximumCountWithFixedSleep(5,
-          TimeDuration.valueOf(5, TimeUnit.SECONDS)))) {
+          cluster.createClient(RaftTestUtil.waitForLeader(cluster).getId(), policy)) {
 
         CompletableFuture<RaftClientReply> reply =
             watchClient.sendAsync(new RaftTestUtil.SimpleMessage("message"));
@@ -448,25 +446,22 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
 
     CompletableFuture<RaftClientReply> watchReply;
     // watch 1000 which will never be committed
-    // so client can not receive reply, and connection closed, throw TimeoutException
-    watchReply = p.sendWatchRequest(1000);
+    // so client can not receive reply, and connection closed, throw TimeoutException.
+    // We should not retry, because if retry, RaftClientImpl::handleIOException will random select a leader,
+    // then sometimes throw NotLeaderException.
+    watchReply = p.sendWatchRequest(1000, RetryPolicies.noRetry());
 
     try {
       watchReply.get();
       fail("runTestWatchRequestClientTimeout failed");
     } catch (Exception ex) {
       LOG.error("error occurred", ex);
-      Assert.assertEquals(RaftRetryFailureException.class,
+      Assert.assertEquals(AlreadyClosedException.class,
           ex.getCause().getClass());
       if (ex.getCause() != null) {
         if (ex.getCause().getCause() != null) {
-          // when client closed and throw TimeoutException,
-          // RaftClientImpl::handleIOException will random select a leader
-          // because suggested new leader is null.
-          // So it maybe sometimes throw NotLeaderException.
-          Assert.assertTrue(
-              ex.getCause().getCause().getClass() == TimeoutIOException.class ||
-              ex.getCause().getCause().getClass() == NotLeaderException.class);
+          Assert.assertEquals(TimeoutIOException.class,
+              ex.getCause().getCause().getClass());
         }
       }
     }

--- a/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
@@ -26,6 +26,7 @@ import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.protocol.AlreadyClosedException;
 import org.apache.ratis.protocol.NotReplicatedException;
 import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftRetryFailureException;
 import org.apache.ratis.protocol.TimeoutIOException;
 import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.retry.RetryPolicy;
@@ -456,8 +457,8 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
       fail("runTestWatchRequestClientTimeout failed");
     } catch (Exception ex) {
       LOG.error("error occurred", ex);
-      Assert.assertEquals(AlreadyClosedException.class,
-          ex.getCause().getClass());
+      Assert.assertTrue(ex.getCause().getClass() == AlreadyClosedException.class ||
+          ex.getCause().getClass() == RaftRetryFailureException.class);
       if (ex.getCause() != null) {
         if (ex.getCause().getCause() != null) {
           Assert.assertEquals(TimeoutIOException.class,


### PR DESCRIPTION
**Why WatchRequestTests.testWatchRequestClientTimeout failed ?**
The test try to watch a log index i.e. 1000 which will never be committed, so client can not receive reply, and connection closed throw AlreadyClosedException, [trigger TimeoutIOException](https://github.com/apache/incubator-ratis/blob/master/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java#L325).

But when throw AlreadyClosedException, suggested new leader is null, because connection has been closed, so RaftClientImpl::handleIOException will [random select](https://github.com/apache/incubator-ratis/blob/master/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java#L418) a new leader, so it maybe sometimes [throw NotLeaderException](https://github.com/apache/incubator-ratis/blob/master/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java#L278) rather than TimeoutIOException.
![企业微信截图_9fed55fa-5428-4ab2-a82f-f637791e9862](https://user-images.githubusercontent.com/51938049/80779794-49a78e00-8b9f-11ea-96ec-a60c86ec6265.png)