### PR TITLE
RATIS-874. Fix AppendEntry validity checks to take the SnapshotIndex into account

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerInfo.java
@@ -41,6 +41,7 @@ public class FollowerInfo {
   private final RaftLogIndex nextIndex;
   private final RaftLogIndex matchIndex = new RaftLogIndex("matchIndex", 0L);
   private final RaftLogIndex commitIndex = new RaftLogIndex("commitIndex", RaftLog.INVALID_LOG_INDEX);
+  private final RaftLogIndex snapshotIndex = new RaftLogIndex("snapshotIndex", 0L);
   private volatile boolean attendVote;
   private final int rpcSlownessTimeoutMs;
 
@@ -75,6 +76,10 @@ public class FollowerInfo {
     return commitIndex.updateToMax(newCommitIndex, debugIndexChange);
   }
 
+  long getSnapshotIndex() {
+    return snapshotIndex.get();
+  }
+
   public long getNextIndex() {
     return nextIndex.get();
   }
@@ -95,9 +100,10 @@ public class FollowerInfo {
     nextIndex.updateToMax(newNextIndex, infoIndexChange);
   }
 
-  public void setSnapshotIndex(long snapshotIndex) {
-    matchIndex.setUnconditionally(snapshotIndex, infoIndexChange);
-    nextIndex.setUnconditionally(snapshotIndex + 1, infoIndexChange);
+  public void setSnapshotIndex(long newSnapshotIndex) {
+    snapshotIndex.setUnconditionally(newSnapshotIndex, infoIndexChange);
+    matchIndex.setUnconditionally(newSnapshotIndex, infoIndexChange);
+    nextIndex.setUnconditionally(newSnapshotIndex + 1, infoIndexChange);
   }
 
   public String getName() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1168,7 +1168,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
         // update the committed index
         // re-load the state machine if this is the last chunk
         if (snapshotChunkRequest.getDone()) {
-          state.reloadStateMachine(lastIncludedIndex, leaderTerm);
+          state.reloadStateMachine(lastIncludedIndex);
         }
       } finally {
         updateLastRpcTime(FollowerState.UpdateType.INSTALL_SNAPSHOT_COMPLETE);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1238,7 +1238,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
                     getMemberId(), reply.getIndex());
                 stateMachine.pause();
                 state.updateInstalledSnapshotIndex(reply);
-                state.reloadStateMachine(reply.getIndex(), leaderTerm);
+                state.reloadStateMachine(reply.getIndex());
               }
               inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
             });

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -372,8 +372,8 @@ public class ServerState implements Closeable {
     return false;
   }
 
-  void reloadStateMachine(long lastIndexInSnapshot, long curTerm) {
-    log.updateLastCommitted(lastIndexInSnapshot, curTerm);
+  void reloadStateMachine(long lastIndexInSnapshot) {
+    log.updateSnapshotIndex(lastIndexInSnapshot);
     stateMachineUpdater.reloadStateMachine();
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -349,7 +349,7 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
           lastTermIndex.getIndex(), latestSnapshotIndex, entry);
     } else {
       Preconditions.assertTrue(entry.getIndex() == latestSnapshotIndex + 1,
-          "Difference between entry index and RaftLog's latest snapshot index is greater than 1 " +
+          "Difference between entry index and RaftLog's latest snapshot index %d is greater than 1 " +
               "and in between log entries are not present, entry: %s",
           latestSnapshotIndex, entry);
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -338,15 +338,15 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
     }
     TermIndex lastTermIndex = getLastEntryTermIndex();
     if (lastTermIndex != null) {
-      long snapshotIndex = getSnapshotIndex();
-      long lastIndex = lastTermIndex.getIndex() > snapshotIndex ?
-          lastTermIndex.getIndex() : snapshotIndex;
+      long latestSnapshotIndex = getSnapshotIndex();
+      long lastIndex = lastTermIndex.getIndex() > latestSnapshotIndex ?
+          lastTermIndex.getIndex() : latestSnapshotIndex;
       Preconditions.assertTrue(entry.getTerm() >= lastTermIndex.getTerm(),
           "Entry term less than RaftLog's last term: %d, entry: %s", lastTermIndex.getTerm(), entry);
       Preconditions.assertTrue(entry.getIndex() == lastIndex + 1,
           "Difference between entry index and RaftLog's last index %d (or snapshot index %d) " +
               "is greater than 1, entry: %s",
-          lastTermIndex.getIndex(), snapshotIndex, entry);
+          lastTermIndex.getIndex(), latestSnapshotIndex, entry);
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -71,6 +71,8 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
    * in the latest snapshot file.
    */
   private final RaftLogIndex commitIndex;
+  /** The last log index in snapshot */
+  private final RaftLogIndex snapshotIndex;
   private final RaftLogIndex purgeIndex;
   private final int purgeGap;
 
@@ -87,6 +89,7 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
     this.name = memberId + "-" + getClass().getSimpleName();
     this.memberId = memberId;
     this.commitIndex = new RaftLogIndex("commitIndex", commitIndex);
+    this.snapshotIndex = new RaftLogIndex("snapshotIndex", commitIndex);
     this.purgeIndex = new RaftLogIndex("purgeIndex", LEAST_VALID_LOG_INDEX - 1);
     this.purgeGap = RaftServerConfigKeys.Log.purgeGap(properties);
 
@@ -96,6 +99,10 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
 
   public long getLastCommittedIndex() {
     return commitIndex.get();
+  }
+
+  public long getSnapshotIndex() {
+    return snapshotIndex.get();
   }
 
   public void checkLogState() {
@@ -127,6 +134,24 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
       }
     }
     return false;
+  }
+
+  /**
+   * Update the last committed index and snapshotIndex with the last index in
+   * the snapshot.
+   * @param newSnapshotIndex the last index in the snapshot
+   */
+  public void updateSnapshotIndex(long newSnapshotIndex) {
+    try(AutoCloseableLock writeLock = writeLock()) {
+      final long oldSnapshotIndex = getSnapshotIndex();
+      if (oldSnapshotIndex < newSnapshotIndex) {
+        snapshotIndex.updateIncreasingly(newSnapshotIndex, infoIndexChange);
+      }
+      final long oldCommitIndex = getLastCommittedIndex();
+      if (oldCommitIndex < newSnapshotIndex) {
+        commitIndex.updateIncreasingly(newSnapshotIndex, traceIndexChange);
+      }
+    }
   }
 
   /**
@@ -313,11 +338,15 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
     }
     TermIndex lastTermIndex = getLastEntryTermIndex();
     if (lastTermIndex != null) {
+      long snapshotIndex = getSnapshotIndex();
+      long lastIndex = lastTermIndex.getIndex() > snapshotIndex ?
+          lastTermIndex.getIndex() : snapshotIndex;
       Preconditions.assertTrue(entry.getTerm() >= lastTermIndex.getTerm(),
           "Entry term less than RaftLog's last term: %d, entry: %s", lastTermIndex.getTerm(), entry);
-      Preconditions.assertTrue(entry.getIndex() == lastTermIndex.getIndex() + 1,
-          "Difference between entry index and RaftLog's last index %d greater than 1, entry: %s",
-          lastTermIndex.getIndex(), entry);
+      Preconditions.assertTrue(entry.getIndex() == lastIndex + 1,
+          "Difference between entry index and RaftLog's last index %d (or snapshot index %d) " +
+              "is greater than 1, entry: %s",
+          lastTermIndex.getIndex(), snapshotIndex, entry);
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -336,9 +336,9 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
     if (entry.hasMetadataEntry()) {
       return;
     }
+    long latestSnapshotIndex = getSnapshotIndex();
     TermIndex lastTermIndex = getLastEntryTermIndex();
     if (lastTermIndex != null) {
-      long latestSnapshotIndex = getSnapshotIndex();
       long lastIndex = lastTermIndex.getIndex() > latestSnapshotIndex ?
           lastTermIndex.getIndex() : latestSnapshotIndex;
       Preconditions.assertTrue(entry.getTerm() >= lastTermIndex.getTerm(),
@@ -347,6 +347,11 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
           "Difference between entry index and RaftLog's last index %d (or snapshot index %d) " +
               "is greater than 1, entry: %s",
           lastTermIndex.getIndex(), latestSnapshotIndex, entry);
+    } else {
+      Preconditions.assertTrue(entry.getIndex() == latestSnapshotIndex + 1,
+          "Difference between entry index and RaftLog's latest snapshot index is greater than 1 " +
+              "and in between log entries are not present, entry: %s",
+          latestSnapshotIndex, entry);
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -248,7 +248,7 @@ public class SegmentedRaftLog extends RaftLog {
         // entries to the state machine
         boolean keepEntryInCache = (paths.size() - i++) <= cache.getMaxCachedSegments();
         final Timer.Context loadSegmentContext = raftLogMetrics.getRaftLogLoadSegmentTimer().time();
-        cache.loadSegment(pi, keepEntryInCache, logConsumer);
+        cache.loadSegment(pi, keepEntryInCache, logConsumer, lastIndexInSnapshot);
         loadSegmentContext.stop();
       }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -342,10 +342,10 @@ class SegmentedRaftLogCache {
   }
 
   void loadSegment(LogPathAndIndex pi, boolean keepEntryInCache,
-      Consumer<LogEntryProto> logConsumer) throws IOException {
+      Consumer<LogEntryProto> logConsumer, long lastIndexInSnapshot) throws IOException {
     LogSegment logSegment = LogSegment.loadSegment(storage, pi.getPath().toFile(),
         pi.getStartIndex(), pi.getEndIndex(), pi.isOpen(), keepEntryInCache, logConsumer, raftLogMetrics);
-    if (logSegment != null) {
+    if (logSegment != null && logSegment.getEndIndex() > lastIndexInSnapshot) {
       addSegment(logSegment);
     }
   }

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -274,7 +274,8 @@ public class TestSegmentedRaftLog extends BaseTest {
       } catch (IllegalStateException e) {
         ex = e;
       }
-      Assert.assertTrue(ex.getMessage().contains("and RaftLog's last index " + lastTermIndex.getIndex() + " greater than 1"));
+      Assert.assertTrue(ex.getMessage().contains("and RaftLog's last index " + lastTermIndex.getIndex()
+          + " (or snapshot index " + raftLog.getSnapshotIndex() + ") is greater than 1"));
     }
   }
 


### PR DESCRIPTION
This Jira aims to fix the following:

- Before sending an appendEntry request to follower, leader checks the validity of the request be verifying if the follower has the previous log entry. But if the follower had installed a snapshot, the previous could be missing and the appendEntry would still be valid. Hence, the SnapshotIndex should be factored in while checking the validity of appendEntry request. Leader should store Follower's SnapshotIndex for this.

- When follower receives appendEntry request, it checks the validity of log entry - the first index of the log entry is exactly 1 more than the last log index. During this check, the snapshotIndex should also be considered i.e. the first index of the log entry can be 1 more than the last log index or the snapshotIndex.

- After Ratis server is restared, it loads all the available log segments. But logs with end index < last snapshot index should not be loaded. There can be gaps in the log segments upto the snapshotIndex if a snapshot was installed from leader node.