### PR TITLE
RATIS-917. Set storage dir properties for testServerRestartOnException

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/MiniRaftCluster.java
@@ -222,7 +222,7 @@ public abstract class MiniRaftCluster implements Closeable {
       () -> new File(BaseTest.getRootTestDir(),
           getClass().getSimpleName() + Integer.toHexString(ThreadLocalRandom.current().nextInt())));
 
-  private File getStorageDir(RaftPeerId id) {
+  public File getStorageDir(RaftPeerId id) {
     return new File(rootTestDir.get(), id.toString());
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
@@ -66,6 +66,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.channels.OverlappingFileLockException;
+import java.util.Collections;
 import java.util.SortedMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -101,6 +102,7 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
     // compared to leader. This helps in locking the raft storage directory to
     // be used by next raft server proxy instance.
     final StateMachine stateMachine = cluster.getLeader().getStateMachine();
+    RaftServerConfigKeys.setStorageDir(p, Collections.singletonList(cluster.getStorageDir(leaderId)));
     ServerImplUtils.newRaftServer(leaderId, cluster.getGroup(), gid -> stateMachine, p, null);
     // Close the server rpc for leader so that new raft server can be bound to it.
     cluster.getLeader().getServerRpc().close();
@@ -109,6 +111,7 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
     // the leader. This step would fail as the raft storage has been locked by
     // the raft server proxy created earlier. Raft server proxy should close
     // the rpc server on failure.
+    RaftServerConfigKeys.setStorageDir(p, Collections.singletonList(cluster.getStorageDir(leaderId)));
     testFailureCase("start a new server with the same address",
         () -> ServerImplUtils.newRaftServer(leaderId, cluster.getGroup(), gid -> stateMachine, p, null).start(),
         IOException.class, OverlappingFileLockException.class);


### PR DESCRIPTION
**What's the problem ?**
In unit test testServerRestartOnException,  when call `ServerImplUtils.newRaftServer`, it did not set storage dir in RaftProperties. Then it use the default storage dir [/tmp/raft-server](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java#L45), but when test finish, it did not delete the generated sub dir. So every time testServerRestartOnException, it will generate a sub dir in /tmp/raft-server as the image shows. But when  testServerRestartOnException run, it will call `RaftServerProxy::initGroups`, and [create](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java#L194) a RaftServerImpl for each sub dir in /tmp/raft-server, which leads to a big noise for the test. 

![image](https://user-images.githubusercontent.com/51938049/80867499-f6305f80-8cc6-11ea-813a-5ff9f7eca623.png)

How to fix ?
`cluster.getStorageDir(leaderId)` will generate a dir with random name, so can fix the problem.
