### PR TITLE
RATIS-927. Improve the log of remove group

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -91,6 +91,11 @@ public class RaftServerProxy implements RaftServer {
     }
 
     synchronized CompletableFuture<RaftServerImpl> remove(RaftGroupId groupId) {
+      if (!map.containsKey(groupId)) {
+        LOG.warn("{}: does not contain group: {}", getId(), groupId);
+        return null;
+      }
+
       final CompletableFuture<RaftServerImpl> future = map.remove(groupId);
       LOG.info("{}: remove {}", getId(), toString(groupId, future));
       return future;


### PR DESCRIPTION
The group-4F2C3D50C136 was deleted many times, but the log is not sufficient to find when it was deleted.
![image](https://user-images.githubusercontent.com/51938049/81158822-f0829480-8fba-11ea-8a07-b2ba55b42d3e.png)
