### PR TITLE
RATIS-929. Shutdown EventLoopGroup faster

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -145,8 +145,8 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
   public void closeImpl() throws IOException {
     final ChannelFuture f = getChannel().close();
     f.syncUninterruptibly();
-    bossGroup.shutdownGracefully();
-    workerGroup.shutdownGracefully();
+    bossGroup.shutdownGracefully(0, 100, TimeUnit.MILLISECONDS);
+    workerGroup.shutdownGracefully(0, 100, TimeUnit.MILLISECONDS);
     try {
       bossGroup.awaitTermination(1000, TimeUnit.MILLISECONDS);
       workerGroup.awaitTermination(1000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
What's the problem ?
`shutdownGracefully` does not pass any parameter from ratis, then it will take the default parameter at [shutdownGracefully(DEFAULT_SHUTDOWN_QUIET_PERIOD, DEFAULT_SHUTDOWN_TIMEOUT, TimeUnit.SECONDS)](https://github.com/netty/netty/blob/4.1/common/src/main/java/io/netty/util/concurrent/AbstractEventExecutorGroup.java#L70), the `DEFAULT_SHUTDOWN_QUIET_PERIOD` is 2 seconds, mean it can still accept new request in 2 seconds, you can also find it in the following code copied from netty, the `gracefulShutdownQuietPeriod `is the parameter `DEFAULT_SHUTDOWN_QUIET_PERIOD`. 
```
        final long nanoTime = ScheduledFutureTask.nanoTime();

        if (isShutdown() || nanoTime - gracefulShutdownStartTime > gracefulShutdownTimeout) {
            return true;
        }

        if (nanoTime - lastExecutionTime <= gracefulShutdownQuietPeriod) {
            // Check if any tasks were added to the queue every 100ms.
            // TODO: Change the behavior of takeTask() so that it returns on timeout.
            taskQueue.offer(WAKEUP_TASK);
            try {
                Thread.sleep(100);
            } catch (InterruptedException e) {
                // Ignore
            }

            return false;
        }

        // No tasks were added for last quiet period - hopefully safe to shut down.
        // (Hopefully because we really cannot make a guarantee that there will be no execute() calls by a user.)
        return true;
```
So it must `awaitTermination` timeout, i.e. 1 second, now the timeout of `bossGroup.awaitTermination` and `workerGroup.awaitTermination` are both 1 second, so it need 2 seconds to closeImpl. 

How to fix ?
set `DEFAULT_SHUTDOWN_QUIET_PERIOD = 0`, so that it can shutdown EventLoopGroup immediately. Test with this patch, It can close in 300ms.