### PR TITLE
RATIS-936. Fix ratis-hadoop with non shaded protobuf dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,7 @@
     <shaded.protobuf.version>3.11.0</shaded.protobuf.version>
     <shaded.grpc.version>1.28.1</shaded.grpc.version>
 
+    <hadoop.protobuf.version>2.5.0</hadoop.protobuf.version>
 
     <!-- Test properties -->
     <maven.test.redirectTestOutputToFile>true</maven.test.redirectTestOutputToFile>

--- a/ratis-hadoop/pom.xml
+++ b/ratis-hadoop/pom.xml
@@ -100,6 +100,28 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <configuration>
+          <protocArtifact>
+            com.google.protobuf:protoc:${hadoop.protobuf.version}:exe:${os.detected.classifier}
+          </protocArtifact>
+          <!-- Place these in a location that compiler-plugin is already looking -->
+          <outputDirectory>${project.build.directory}/generated-sources</outputDirectory>
+          <!-- With multiple executions, this must be `false` otherwise we wipe out the previous execution -->
+          <clearOutputDirectory>false</clearOutputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <id>compile-protobuf</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolClientSideTranslatorPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolClientSideTranslatorPB.java
@@ -123,8 +123,8 @@ public class CombinedClientProtocolClientSideTranslatorPB
       byte[] reply = getProtocol().sendClient(null, req)
           .getResponse().toByteArray();
 
-      PROTO_REP reply_proto = byteToProto.apply(reply);
-      return repToProto.apply(reply_proto);
+      PROTO_REP replyProto = byteToProto.apply(reply);
+      return repToProto.apply(replyProto);
     } catch (ServiceException se) {
       LOG.trace("Failed to handle " + request, se);
       throw new IOException(se);

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolClientSideTranslatorPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolClientSideTranslatorPB.java
@@ -17,10 +17,15 @@
  */
 package org.apache.ratis.hadooprpc.client;
 
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ServiceException;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.hadooprpc.Proxy;
+import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.ClientRequestProto;
+import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.ClientOps;
 import org.apache.ratis.protocol.GroupInfoReply;
 import org.apache.ratis.protocol.GroupInfoRequest;
 import org.apache.ratis.protocol.GroupListReply;
@@ -29,8 +34,10 @@ import org.apache.ratis.protocol.GroupManagementRequest;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.SetConfigurationRequest;
-import org.apache.ratis.thirdparty.com.google.protobuf.ServiceException;
-import org.apache.ratis.util.ProtoUtils;
+import org.apache.ratis.thirdparty.com.google.protobuf
+    .GeneratedMessageV3;
+import org.apache.ratis.thirdparty.com.google.protobuf
+    .InvalidProtocolBufferException;
 import org.apache.ratis.util.function.CheckedFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,7 +63,8 @@ public class CombinedClientProtocolClientSideTranslatorPB
     return handleRequest(request,
         ClientProtoUtils::toRaftClientRequestProto,
         ClientProtoUtils::toRaftClientReply,
-        p -> getProtocol().submitClientRequest(null, p));
+        ClientOps.submitClientRequest,
+        RaftProtos.RaftClientReplyProto::parseFrom);
   }
 
   @Override
@@ -65,7 +73,8 @@ public class CombinedClientProtocolClientSideTranslatorPB
     return handleRequest(request,
         ClientProtoUtils::toSetConfigurationRequestProto,
         ClientProtoUtils::toRaftClientReply,
-        p -> getProtocol().setConfiguration(null, p));
+        ClientOps.setConfiguration,
+        RaftProtos.RaftClientReplyProto::parseFrom);
   }
 
   @Override
@@ -73,7 +82,8 @@ public class CombinedClientProtocolClientSideTranslatorPB
     return handleRequest(request,
         ClientProtoUtils::toGroupManagementRequestProto,
         ClientProtoUtils::toRaftClientReply,
-        p -> getProtocol().groupManagement(null, p));
+        ClientOps.groupManagement,
+        RaftProtos.RaftClientReplyProto::parseFrom);
   }
 
   @Override
@@ -81,7 +91,8 @@ public class CombinedClientProtocolClientSideTranslatorPB
     return handleRequest(request,
         ClientProtoUtils::toGroupListRequestProto,
         ClientProtoUtils::toGroupListReply,
-        p -> getProtocol().groupList(null, p));
+        ClientOps.groupList,
+        RaftProtos.GroupListReplyProto::parseFrom);
   }
 
   @Override
@@ -89,23 +100,34 @@ public class CombinedClientProtocolClientSideTranslatorPB
     return handleRequest(request,
         ClientProtoUtils::toGroupInfoRequestProto,
         ClientProtoUtils::toGroupInfoReply,
-        p -> getProtocol().groupInfo(null, p));
+        ClientOps.groupInfo,
+        RaftProtos.GroupInfoReplyProto::parseFrom);
   }
 
-  static <REQUEST extends RaftClientRequest, REPLY extends RaftClientReply,
-      PROTO_REQ, PROTO_REP> REPLY handleRequest(
+  <REQUEST extends RaftClientRequest,
+      REPLY extends RaftClientReply,
+      PROTO_REQ extends GeneratedMessageV3,
+      PROTO_REP extends GeneratedMessageV3> REPLY handleRequest(
       REQUEST request,
       Function<REQUEST, PROTO_REQ> reqToProto,
       Function<PROTO_REP, REPLY> repToProto,
-      CheckedFunction<PROTO_REQ, PROTO_REP, ServiceException> handler)
+      ClientOps type,
+      CheckedFunction<byte[], PROTO_REP, InvalidProtocolBufferException> byteToProto)
       throws IOException {
     final PROTO_REQ proto = reqToProto.apply(request);
     try {
-      final PROTO_REP reply = handler.apply(proto);
-      return repToProto.apply(reply);
+      ClientRequestProto req = ClientRequestProto.newBuilder()
+          .setType(type)
+          .setRequest(ByteString.copyFrom(proto.toByteArray()))
+          .build();
+      byte[] reply = getProtocol().sendClient(null, req)
+          .getResponse().toByteArray();
+
+      PROTO_REP reply_proto = byteToProto.apply(reply);
+      return repToProto.apply(reply_proto);
     } catch (ServiceException se) {
       LOG.trace("Failed to handle " + request, se);
-      throw ProtoUtils.toIOException(se);
+      throw new IOException(se);
     }
   }
 }

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolPB.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.ratis.hadooprpc.HadoopConstants;
-import org.apache.ratis.proto.hadoop.HadoopProtos.CombinedClientProtocolService;
+import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.HadoopClientProtocolService;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
@@ -33,5 +33,5 @@ import org.apache.ratis.proto.hadoop.HadoopProtos.CombinedClientProtocolService;
     protocolName = HadoopConstants.COMBINED_CLIENT_PROTOCOL_NAME,
     protocolVersion = 1)
 public interface CombinedClientProtocolPB extends
-    CombinedClientProtocolService.BlockingInterface {
+    HadoopClientProtocolService.BlockingInterface {
 }

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/RaftServerProtocolPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/RaftServerProtocolPB.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.ratis.hadooprpc.HadoopConstants;
-import org.apache.ratis.proto.hadoop.HadoopProtos.RaftServerProtocolService;
+import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.HadoopServerProtocolService;
 
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
@@ -33,5 +33,5 @@ import org.apache.ratis.proto.hadoop.HadoopProtos.RaftServerProtocolService;
     protocolName = HadoopConstants.RAFT_SERVER_PROTOCOL_NAME,
     protocolVersion = 1)
 public interface RaftServerProtocolPB extends
-    RaftServerProtocolService.BlockingInterface {
+    HadoopServerProtocolService.BlockingInterface {
 }

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/RaftServerProtocolServerSideTranslatorPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/RaftServerProtocolServerSideTranslatorPB.java
@@ -18,17 +18,22 @@
 package org.apache.ratis.hadooprpc.server;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.apache.hadoop.classification.InterfaceAudience;
+import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.ServerOps;
+import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.ServerReplyProto;
+import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.ServerRequestProto;
 import org.apache.ratis.server.protocol.RaftServerProtocol;
-import org.apache.ratis.thirdparty.com.google.protobuf.RpcController;
-import org.apache.ratis.thirdparty.com.google.protobuf.ServiceException;
+import com.google.protobuf.RpcController;
+import com.google.protobuf.ServiceException;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.thirdparty.com.google.protobuf.GeneratedMessageV3;
 
 @InterfaceAudience.Private
 public class RaftServerProtocolServerSideTranslatorPB
@@ -40,34 +45,45 @@ public class RaftServerProtocolServerSideTranslatorPB
   }
 
   @Override
-  public RequestVoteReplyProto requestVote(
-      RpcController unused, RequestVoteRequestProto request)
-      throws ServiceException {
+  public ServerReplyProto sendServer(RpcController unused, ServerRequestProto requestProto) throws ServiceException {
+    ServerOps type = requestProto.getType();
+    ByteBuffer buffer = requestProto.getRequest().asReadOnlyByteBuffer();
+    GeneratedMessageV3 respone = null;
     try {
-      return impl.requestVote(request);
+      switch (type) {
+        case requestVote:
+          respone = requestVote(RequestVoteRequestProto.parseFrom(buffer));
+          break;
+        case installSnapshot:
+          respone = installSnapshot(InstallSnapshotRequestProto.parseFrom(buffer));
+          break;
+        case appendEntries:
+          respone = appendEntries(AppendEntriesRequestProto.parseFrom(buffer));
+          break;
+        default:
+          throw new IOException("Invalid Request Type:" + type);
+      }
+      return ServerReplyProto.newBuilder()
+          .setType(type)
+          .setResponse(com.google.protobuf.ByteString.copyFrom(respone.toByteArray()))
+          .build();
     } catch(IOException ioe) {
       throw new ServiceException(ioe);
     }
   }
 
-  @Override
-  public AppendEntriesReplyProto appendEntries(
-      RpcController unused, AppendEntriesRequestProto request)
-      throws ServiceException {
-    try {
-      return impl.appendEntries(request);
-    } catch(IOException ioe) {
-      throw new ServiceException(ioe);
-    }
+  public RequestVoteReplyProto requestVote(RequestVoteRequestProto request)
+      throws IOException {
+    return impl.requestVote(request);
   }
 
-  @Override
-  public InstallSnapshotReplyProto installSnapshot(RpcController controller,
-      InstallSnapshotRequestProto request) throws ServiceException {
-    try {
-      return impl.installSnapshot(request);
-    } catch(IOException ioe) {
-      throw new ServiceException(ioe);
-    }
+  public AppendEntriesReplyProto appendEntries(AppendEntriesRequestProto request)
+      throws IOException {
+    return impl.appendEntries(request);
+  }
+
+  public InstallSnapshotReplyProto installSnapshot(
+      InstallSnapshotRequestProto request) throws IOException {
+    return impl.installSnapshot(request);
   }
 }

--- a/ratis-hadoop/src/main/proto/HadoopCompatability.proto
+++ b/ratis-hadoop/src/main/proto/HadoopCompatability.proto
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+option java_package = "org.apache.ratis.proto.hadoop";
+option java_outer_classname = "HadoopCompatibilityProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+package ratis.hadoop;
+
+/**
+ * This proto file is a replacement for Hadoop.proto.
+ * The problem occurs because Hadoop's depends on protobuf 2.5.0.
+ * Where as Ratis uses protbuf 3.5.0 or greater
+ * This proto create a bytestring format to transfer the protos
+ * and then convert the bytestring to v3.5.0 proto at the rpc endpoint.
+ */
+
+enum ServerOps {
+  requestVote = 1;
+  appendEntries = 2;
+  installSnapshot = 3;
+}
+
+message ServerRequestProto {
+    required ServerOps type = 1;
+    required bytes request = 2;
+}
+
+message ServerReplyProto {
+    required ServerOps type = 1;
+    required bytes response = 2;
+}
+
+enum ClientOps {
+    submitClientRequest = 1;
+    setConfiguration = 2;
+    groupManagement = 3;
+    groupList = 4;
+    groupInfo = 5;
+}
+
+message ClientRequestProto {
+    required ClientOps type = 1;
+    required bytes request = 2;
+}
+
+message ClientReplyProto {
+    required ClientOps type = 1;
+    required bytes response = 2;
+}
+
+service HadoopServerProtocolService {
+    rpc sendServer(ServerRequestProto) returns (ServerReplyProto);
+}
+
+service HadoopClientProtocolService {
+    rpc sendClient(ClientRequestProto) returns (ClientReplyProto);
+}

--- a/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/TestRaftReconfigurationWithHadoopRpc.java
+++ b/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/TestRaftReconfigurationWithHadoopRpc.java
@@ -32,9 +32,6 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONN
 public class TestRaftReconfigurationWithHadoopRpc
     extends RaftReconfigurationBaseTest<MiniRaftClusterWithHadoopRpc>
     implements MiniRaftClusterWithHadoopRpc.Factory.Get {
-  static {
-    ((Log4JLogger) Client.LOG).getLogger().setLevel(Level.ERROR);
-  }
 
   @Override
   public MiniRaftClusterWithHadoopRpc newCluster(int numPeers) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/RATIS-936

With RATIS-932, dependency on shaded Ratis thirdparty has been removed. This has caused the ratis-hadoop protocol to break.

This jira purposes to fix this by using the protobuf 2.5.0 for the rpc communication and then converting to Protobuf 3.5.0 at rpc endpoint.