### PR TITLE
RATIS-920. Fix error use of onCompleted in onError

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -141,9 +141,7 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
     @Override
     public void onError(Throwable t) {
       GrpcUtil.warn(LOG, () -> getId() + ": installSnapshot onError, lastRequest: " + getPreviousRequestString(), t);
-      if (isClosed.compareAndSet(false, true)) {
-        responseObserver.onCompleted();
-      }
+      isClosed.compareAndSet(false, true);
     }
   }
 


### PR DESCRIPTION
Apache jira:
https://issues.apache.org/jira/browse/RATIS-920

**What's the problem ?**
When run test, a lot of  `StatusRuntimeException: CANCELLED: call already cancelled` was thrown, as the image shows.
![image](https://user-images.githubusercontent.com/51938049/81052182-953a9e80-8ef5-11ea-8661-70d5bdd1751b.png)

**What's the reason ?**

1. When run into onError, the call has already been cancelled, there is no need to call onCompleted. You can find from the following doc of onError, it's the last method call, and 
no further calls to any method are allowed.

> void onError(Throwable t)
> Receives a terminating error from the stream.
> May only be called once and if called it must be the last method called. In particular if an exception is thrown by an implementation of onError no further calls to any method are allowed.
> 
> t should be a StatusException or StatusRuntimeException, but other Throwable types are possible. Callers should generally convert from a Status via Status.asException() or Status.asRuntimeException(). Implementations should generally convert to a Status via Status.fromThrowable(Throwable).
> 

2. You can find why the exception was thrown in the following code, copied from [gRPC](https://github.com/grpc/grpc-java/blob/master/stub/src/main/java/io/grpc/stub/ServerCalls.java).

2.1. Before call requestObserver.onError, it will first set responseObserver.cancelled = true. Besides the onCancelHandler  is null, because it was not set in ratis.

```
      @Override
      public void onCancel() {
        responseObserver.cancelled = true;
        if (responseObserver.onCancelHandler != null) {
          responseObserver.onCancelHandler.run();
        }
        if (!halfClosed) {
          requestObserver.onError(
              Status.CANCELLED
                  .withDescription("cancelled before receiving half close")
                  .asRuntimeException());
        }
      }
```

2.2. When call responseObserver.onCompleted, because cancelled == true and onCancelHandler  == null, then exception was threw.

```
    @Override
    public void onCompleted() {
      if (cancelled) {
        if (onCancelHandler == null) {
          throw Status.CANCELLED.withDescription("call already cancelled").asRuntimeException();
        }
      } else {
        call.close(Status.OK, new Metadata());
        completed = true;
      }
    }
```
