### PR TITLE
RATIS-925. Fix memory leak of RaftServerImpl for no remove from static RaftServerMetrics::metricsMap

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -276,6 +276,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
       }
       leaderElectionMetrics.unregister();
       raftServerMetrics.unregister();
+      RaftServerMetrics.removeRaftServerMetrics(this);
       if (deleteDirectory) {
         final RaftStorageDirectory dir = state.getStorage().getStorageDir();
         try {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerMetrics.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerMetrics.java
@@ -78,6 +78,13 @@ public final class RaftServerMetrics extends RatisMetrics {
     return serverMetrics;
   }
 
+  public static void removeRaftServerMetrics(RaftServerImpl raftServer) {
+    String memberId = raftServer.getMemberId().toString();
+    if (metricsMap.containsKey(memberId)) {
+      metricsMap.remove(memberId);
+    }
+  }
+
   private RaftServerMetrics(RaftServerImpl server) {
     registry = getMetricRegistryForRaftServer(server.getMemberId().toString());
     commitInfoCache = server.getCommitInfoCache();


### PR DESCRIPTION
**What's the problem ?**
As the image shows, there are 2066 instances of RaftServerImpl, most of them are Closed, and should be GC, but actually not.
![image](https://user-images.githubusercontent.com/51938049/81141951-bc9a7580-8fa0-11ea-9516-f0fb38067113.png)

**What's the reason ?**
You can find from the image 2040 RaftServerImpl were held by RaftServerMetrics::metricsMap which is a staic map 
![image](https://user-images.githubusercontent.com/51938049/81141965-c7eda100-8fa0-11ea-95f7-841981576bca.png)
