### PR TITLE
RATIS-937. Loading of open segments always throws corrupted segment warning

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -44,6 +44,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import static org.apache.ratis.server.raftlog.RaftLog.INVALID_LOG_INDEX;
+
 /**
  * In-memory cache for a log segment file. All the updates will be first written
  * into LogSegment then into corresponding files in the same order.
@@ -145,6 +147,10 @@ public class LogSegment implements Comparable<Long> {
     });
     LOG.info("Successfully read {} entries from segment file {}", entryCount, file);
 
+    if (isOpen && end == INVALID_LOG_INDEX) {
+      end = segment.getEndIndex();
+    }
+
     final int expectedEntryCount = Math.toIntExact(end - start + 1);
     final boolean corrupted = entryCount != expectedEntryCount;
     if (corrupted) {
@@ -181,7 +187,7 @@ public class LogSegment implements Comparable<Long> {
       Preconditions.assertSame(expectedLastIndex, last.getTermIndex().getIndex(), "Index at the last record");
       Preconditions.assertSame(expectedStart, records.get(0).getTermIndex().getIndex(), "Index at the first record");
     }
-    if (!isOpen && !corrupted) {
+    if (!corrupted) {
       Preconditions.assertSame(expectedEnd, expectedLastIndex, "End/last Index");
     }
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -147,7 +147,7 @@ public class LogSegment implements Comparable<Long> {
     });
     LOG.info("Successfully read {} entries from segment file {}", entryCount, file);
 
-    if (isOpen && end == INVALID_LOG_INDEX) {
+    if (isOpen) {
       end = segment.getEndIndex();
     }
 


### PR DESCRIPTION
When an open log segment is loaded, it always logs a warning that the segment is corrupted.

```
Segment file is corrupted: expected to have -43 entries but only 8 entries read successfully
```
LogSegment#loadSegment() has the following check for corruption:
```
final int expectedEntryCount = Math.toIntExact(end - start + 1);
final boolean corrupted = entryCount != expectedEntryCount;
if (corrupted) {
  LOG.warn("Segment file is corrupted: expected to have {} entries but only {} entries read successfully",
      expectedEntryCount, entryCount);
}
```
But the end is always INVALID_LOG_INDEX (-1) for an open segment.
Before this check, entries are appended to the segment. So the end variable should be updated with the correct endIndex of the segment before checking for corruption.