### PR TITLE
RATIS-921. Fix resource leak by closing thousands  of gRPC clients after use

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -20,6 +20,7 @@ package org.apache.ratis.grpc;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.ServerNotReadyException;
 import org.apache.ratis.protocol.TimeoutIOException;
+import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
 import org.apache.ratis.thirdparty.io.grpc.Metadata;
 import org.apache.ratis.thirdparty.io.grpc.Status;
 import org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException;
@@ -30,13 +31,17 @@ import org.apache.ratis.util.LogUtils;
 import org.apache.ratis.util.ReflectionUtils;
 import org.apache.ratis.util.function.CheckedSupplier;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 public interface GrpcUtil {
+  static final Logger LOG = LoggerFactory.getLogger(GrpcUtil.class);
+
   Metadata.Key<String> EXCEPTION_TYPE_KEY =
       Metadata.Key.of("exception-type", Metadata.ASCII_STRING_MARSHALLER);
   Metadata.Key<byte[]> EXCEPTION_OBJECT_KEY =
@@ -196,6 +201,36 @@ public interface GrpcUtil {
 
     Metadata build() {
       return trailers;
+    }
+  }
+
+  /**
+   * Tries to gracefully shut down the managed channel. Falls back to forceful shutdown if
+   * graceful shutdown times out.
+   */
+  static void shutdownManagedChannel(ManagedChannel managedChannel) {
+    // Close the gRPC managed-channel if not shut down already.
+    if (!managedChannel.isShutdown()) {
+      try {
+        managedChannel.shutdown();
+        if (!managedChannel.awaitTermination(3, TimeUnit.SECONDS)) {
+          LOG.warn("Timed out gracefully shutting down connection: {}. ", managedChannel);
+        }
+      } catch (Exception e) {
+        LOG.error("Unexpected exception while waiting for channel termination", e);
+      }
+    }
+
+    // Forceful shut down if still not terminated.
+    if (!managedChannel.isTerminated()) {
+      try {
+        managedChannel.shutdownNow();
+        if (!managedChannel.awaitTermination(2, TimeUnit.SECONDS)) {
+          LOG.warn("Timed out forcefully shutting down connection: {}. ", managedChannel);
+        }
+      } catch (Exception e) {
+        LOG.error("Unexpected exception while waiting for channel termination", e);
+      }
     }
   }
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
@@ -66,7 +66,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -143,12 +142,7 @@ public class GrpcClientProtocolClient implements Closeable {
   public void close() {
     Optional.ofNullable(orderedStreamObservers.getAndSet(null)).ifPresent(AsyncStreamObservers::close);
     Optional.ofNullable(unorderedStreamObservers.getAndSet(null)).ifPresent(AsyncStreamObservers::close);
-    channel.shutdown();
-    try {
-      channel.awaitTermination(5, TimeUnit.SECONDS);
-    } catch (Exception e) {
-      LOG.error("Unexpected exception while waiting for channel termination", e);
-    }
+    GrpcUtil.shutdownManagedChannel(channel);
     scheduler.close();
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.grpc.server;
 
 import org.apache.ratis.grpc.GrpcTlsConfig;
+import org.apache.ratis.grpc.GrpcUtil;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.thirdparty.io.grpc.ManagedChannel;
 import org.apache.ratis.thirdparty.io.grpc.netty.GrpcSslContexts;
@@ -35,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.util.concurrent.TimeUnit;
 
 /**
  * This is a RaftClient implementation that supports streaming data to the raft
@@ -89,12 +89,7 @@ public class GrpcServerProtocolClient implements Closeable {
 
   @Override
   public void close() {
-    channel.shutdown();
-    try {
-      channel.awaitTermination(5, TimeUnit.SECONDS);
-    } catch (Exception e) {
-      LOG.error("Unexpected exception while waiting for channel termination, peerId={}", raftPeerId, e);
-    }
+    GrpcUtil.shutdownManagedChannel(channel);
   }
 
   public RequestVoteReplyProto requestVote(RequestVoteRequestProto request) {

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/impl/LogStreamImpl.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/impl/LogStreamImpl.java
@@ -192,6 +192,7 @@ public class LogStreamImpl implements LogStream {
   @Override
   public void close() throws Exception {
     // TODO Auto-generated method stub
+    raftClient.close();
     state = State.CLOSED;
   }
 

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogServer.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogServer.java
@@ -176,6 +176,7 @@ public class LogServer extends BaseServer {
 
 
     public void close() throws IOException {
+        metaClient.close();
         raftServer.close();
         daemon.interrupt();
     }

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
@@ -485,6 +485,13 @@ public class LogStateMachine extends BaseStateMachine {
   public void close() {
     reset();
     logServiceMetrics.unregister();
+    if (client != null) {
+      try {
+        client.close();
+      } catch (Exception ignored) {
+        LOG.warn(ignored.getClass().getSimpleName() + " is ignored", ignored);
+      }
+    }
   }
 
   @Override

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java
@@ -261,21 +261,15 @@ public class MetaStateMachine extends BaseStateMachine {
         } else {
             Collection<RaftPeer> raftPeers = raftGroup.getPeers();
             raftPeers.stream().forEach(peer -> {
-                RaftClient client = RaftClient.newBuilder().setProperties(properties)
-                    .setClientId(ClientId.randomId())
-                    .setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build();
-                try {
+                try (RaftClient client = RaftClient.newBuilder().setProperties(properties)
+                    .setClientId(ClientId.randomId()).setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build()){
                     client.groupRemove(raftGroup.getGroupId(), true, peer.getId());
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
             });
-            RaftClient client = RaftClient.newBuilder()
-                    .setRaftGroup(currentGroup)
-                    .setClientId(ClientId.randomId())
-                    .setProperties(properties)
-                    .build();
-            try {
+            try (RaftClient client = RaftClient.newBuilder().setRaftGroup(currentGroup)
+                .setClientId(ClientId.randomId()).setProperties(properties).build()){
                 client.send(() -> MetaServiceProtos.MetaSMRequestProto.newBuilder()
                         .setUnregisterRequest(
                                 LogServiceUnregisterLogRequestProto.newBuilder()
@@ -323,9 +317,8 @@ public class MetaStateMachine extends BaseStateMachine {
                 int provisionedPeers = 0;
                 Exception originalException = null;
                 for (RaftPeer peer : peers) {
-                    RaftClient client = RaftClient.newBuilder().setProperties(properties)
-                        .setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build();
-                    try {
+                    try (RaftClient client = RaftClient.newBuilder().setProperties(properties)
+                        .setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build()) {
                         client.groupAdd(raftGroup, peer.getId());
                     } catch (IOException e) {
                         LOG.error("Failed to add Raft group ({}) for new Log({})",
@@ -343,9 +336,8 @@ public class MetaStateMachine extends BaseStateMachine {
                         if (tornDownPeers >= provisionedPeers) {
                             break;
                         }
-                        RaftClient client = RaftClient.newBuilder().setProperties(properties)
-                            .setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build();
-                        try {
+                        try (RaftClient client = RaftClient.newBuilder().setProperties(properties)
+                            .setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build()) {
                             client.groupRemove(raftGroup.getGroupId(), true, peer.getId());
                         } catch (IOException e) {
                             LOG.error("Failed to clean up Raft group ({}) for peer ({}), "
@@ -358,12 +350,8 @@ public class MetaStateMachine extends BaseStateMachine {
                         MetaServiceProtoUtil.toCreateLogExceptionReplyProto(originalException)
                             .build().toByteString()));
                 }
-                RaftClient client = RaftClient.newBuilder()
-                        .setRaftGroup(currentGroup)
-                        .setClientId(ClientId.randomId())
-                        .setProperties(properties)
-                        .build();
-                try {
+                try (RaftClient client = RaftClient.newBuilder().setRaftGroup(currentGroup)
+                    .setClientId(ClientId.randomId()).setProperties(properties).build()){
                     client.send(() -> MetaServiceProtos.MetaSMRequestProto.newBuilder()
                             .setRegisterRequest(LogServiceRegisterLogRequestProto.newBuilder()
                                     .setLogname(LogServiceProtoUtil.toLogNameProto(name))
@@ -458,9 +446,8 @@ public class MetaStateMachine extends BaseStateMachine {
                                 while(itr.hasNext()) {
                                     LogName logName = itr.next();
                                     RaftGroup group = map.get(logName);
-                                    RaftClient client = RaftClient.newBuilder().
-                                            setRaftGroup(group).setProperties(properties).build();
-                                    try {
+                                    try (RaftClient client = RaftClient.newBuilder()
+                                        .setRaftGroup(group).setProperties(properties).build()) {
                                         LOG.warn(String.format("Peer %s in the group %s went down." +
                                                         " Hence closing the log %s serve by the group.",
                                                 raftPeer.toString(), group.toString(), logName.toString()));
@@ -475,7 +462,6 @@ public class MetaStateMachine extends BaseStateMachine {
                                             throw new IOException(message.getException().getErrorMsg());
                                         }
                                         itr.remove();
-                                        client.close();
                                     } catch (IOException e) {
                                         LOG.warn(String.format("Failed to close log %s on peer %s failure.",
                                                 logName, raftPeer.toString()), e);

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/LogServiceReadWriteBase.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/LogServiceReadWriteBase.java
@@ -125,12 +125,12 @@ public abstract class LogServiceReadWriteBase<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testLogServiceReadWrite() throws Exception {
-    RaftClient raftClient =
-        RaftClient.newBuilder().setProperties(getProperties()).setRaftGroup(cluster.getGroup())
-            .build();
-    LogName logName = LogName.of("log1");
-    // TODO need API to circumvent metadata service for testing
-    try (LogStream logStream = new MetricLogStream(logName, raftClient)) {
+    try (RaftClient raftClient =
+        RaftClient.newBuilder().setProperties(getProperties())
+            .setRaftGroup(cluster.getGroup()).build()) {
+      LogName logName = LogName.of("log1");
+      // TODO need API to circumvent metadata service for testing
+      LogStream logStream = new MetricLogStream(logName, raftClient);
       assertEquals("log1", logStream.getName().getName());
       assertEquals(State.OPEN, logStream.getState());
       assertEquals(0, logStream.getSize());
@@ -181,13 +181,13 @@ public abstract class LogServiceReadWriteBase<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testReadAllRecords() throws Exception {
-    final RaftClient raftClient =
-        RaftClient.newBuilder().setProperties(getProperties()).setRaftGroup(cluster.getGroup())
-            .build();
-    final LogName logName = LogName.of("log1");
-    final int numRecords = 25;
-    // TODO need API to circumvent metadata service for testing
-    try (LogStream logStream = new MetricLogStream(logName, raftClient)) {
+    try (RaftClient raftClient =
+        RaftClient.newBuilder().setProperties(getProperties())
+            .setRaftGroup(cluster.getGroup()).build()) {
+      final LogName logName = LogName.of("log1");
+      final int numRecords = 25;
+      // TODO need API to circumvent metadata service for testing
+      LogStream logStream = new MetricLogStream(logName, raftClient);
       try (LogWriter writer = logStream.createWriter()) {
         LOG.info("Writing {} records", numRecords);
         // Write records 0 through 99 (inclusive)
@@ -222,13 +222,13 @@ public abstract class LogServiceReadWriteBase<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testSeeking() throws Exception {
-    final RaftClient raftClient =
-        RaftClient.newBuilder().setProperties(getProperties()).setRaftGroup(cluster.getGroup())
-            .build();
-    final LogName logName = LogName.of("log1");
-    final int numRecords = 100;
-    // TODO need API to circumvent metadata service for testing
-    try (LogStream logStream = new MetricLogStream(logName, raftClient)) {
+    try (final RaftClient raftClient =
+        RaftClient.newBuilder().setProperties(getProperties())
+            .setRaftGroup(cluster.getGroup()).build()) {
+      final LogName logName = LogName.of("log1");
+      final int numRecords = 100;
+      // TODO need API to circumvent metadata service for testing
+      LogStream logStream = new MetricLogStream(logName, raftClient);
       try (LogWriter writer = logStream.createWriter()) {
         LOG.info("Writing {} records", numRecords);
         // Write records 0 through 99 (inclusive)
@@ -259,12 +259,12 @@ public abstract class LogServiceReadWriteBase<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testSeekFromWrite() throws Exception {
-    final RaftClient raftClient =
-        RaftClient.newBuilder().setProperties(getProperties()).setRaftGroup(cluster.getGroup())
-            .build();
-    final LogName logName = LogName.of("log1");
-    final int numRecords = 10;
-    try (LogStream logStream = new MetricLogStream(logName, raftClient)) {
+    try (final RaftClient raftClient =
+        RaftClient.newBuilder().setProperties(getProperties())
+            .setRaftGroup(cluster.getGroup()).build()) {
+      final LogName logName = LogName.of("log1");
+      final int numRecords = 10;
+      LogStream logStream = new MetricLogStream(logName, raftClient);
       final List<Long> recordIds;
       try (LogWriter writer = logStream.createWriter()) {
         LOG.info("Writing {} records", numRecords);

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
@@ -39,6 +39,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,6 +57,8 @@ import javax.management.ObjectName;
 import static org.junit.Assert.*;
 
 public class TestMetaServer {
+    private static final Logger LOG = LoggerFactory.getLogger(TestMetaServer.class);
+
     static {
         JVMMetrics.initJvmMetrics(TimeDuration.valueOf(10, TimeUnit.SECONDS));
     }
@@ -129,10 +133,12 @@ public class TestMetaServer {
     @Test
     public void testCreateAndGetLog() throws Exception {
         // This should be LogServiceStream ?
-        LogStream logStream1 = client.createLog(LogName.of("testCreateLog"));
-        assertNotNull(logStream1);
-        LogStream logStream2 = client.getLog(LogName.of("testCreateLog"));
-        assertNotNull(logStream2);
+        try (LogStream logStream1 = client.createLog(LogName.of("testCreateLog"))) {
+            assertNotNull(logStream1);
+        }
+        try (LogStream logStream2 = client.getLog(LogName.of("testCreateLog"))) {
+            assertNotNull(logStream2);
+        }
     }
 
     /**
@@ -144,8 +150,9 @@ public class TestMetaServer {
         boolean peerClosed = false;
         try {
             for(int i = 0; i < 5; i++) {
-                LogStream logStream1 = client.createLog(LogName.of("testCloseLogOnNodeFailure"+i));
-                assertNotNull(logStream1);
+                try (LogStream logStream1 = client.createLog(LogName.of("testCloseLogOnNodeFailure"+i))) {
+                    assertNotNull(logStream1);
+                }
             }
             assertTrue(((MetaStateMachine)cluster.getMasters().get(0).getMetaStateMachine()).checkPeersAreSame());
             workers.get(0).close();
@@ -153,9 +160,10 @@ public class TestMetaServer {
             Thread.sleep(90000);
             assertTrue(((MetaStateMachine)cluster.getMasters().get(0).getMetaStateMachine()).checkPeersAreSame());
             for(int i = 0; i < 5; i++) {
-                LogStream logStream2 = client.getLog(LogName.of("testCloseLogOnNodeFailure"+i));
-                assertNotNull(logStream2);
-                assertEquals(State.CLOSED, logStream2.getState());
+                try (LogStream logStream2 = client.getLog(LogName.of("testCloseLogOnNodeFailure"+i))) {
+                    assertNotNull(logStream2);
+                    assertEquals(State.CLOSED, logStream2.getState());
+                }
             }
         } finally {
             if(peerClosed) {
@@ -166,108 +174,111 @@ public class TestMetaServer {
     }
 
     @Test
-    public void testReadWritetoLog() throws IOException, InterruptedException {
-        LogStream stream = client.createLog(LogName.of("testReadWrite"));
-        LogWriter writer = stream.createWriter();
-        ByteBuffer testMessage =  ByteBuffer.wrap("Hello world!".getBytes());
-        List<LogInfo> listLogs = client.listLogs();
-        assert(listLogs.stream().filter(log -> log.getLogName().getName().startsWith("testReadWrite")).count() == 1);
-        List<LogServer> workers = cluster.getWorkers();
-        for(LogServer worker : workers) {
-             RaftServerImpl server = ((RaftServerProxy)worker.getServer())
-                     .getImpl(listLogs.get(0).getRaftGroup().getGroupId());
-        // TODO: perform all additional checks on state machine level
-        }
-        writer.write(testMessage);
-        for(LogServer worker : workers) {
-            RaftServerImpl server = ((RaftServerProxy)worker.getServer())
-                    .getImpl(listLogs.get(0).getRaftGroup().getGroupId());
-        }
+    public void testReadWritetoLog() throws Exception {
+        try (LogStream stream = client.createLog(LogName.of("testReadWrite"))) {
+            LogWriter writer = stream.createWriter();
+            ByteBuffer testMessage = ByteBuffer.wrap("Hello world!".getBytes());
+            List<LogInfo> listLogs = client.listLogs();
+            assert (listLogs.stream().filter(log -> log.getLogName().getName().startsWith("testReadWrite")).count() == 1);
+            List<LogServer> workers = cluster.getWorkers();
+            for (LogServer worker : workers) {
+                RaftServerImpl server = ((RaftServerProxy) worker.getServer())
+                        .getImpl(listLogs.get(0).getRaftGroup().getGroupId());
+                // TODO: perform all additional checks on state machine level
+            }
+            writer.write(testMessage);
+            for (LogServer worker : workers) {
+                RaftServerImpl server = ((RaftServerProxy) worker.getServer())
+                        .getImpl(listLogs.get(0).getRaftGroup().getGroupId());
+            }
 //        assert(stream.getSize() > 0); //TODO: Doesn't work
-        LogReader reader = stream.createReader();
-        ByteBuffer res = reader.readNext();
-        assert(res.array().length > 0);
+            LogReader reader = stream.createReader();
+            ByteBuffer res = reader.readNext();
+            assert (res.array().length > 0);
+        }
     }
 
     @Test
-    public void testLogArchival() throws IOException, InterruptedException {
+    public void testLogArchival() throws Exception {
         LogName logName = LogName.of("testArchivalLog");
-        LogStream logStream = client.createLog(logName);
-        LogWriter writer = logStream.createWriter();
-        List<LogInfo> listLogs = client.listLogs();
-        assert (listLogs.stream()
-            .filter(log -> log.getLogName().getName().startsWith(logName.getName())).count() == 1);
-        List<LogServer> workers = cluster.getWorkers();
-        List<ByteBuffer> records = TestUtils.getRandomData(100, 10);
-        writer.write(records);
-        client.closeLog(logName);
-        assertEquals(logStream.getState(), State.CLOSED);
-        client.archiveLog(logName);
-        int retry = 0;
-        while (logStream.getState() != State.ARCHIVED && retry <= 40) {
-            Thread.sleep(1000);
-            retry++;
-        }
-        assertEquals(logStream.getState(), State.ARCHIVED);
-        LogReader reader = logStream.createReader();
-        List<ByteBuffer> data = reader.readBulk(records.size());
-        assertEquals(records.size(), data.size());
-        reader.seek(1);
-        data = reader.readBulk(records.size());
-        assertEquals(records.size() - 1, data.size());
+        try (LogStream logStream = client.createLog(logName)) {
+            LogWriter writer = logStream.createWriter();
+            List<LogInfo> listLogs = client.listLogs();
+            assert (listLogs.stream()
+                    .filter(log -> log.getLogName().getName().startsWith(logName.getName())).count() == 1);
+            List<LogServer> workers = cluster.getWorkers();
+            List<ByteBuffer> records = TestUtils.getRandomData(100, 10);
+            writer.write(records);
+            client.closeLog(logName);
+            assertEquals(logStream.getState(), State.CLOSED);
+            client.archiveLog(logName);
+            int retry = 0;
+            while (logStream.getState() != State.ARCHIVED && retry <= 40) {
+                Thread.sleep(1000);
+                retry++;
+            }
+            assertEquals(logStream.getState(), State.ARCHIVED);
+            LogReader reader = logStream.createReader();
+            List<ByteBuffer> data = reader.readBulk(records.size());
+            assertEquals(records.size(), data.size());
+            reader.seek(1);
+            data = reader.readBulk(records.size());
+            assertEquals(records.size() - 1, data.size());
 
-        //Test ArchiveLogStream
-        LogServiceConfiguration config = LogServiceConfiguration.create();
-        LogStream archiveLogStream = client.getArchivedLog(logName);
-        reader = archiveLogStream.createReader();
-        data = reader.readBulk(records.size());
-        assertEquals(records.size(), data.size());
+            //Test ArchiveLogStream
+            LogServiceConfiguration config = LogServiceConfiguration.create();
+            LogStream archiveLogStream = client.getArchivedLog(logName);
+            reader = archiveLogStream.createReader();
+            data = reader.readBulk(records.size());
+            assertEquals(records.size(), data.size());
+        }
     }
 
     @Test
-    public void testLogExport() throws IOException, InterruptedException {
+    public void testLogExport() throws Exception {
         LogName logName = LogName.of("testLogExport");
-        LogStream logStream = client.createLog(logName);
-        LogWriter writer = logStream.createWriter();
-        List<LogInfo> listLogs = client.listLogs();
-        assert (listLogs.stream()
-            .filter(log -> log.getLogName().getName().startsWith(logName.getName())).count() == 1);
-        List<LogServer> workers = cluster.getWorkers();
-        List<ByteBuffer> records = TestUtils.getRandomData(100, 10);
-        writer.write(records);
-        String location1 = "target/tmp/export_1/";
-        String location2 = "target/tmp/export_2/";
-        deleteLocalDirectory(new File(location1));
-        deleteLocalDirectory(new File(location2));
-        int startPosition1 = 3;
-        int startPosition2 = 5;
-        client.exportLog(logName, location1, startPosition1);
-        client.exportLog(logName, location2, startPosition2);
-        List<ArchivalInfo> infos=client.getExportStatus(logName);
-        int count=0;
-        while (infos.size() > 1 && (
-            infos.get(0).getStatus() != ArchivalInfo.ArchivalStatus.COMPLETED
-                || infos.get(1).getStatus() != ArchivalInfo.ArchivalStatus.COMPLETED)
-            && count < 10) {
-            infos = client.getExportStatus(logName);
-            ;
-            Thread.sleep(1000);
-            count++;
+        try (LogStream logStream = client.createLog(logName)) {
+            LogWriter writer = logStream.createWriter();
+            List<LogInfo> listLogs = client.listLogs();
+            assert (listLogs.stream()
+                    .filter(log -> log.getLogName().getName().startsWith(logName.getName())).count() == 1);
+            List<LogServer> workers = cluster.getWorkers();
+            List<ByteBuffer> records = TestUtils.getRandomData(100, 10);
+            writer.write(records);
+            String location1 = "target/tmp/export_1/";
+            String location2 = "target/tmp/export_2/";
+            deleteLocalDirectory(new File(location1));
+            deleteLocalDirectory(new File(location2));
+            int startPosition1 = 3;
+            int startPosition2 = 5;
+            client.exportLog(logName, location1, startPosition1);
+            client.exportLog(logName, location2, startPosition2);
+            List<ArchivalInfo> infos = client.getExportStatus(logName);
+            int count = 0;
+            while (infos.size() > 1 && (
+                    infos.get(0).getStatus() != ArchivalInfo.ArchivalStatus.COMPLETED
+                            || infos.get(1).getStatus() != ArchivalInfo.ArchivalStatus.COMPLETED)
+                    && count < 10) {
+                infos = client.getExportStatus(logName);
+                ;
+                Thread.sleep(1000);
+                count++;
 
+            }
+
+            //Test ExportLogStream
+            LogStream exportLogStream = client.getExportLog(logName, location1);
+            LogReader reader = exportLogStream.createReader();
+            List<ByteBuffer> data = reader.readBulk(records.size());
+            assertEquals(records.size() - startPosition1, data.size());
+            reader.close();
+            exportLogStream = client.getExportLog(logName, location2);
+            reader = exportLogStream.createReader();
+            data = reader.readBulk(records.size());
+            assertEquals(records.size() - startPosition2, data.size());
+            reader.close();
+            writer.close();
         }
-
-        //Test ExportLogStream
-        LogStream exportLogStream = client.getExportLog(logName, location1);
-        LogReader reader = exportLogStream.createReader();
-        List<ByteBuffer> data = reader.readBulk(records.size());
-        assertEquals(records.size() - startPosition1, data.size());
-        reader.close();
-        exportLogStream = client.getExportLog(logName, location2);
-        reader = exportLogStream.createReader();
-        data = reader.readBulk(records.size());
-        assertEquals(records.size() - startPosition2, data.size());
-        reader.close();
-        writer.close();
     }
 
     boolean deleteLocalDirectory(File dir) {
@@ -289,31 +300,40 @@ public class TestMetaServer {
     @Test
     public void testDeleteLog() throws Exception {
         // This should be LogServiceStream ?
-        LogStream logStream1 = client.createLog(LogName.of("testDeleteLog"));
-        assertNotNull(logStream1);
-        client.deleteLog(LogName.of("testDeleteLog"));
-        testJMXCount(MetaServiceProtos.MetaServiceRequestProto.TypeCase.DELETELOG.name(),
-            (long) deleteCount.get());
-        try {
-          logStream1 = client.getLog(LogName.of("testDeleteLog"));
-            fail("Failed to throw LogNotFoundException");
-        } catch(Exception e) {
-            assert(e instanceof LogNotFoundException);
+        try (LogStream logStream1 = client.createLog(LogName.of("testDeleteLog"))) {
+            assertNotNull(logStream1);
+            client.deleteLog(LogName.of("testDeleteLog"));
+            testJMXCount(MetaServiceProtos.MetaServiceRequestProto.TypeCase.DELETELOG.name(),
+                    (long) deleteCount.get());
+            LogStream logStream2 = null;
+            try {
+                logStream2 = client.getLog(LogName.of("testDeleteLog"));
+                fail("Failed to throw LogNotFoundException");
+            } catch (Exception e) {
+                assert (e instanceof LogNotFoundException);
+            } finally {
+                if (logStream2 != null) {
+                    logStream2.close();
+                }
+            }
         }
-
-
     }
     /**
      * Test for getting not existing log. Should throw an exception
      * @throws IOException
      */
     @Test
-    public void testGetNotExistingLog() {
+    public void testGetNotExistingLog() throws Exception {
+        LogStream logStream = null;
         try {
-            LogStream log = client.getLog(LogName.of("no_such_log"));
+            logStream = client.getLog(LogName.of("no_such_log"));
             fail("LogNotFoundException was not thrown");
         } catch (IOException e) {
             assert(e instanceof LogNotFoundException);
+        } finally {
+            if (logStream != null) {
+               logStream.close();
+            }
         }
     }
 
@@ -323,13 +343,30 @@ public class TestMetaServer {
      */
     @Test
     public void testAlreadyExistLog() throws Exception {
-        LogStream logStream1 = client.createLog(LogName.of("test1"));
-        assertNotNull(logStream1);
+        try (LogStream logStream1 = client.createLog(LogName.of("test1"))) {
+            assertNotNull(logStream1);
+            LogStream logStream2 = null;
+            try {
+                logStream2 = client.createLog(LogName.of("test1"));
+                fail("Didn't fail with LogAlreadyExistException");
+            } catch (IOException e) {
+                assert (e instanceof LogAlreadyExistException);
+            } finally {
+                if (logStream2 != null) {
+                    logStream2.close();
+                }
+            }
+        }
+    }
+
+    private void createLogAndClose(String name) throws Exception {
+        LogStream logStream = null;
         try {
-            logStream1 = client.createLog(LogName.of("test1"));
-            fail("Didn't fail with LogAlreadyExistException");
-        } catch (IOException e) {
-            assert(e instanceof LogAlreadyExistException);
+            logStream = client.createLog(LogName.of(name));
+        } finally {
+            if (logStream != null) {
+                logStream.close();
+            }
         }
     }
 
@@ -339,13 +376,13 @@ public class TestMetaServer {
      */
     @Test
     public void testListLogs() throws Exception {
-        client.createLog(LogName.of("listLogTest1"));
-        client.createLog(LogName.of("listLogTest2"));
-        client.createLog(LogName.of("listLogTest3"));
-        client.createLog(LogName.of("listLogTest4"));
-        client.createLog(LogName.of("listLogTest5"));
-        client.createLog(LogName.of("listLogTest6"));
-        client.createLog(LogName.of("listLogTest7"));
+        createLogAndClose("listLogTest1");
+        createLogAndClose("listLogTest2");
+        createLogAndClose("listLogTest3");
+        createLogAndClose("listLogTest4");
+        createLogAndClose("listLogTest5");
+        createLogAndClose("listLogTest6");
+        createLogAndClose("listLogTest7");
         // Test jmx
 
         List<LogInfo> list = client.listLogs();
@@ -380,10 +417,19 @@ public class TestMetaServer {
     @Test
     public void testFinalClieanUp() throws Exception {
         IntStream.range(0, 10).forEach(i -> {
+            LogStream logStream = null;
             try {
-                client.createLog(LogName.of("CleanTest" + i));
+                logStream = client.createLog(LogName.of("CleanTest" + i));
             } catch (IOException e) {
                 throw new RuntimeException(e);
+            } finally {
+                if (logStream != null) {
+                    try {
+                        logStream.close();
+                    } catch (Exception ignored) {
+                        LOG.warn(ignored.getClass().getSimpleName() + " is ignored", ignored);
+                    }
+                }
             }
         });
         List<LogInfo> list = client.listLogs();

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -85,9 +85,10 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     // Add groups
     final RaftGroup newGroup = RaftGroup.valueOf(RaftGroupId.randomId(), cluster.getPeers());
     LOG.info("add new group: " + newGroup);
-    final RaftClient client = cluster.createClient(newGroup);
-    for(RaftPeer p : newGroup.getPeers()) {
-      client.groupAdd(newGroup, p.getId());
+    try (final RaftClient client = cluster.createClient(newGroup)) {
+      for (RaftPeer p : newGroup.getPeers()) {
+        client.groupAdd(newGroup, p.getId());
+      }
     }
     Assert.assertNotNull(RaftTestUtil.waitForLeader(cluster));
     TimeUnit.SECONDS.sleep(1);
@@ -241,16 +242,17 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     final RaftPeer peer = cluster.getPeers().get(0);
     final RaftPeerId peerId = peer.getId();
     final RaftGroup group = RaftGroup.valueOf(cluster.getGroupId(), peer);
-    final RaftClient client = cluster.createClient();
-    Assert.assertEquals(group, cluster.getRaftServerImpl(peerId).getGroup());
-    try {
-      client.groupAdd(group, peer.getId());
-    } catch (IOException ex) {
-      // HadoopRPC throws RemoteException, which makes it hard to check if
-      // the exception is instance of AlreadyExistsException
-      Assert.assertTrue(ex.toString().contains(AlreadyExistsException.class.getCanonicalName()));
+    try (final RaftClient client = cluster.createClient()) {
+      Assert.assertEquals(group, cluster.getRaftServerImpl(peerId).getGroup());
+      try {
+        client.groupAdd(group, peer.getId());
+      } catch (IOException ex) {
+        // HadoopRPC throws RemoteException, which makes it hard to check if
+        // the exception is instance of AlreadyExistsException
+        Assert.assertTrue(ex.toString().contains(AlreadyExistsException.class.getCanonicalName()));
+      }
+      Assert.assertEquals(group, cluster.getRaftServerImpl(peerId).getGroup());
+      cluster.shutdown();
     }
-    Assert.assertEquals(group, cluster.getRaftServerImpl(peerId).getGroup());
-    cluster.shutdown();
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/retry/TestExceptionDependentRetry.java
+++ b/ratis-test/src/test/java/org/apache/ratis/retry/TestExceptionDependentRetry.java
@@ -184,13 +184,14 @@ public class TestExceptionDependentRetry implements MiniRaftClusterWithGrpc.Fact
       builder.setDefaultPolicy(RetryPolicies.retryForeverNoSleep());
 
       // create a client with the exception dependent policy
-      RaftClient client = cluster.createClient(builder.build());
-      client.sendAsync(new RaftTestUtil.SimpleMessage("1")).get();
+      try (final RaftClient client = cluster.createClient(builder.build())) {
+        client.sendAsync(new RaftTestUtil.SimpleMessage("1")).get();
 
-      leader = cluster.getLeader();
-      ((SimpleStateMachine4Testing)leader.getStateMachine()).blockWriteStateMachineData();
+        leader = cluster.getLeader();
+        ((SimpleStateMachine4Testing) leader.getStateMachine()).blockWriteStateMachineData();
 
-      client.sendAsync(new RaftTestUtil.SimpleMessage("2")).get();
+        client.sendAsync(new RaftTestUtil.SimpleMessage("2")).get();
+      }
       Assert.fail("Test should have failed.");
     } catch (ExecutionException e) {
       RaftRetryFailureException rrfe = (RaftRetryFailureException) e.getCause();

--- a/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
@@ -237,16 +237,14 @@ public abstract class ServerRestartTests<CLUSTER extends MiniRaftCluster>
       futures.add(f);
 
       final SimpleMessage m = messages[i];
-      try (final RaftClient client = cluster.createClient()) {
-        new Thread(() -> {
-          try {
-            Assert.assertTrue(client.send(m).isSuccess());
-          } catch (IOException e) {
-            throw new IllegalStateException("Failed to send " + m, e);
-          }
-          f.complete(null);
-        }).start();
-      }
+      new Thread(() -> {
+        try (final RaftClient client = cluster.createClient()) {
+          Assert.assertTrue(client.send(m).isSuccess());
+        } catch (IOException e) {
+          throw new IllegalStateException("Failed to send " + m, e);
+        }
+        f.complete(null);
+      }).start();
     }
     JavaUtils.allOf(futures).get();
 

--- a/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
+++ b/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
@@ -185,9 +185,10 @@ public class TestStateMachine extends BaseTest implements MiniRaftClusterWithSim
       for(RaftGroupId gid : registry.keySet()) {
         final RaftGroup newGroup = RaftGroup.valueOf(gid, cluster.getPeers());
         LOG.info("add new group: " + newGroup);
-        final RaftClient client = cluster.createClient(newGroup);
-        for(RaftPeer p : newGroup.getPeers()) {
-          client.groupAdd(newGroup, p.getId());
+        try (final RaftClient client = cluster.createClient(newGroup)) {
+          for (RaftPeer p : newGroup.getPeers()) {
+            client.groupAdd(newGroup, p.getId());
+          }
         }
       }
 


### PR DESCRIPTION
**What's the problem ?**
Thousands of gRPC clients were not closed after use, in test and src. It will cause resource leak, and the unit test become very flaky. 

![](https://issues.apache.org/jira/secure/attachment/13002064/13002064_screenshot-1.png)

I think the following error is also caused by this problem.
![image](https://user-images.githubusercontent.com/51938049/83519225-2c534000-a50e-11ea-9405-e9f4c62bca30.png)


**How to fix ?**
This patch do the following:
1. add `GrpcUtil.shutdownManagedChannel` method to ensure the ManagedChannel was closed.
2. change `RaftClient client = ...` to `try (RaftClient client = ...)`, so that client can be closed.
3. change `LogStream logStream1 = client.createLog...` to` try (LogStream logStream1 = client.createLog...)`, so that the client in `LogStreamImpl` can be closed.
4. close the filed client which forgot to be closed in close method. Such as `metaClient` in `LogServer`

