### PR TITLE
RATIS-639. Inconsistent pattern for variable names

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/cli/Assign.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/cli/Assign.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -43,12 +43,13 @@ public class Assign extends Client {
 
   private static final Pattern NUMBER_PATTERN = Pattern.compile("\\d+|\\d*\\.\\d+");
   private static final String VARIABLE_OR_NUMBER = String.format("(%s|%s)", NUMBER_PATTERN, Variable.PATTERN.pattern());
-  private static final Pattern BINARY_OPERATION_PATTERN = Pattern.compile(VARIABLE_OR_NUMBER + "\\s*([*+/-])\\s*" + VARIABLE_OR_NUMBER);
+  private static final Pattern BINARY_OPERATION_PATTERN = Pattern.compile(
+      VARIABLE_OR_NUMBER + "\\s*([*+/-])\\s*" + VARIABLE_OR_NUMBER);
   private static final Pattern UNARY_OPERATION_PATTERN = Pattern.compile("([√~-])" + VARIABLE_OR_NUMBER);
 
-  @Parameter(names = {
-      "--name"}, description = "Name of the variable to set", required = true)
-  String name;
+  @Parameter(names = {"--name"},
+      description = "Name of the variable to set", required = true)
+  private String name;
 
   @Parameter(names = {"--value"}, description = "Value to set", required = true)
   private String value;
@@ -62,21 +63,21 @@ public class Assign extends Client {
   }
 
   @VisibleForTesting
-  protected Expression createExpression(String value) {
-    if (NUMBER_PATTERN.matcher(value).matches()) {
-      return new DoubleValue(Double.valueOf(value));
-    } else if (Variable.PATTERN.matcher(value).matches()) {
-      return new Variable(value);
+  Expression createExpression(String val) {
+    if (NUMBER_PATTERN.matcher(val).matches()) {
+      return new DoubleValue(Double.parseDouble(val));
+    } else if (Variable.PATTERN.matcher(val).matches()) {
+      return new Variable(val);
     }
-    Matcher binaryMatcher = BINARY_OPERATION_PATTERN.matcher(value);
-    Matcher unaryMatcher = UNARY_OPERATION_PATTERN.matcher(value);
+    Matcher binaryMatcher = BINARY_OPERATION_PATTERN.matcher(val);
+    Matcher unaryMatcher = UNARY_OPERATION_PATTERN.matcher(val);
 
     if (binaryMatcher.matches()) {
       return createBinaryExpression(binaryMatcher);
     } else if (unaryMatcher.matches()) {
       return createUnaryExpression(unaryMatcher);
     } else {
-      throw new IllegalArgumentException("Invalid expression " + value + " Try something like: 'a+b' or '2'");
+      throw new IllegalArgumentException("Invalid expression " + val + " Try something like: 'a+b' or '2'");
     }
   }
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/UnaryExpression.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/UnaryExpression.java
@@ -30,7 +30,8 @@ public class UnaryExpression implements Expression {
   static final BiFunction<Op, Expression, String> POSTFIX_OP_TO_STRING = (op, e) -> e + "" + op;
 
   public enum Op implements UnaryOperator<Expression>, DoubleFunction<Expression> {
-    NEG("~"), SQRT("√"), SQUARE("^2", POSTFIX_OP_TO_STRING);
+    NEG("~"), SQRT("√"), SQUARE("^2", POSTFIX_OP_TO_STRING),
+    MINUS("-"), ;
 
     private final String symbol;
     private final BiFunction<Op, Expression, String> stringFunction;
@@ -109,6 +110,7 @@ public class UnaryExpression implements Expression {
   public Double evaluate(Map<String, Double> variableMap) {
     final double value = expression.evaluate(variableMap);
     switch (op) {
+      case MINUS:
       case NEG:
         return -value;
       case SQRT:

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/Variable.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/Variable.java
@@ -25,8 +25,7 @@ import org.apache.ratis.util.Preconditions;
 
 public class Variable implements Expression {
   static final int LENGTH_LIMIT = 32;
-  static final String REGEX = "[a-zA-Z]\\w*";
-  static final Pattern PATTERN = Pattern.compile(REGEX);
+  public static final Pattern PATTERN = Pattern.compile("[a-zA-Z]\\w*");
 
   static byte[] string2bytes(String s) {
     final byte[] stringBytes = s.getBytes(AssignmentMessage.UTF8);

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/cli/TestAssignCli.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/cli/TestAssignCli.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 
 import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.ADD;
 import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.MULT;
+import static org.apache.ratis.examples.arithmetic.expression.BinaryExpression.Op.SUBTRACT;
+import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op.MINUS;
+import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op.NEG;
 import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op.SQRT;
 
 public class TestAssignCli {
@@ -34,23 +37,51 @@ public class TestAssignCli {
         new Assign().createExpression("2.0"));
 
     Assert.assertEquals(
+        new DoubleValue(42.0),
+        new Assign().createExpression("42"));
+
+    Assert.assertEquals(
         MULT.apply(2.0, new Variable("a")),
         new Assign().createExpression("2*a"));
+
+    Assert.assertEquals(
+        MULT.apply(new Variable("v1"), 2.0),
+        new Assign().createExpression("v1 * 2"));
 
     Assert.assertEquals(
         ADD.apply(2.0, 1.0),
         new Assign().createExpression("2+1"));
 
     Assert.assertEquals(
-        ADD.apply(new Variable("a"), new Variable("b")),
-        new Assign().createExpression("a+b"));
+        SUBTRACT.apply(1.0, 6.0),
+        new Assign().createExpression("1 - 6"));
+
+    Assert.assertEquals(
+        ADD.apply(new Variable("a"), new Variable("v2")),
+        new Assign().createExpression("a+v2"));
+
+    Assert.assertEquals(
+        ADD.apply(new Variable("v1"), new Variable("b")),
+        new Assign().createExpression("v1 + b"));
 
     Assert.assertEquals(
         SQRT.apply(new Variable("a")),
         new Assign().createExpression("√a"));
 
     Assert.assertEquals(
+        SQRT.apply(new Variable("ABC")),
+        new Assign().createExpression("√ABC"));
+
+    Assert.assertEquals(
         SQRT.apply(2.0),
         new Assign().createExpression("√2"));
+
+    Assert.assertEquals(
+        NEG.apply(2.0),
+        new Assign().createExpression("~2.0"));
+
+    Assert.assertEquals(
+        MINUS.apply(6.0),
+        new Assign().createExpression("-6.0"));
   }
 }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/cli/TestAssignCli.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/cli/TestAssignCli.java
@@ -31,7 +31,7 @@ import static org.apache.ratis.examples.arithmetic.expression.UnaryExpression.Op
 
 public class TestAssignCli {
   @Test
-  public void createExpression() throws Exception {
+  public void createExpression() {
     Assert.assertEquals(
         new DoubleValue(2.0),
         new Assign().createExpression("2.0"));


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Allow variable names like `v1` in expressions, too
2. Allow expressions like `0.1 + 0.2`
3. Fix `NumberFormatException` for expression like `-5`

https://issues.apache.org/jira/browse/RATIS-639

## How was this patch tested?

Added test cases in unit test.  Also tested manually via CLI.