### PR TITLE
RATIS-923. Cache evicted before RollSegment completes

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -225,6 +225,7 @@ public class SegmentedRaftLog extends RaftLog {
           .getOpenLogFile(openSegment.getStartIndex());
     }
     fileLogWorker.start(Math.max(cache.getEndIndex(), lastIndexInSnapshot),
+        Math.max(cache.getLastIndexInClosedSegments(), lastIndexInSnapshot),
         openSegmentFile);
   }
 
@@ -324,7 +325,8 @@ public class SegmentedRaftLog extends RaftLog {
       // TODO if the cache is hitting the maximum size and we cannot evict any
       // segment's cache, should block the new entry appending or new segment
       // allocation.
-      cache.evictCache(server.getFollowerNextIndices(), fileLogWorker.getFlushIndex(), server.getLastAppliedIndex());
+      cache.evictCache(server.getFollowerNextIndices(), fileLogWorker.getSafeCacheEvictIndex(),
+          server.getLastAppliedIndex());
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -225,7 +225,7 @@ public class SegmentedRaftLog extends RaftLog {
           .getOpenLogFile(openSegment.getStartIndex());
     }
     fileLogWorker.start(Math.max(cache.getEndIndex(), lastIndexInSnapshot),
-        Math.max(cache.getLastIndexInClosedSegments(), lastIndexInSnapshot),
+        Math.min(cache.getLastIndexInClosedSegments(), lastIndexInSnapshot),
         openSegmentFile);
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -358,10 +358,9 @@ class SegmentedRaftLogCache {
     return closedSegments.countCached() > maxCachedSegments;
   }
 
-  void evictCache(long[] followerIndices, long flushedIndex,
-      long lastAppliedIndex) {
+  void evictCache(long[] followerIndices, long safeEvictIndex, long lastAppliedIndex) {
     List<LogSegment> toEvict = evictionPolicy.evict(followerIndices,
-        flushedIndex, lastAppliedIndex, closedSegments, maxCachedSegments);
+        safeEvictIndex, lastAppliedIndex, closedSegments, maxCachedSegments);
     for (LogSegment s : toEvict) {
       s.evictCache();
     }
@@ -483,6 +482,11 @@ class SegmentedRaftLogCache {
         (closedSegments.isEmpty() ?
             RaftLog.INVALID_LOG_INDEX:
             closedSegments.get(closedSegments.size() - 1).getEndIndex());
+  }
+
+  long getLastIndexInClosedSegments() {
+    return (closedSegments.isEmpty() ? RaftLog.INVALID_LOG_INDEX :
+        closedSegments.get(closedSegments.size() - 1).getEndIndex());
   }
 
   TermIndex getLastTermIndex() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -158,6 +158,10 @@ class SegmentedRaftLogWorker implements Runnable {
   private long lastWrittenIndex;
   /** the largest index of the entry that has been flushed */
   private final RaftLogIndex flushIndex = new RaftLogIndex("flushIndex", 0);
+  /** the largest index of the entry in a closed segment */
+  /** the index up to which cache can be evicted - max of snapshotIndex and
+   * largest index in a closed segment */
+  private final RaftLogIndex safeCacheEvictIndex = new RaftLogIndex("safeCacheEvictIndex", 0);
 
   private final int forceSyncNum;
 
@@ -207,10 +211,11 @@ class SegmentedRaftLogWorker implements Runnable {
     this.writeBuffer = ByteBuffer.allocateDirect(bufferSize);
   }
 
-  void start(long latestIndex, File openSegmentFile) throws IOException {
+  void start(long latestIndex, long evictIndex, File openSegmentFile) throws IOException {
     LOG.trace("{} start(latestIndex={}, openSegmentFile={})", name, latestIndex, openSegmentFile);
     lastWrittenIndex = latestIndex;
     flushIndex.setUnconditionally(latestIndex, infoIndexChange);
+    safeCacheEvictIndex.setUnconditionally(evictIndex, infoIndexChange);
     if (openSegmentFile != null) {
       Preconditions.assertTrue(openSegmentFile.exists());
       allocateSegmentedRaftLogOutputStream(openSegmentFile, true);
@@ -237,6 +242,7 @@ class SegmentedRaftLogWorker implements Runnable {
     queue.clear();
     lastWrittenIndex = lastSnapshotIndex;
     flushIndex.setUnconditionally(lastSnapshotIndex, infoIndexChange);
+    safeCacheEvictIndex.setUnconditionally(lastSnapshotIndex, infoIndexChange);
     pendingFlushNum = 0;
   }
 
@@ -550,6 +556,7 @@ class SegmentedRaftLogWorker implements Runnable {
         LOG.info("{}: Deleted empty log segment {}", name, openFile);
       }
       updateFlushedIndexIncreasingly();
+      updateSafeCacheEvitIndex(endIndex);
     }
 
     @Override
@@ -664,6 +671,7 @@ class SegmentedRaftLogWorker implements Runnable {
         IOUtils.getFromFuture(stateMachineFuture, () -> this + "-truncateStateMachineData");
       }
       flushIndex.setUnconditionally(lastWrittenIndex, infoIndexChange);
+      safeCacheEvictIndex.setUnconditionally(lastWrittenIndex, infoIndexChange);
       postUpdateFlushedIndex();
     }
 
@@ -685,6 +693,14 @@ class SegmentedRaftLogWorker implements Runnable {
 
   long getFlushIndex() {
     return flushIndex.get();
+  }
+
+  void updateSafeCacheEvitIndex(long newIndex) {
+    safeCacheEvictIndex.updateToMax(newIndex, traceIndexChange);
+  }
+
+  long getSafeCacheEvictIndex() {
+    return safeCacheEvictIndex.get();
   }
 
   private void freeSegmentedRaftLogOutputStream() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -556,7 +556,7 @@ class SegmentedRaftLogWorker implements Runnable {
         LOG.info("{}: Deleted empty log segment {}", name, openFile);
       }
       updateFlushedIndexIncreasingly();
-      updateSafeCacheEvitIndex(endIndex);
+      safeCacheEvictIndex.updateToMax(endIndex, traceIndexChange);
     }
 
     @Override
@@ -693,10 +693,6 @@ class SegmentedRaftLogWorker implements Runnable {
 
   long getFlushIndex() {
     return flushIndex.get();
-  }
-
-  void updateSafeCacheEvitIndex(long newIndex) {
-    safeCacheEvictIndex.updateToMax(newIndex, traceIndexChange);
   }
 
   long getSafeCacheEvictIndex() {


### PR DESCRIPTION
If a segment is evicted from Segment Cache before it is rolled over and applyTransaction thread tries to read this segment, it can lead to FileNotFoundException.
