### PR TITLE
RATIS-873. Fix Install Snapshot Notification

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -376,6 +376,7 @@ public class GrpcLogAppender extends LogAppender {
           final long followerSnapshotIndex = reply.getSnapshotIndex();
           LOG.info("{}: set follower snapshotIndex to {}.", this, followerSnapshotIndex);
           getFollower().setSnapshotIndex(followerSnapshotIndex);
+          updateCommitIndex(followerSnapshotIndex);
           removePending(reply);
           break;
         case NOT_LEADER:

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -223,7 +223,7 @@ public class GrpcLogAppender extends LogAppender {
   }
 
   private void increaseNextIndex(final long installedSnapshotIndex) {
-    getFollower().increaseNextIndex(installedSnapshotIndex + 1);
+    getFollower().updateNextIndexToMax(installedSnapshotIndex + 1);
   }
 
   /**
@@ -423,12 +423,8 @@ public class GrpcLogAppender extends LogAppender {
 
     @Override
     public void onCompleted() {
-      if (!isNotificationOnly) {
+      if (!isNotificationOnly || LOG.isDebugEnabled()) {
         LOG.info("{}: follower responded installSnapshot COMPLETED", this);
-      } else {
-        if (LOG.isDebugEnabled()) {
-          LOG.info("{}: follower responded installSnapshot COMPLETED", this);
-        }
       }
       close();
     }

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -132,6 +132,7 @@ enum InstallSnapshotResult {
   IN_PROGRESS = 2;
   ALREADY_INSTALLED = 3;
   CONF_MISMATCH = 4;
+  NOTIFIED = 5;
 }
 
 message RequestVoteRequestProto {

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -132,7 +132,6 @@ enum InstallSnapshotResult {
   IN_PROGRESS = 2;
   ALREADY_INSTALLED = 3;
   CONF_MISMATCH = 4;
-  NOTIFIED = 5;
 }
 
 message RequestVoteRequestProto {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfo.java
@@ -91,6 +91,10 @@ public class FollowerInfo {
     nextIndex.updateUnconditionally(old -> newNextIndex >= 0 ? newNextIndex : old, infoIndexChange);
   }
 
+  public void updateNextIndexToMax(long newNextIndex) {
+    nextIndex.updateToMax(newNextIndex, infoIndexChange);
+  }
+
   public void setSnapshotIndex(long snapshotIndex) {
     matchIndex.setUnconditionally(snapshotIndex, infoIndexChange);
     nextIndex.setUnconditionally(snapshotIndex + 1, infoIndexChange);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1242,11 +1242,13 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
               inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
             });
 
-        return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
-            currentTerm, InstallSnapshotResult.NOTIFIED, -1);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("{}: Snapshot Installation Request received and is in progress", getMemberId());
+        }
+      } else {
+        LOG.info("{}: Snapshot Installation by StateMachine is in progress.", getMemberId());
       }
 
-      LOG.info("{}: Snapshot Installation by StateMachine is in progress.", getMemberId());
       return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
           currentTerm, InstallSnapshotResult.IN_PROGRESS, -1);
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1051,7 +1051,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
     final TermIndex installSnapshot = inProgressInstallSnapshotRequest.get();
     if (installSnapshot != null) {
       LOG.info("{}: Failed appendEntries as snapshot ({}) installation is in progress", getMemberId(), installSnapshot);
-      return installSnapshot.getIndex();
+      return state.getNextIndex();
     }
 
     // Check that the first log entry is greater than the snapshot index in the latest snapshot.

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1233,8 +1233,8 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
 
               if (reply != null) {
                 stateMachine.pause();
-                state.reloadStateMachine(reply.getIndex(), leaderTerm);
                 state.updateInstalledSnapshotIndex(reply);
+                state.reloadStateMachine(reply.getIndex(), leaderTerm);
               }
               inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
             });

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -492,6 +492,13 @@ public class SegmentedRaftLog extends RaftLog {
     // if the last index in snapshot is larger than the index of the last
     // log entry, we should delete all the log entries and their cache to avoid
     // gaps between log segments.
+
+    // Close open log segment if entries are already included in snapshot
+    LogSegment openSegment = cache.getOpenSegment();
+    if (openSegment != null && openSegment.getEndIndex() <= lastSnapshotIndex) {
+      fileLogWorker.closeLogSegment(openSegment);
+    }
+    cache.clear();
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -497,8 +497,8 @@ public class SegmentedRaftLog extends RaftLog {
     LogSegment openSegment = cache.getOpenSegment();
     if (openSegment != null && openSegment.getEndIndex() <= lastSnapshotIndex) {
       fileLogWorker.closeLogSegment(openSegment);
+      cache.clear();
     }
-    cache.clear();
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -408,6 +408,12 @@ class SegmentedRaftLogWorker implements Runnable {
     return addIOTask(new TruncateLog(ts, index));
   }
 
+  void closeLogSegment(LogSegment segmentToClose) {
+    LOG.info("{}: Closing segment {} to index: {}", name,
+        segmentToClose.toString(), segmentToClose.getEndIndex());
+    addIOTask(new FinalizeLogSegment(segmentToClose));
+  }
+
   Task purge(TruncationSegments ts) {
     return addIOTask(new PurgeLog(ts, storage));
   }


### PR DESCRIPTION
This Jira aims to fix the following:

- When Follower is in the process of installing snapshot and it gets an append entry, it replies with result INCONSISTENCY and the follower next index is updated to the snapshot index being installed. This should not happen as the snapshot installation is still in progress. Follower's next index on the leader should remain the same.

- After InstallSnapshot is done, Leader should update the commitIndex of the Follower to the installed snapshot index.

- After InstallSnapshot, when reloading StateMachine, any previously open LogSegment should be closed, if the last entry in the open log is already included in the snapshot.

- When Follower is notified to install snapshot through StateMachine, the reply should indicate the same. It would help with debugging if the Install Snapshot success reply and Install Snapshot notified replies are distinct.