### PR TITLE
RATIS-939. Fix Failed UT: testRaftServerMetrics

### DIFF
--- a/ratis-metrics/src/main/java/org/apache/ratis/metrics/RatisMetricRegistry.java
+++ b/ratis-metrics/src/main/java/org/apache/ratis/metrics/RatisMetricRegistry.java
@@ -37,6 +37,8 @@ public interface RatisMetricRegistry {
 
   Counter counter(String name);
 
+  boolean remove(String name);
+
   Gauge gauge(String name, MetricRegistry.MetricSupplier<Gauge> supplier);
 
   Timer timer(String name, MetricRegistry.MetricSupplier<Timer> supplier);

--- a/ratis-metrics/src/main/java/org/apache/ratis/metrics/impl/RatisMetricRegistryImpl.java
+++ b/ratis-metrics/src/main/java/org/apache/ratis/metrics/impl/RatisMetricRegistryImpl.java
@@ -62,6 +62,11 @@ public class RatisMetricRegistryImpl implements RatisMetricRegistry {
     return metricRegistry.counter(getMetricName(name));
   }
 
+  @Override
+  public boolean remove(String name) {
+    return metricRegistry.remove(getMetricName(name));
+  }
+
   @Override public Gauge gauge(String name, MetricSupplier<Gauge> supplier) {
     return metricRegistry.gauge(getMetricName(name), supplier);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
@@ -277,6 +277,9 @@ public class LeaderState {
     server.getServerRpc().notifyNotLeader(server.getMemberId().getGroupId());
     logAppenderMetrics.unregister();
     raftServerMetrics.unregister();
+    if (pendingRequests != null) {
+      pendingRequests.close();
+    }
   }
 
   void notifySenders() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java
@@ -87,10 +87,7 @@ class PendingRequests {
       this.resource = new RequestLimits(elementLimit, byteLimit);
       this.raftServerMetrics = raftServerMetrics;
 
-      raftServerMetrics.removeNumPendingRequestsGauge();
       raftServerMetrics.addNumPendingRequestsGauge(resource::getElementCount);
-
-      raftServerMetrics.removeNumPendingRequestsByteSize();
       raftServerMetrics.addNumPendingRequestsByteSize(resource::getByteSize);
     }
 
@@ -166,6 +163,13 @@ class PendingRequests {
         if (pending != null) {
           transactions.add(pending.setNotLeaderException(nle, commitInfos));
         }
+      }
+    }
+
+    void close() {
+      if (raftServerMetrics != null) {
+        raftServerMetrics.removeNumPendingRequestsGauge();
+        raftServerMetrics.removeNumPendingRequestsByteSize();
       }
     }
   }
@@ -249,5 +253,11 @@ class PendingRequests {
       pendingSetConf.setNotLeaderException(nle, commitInfos);
     }
     return transactions;
+  }
+
+  void close() {
+    if (pendingRequests != null) {
+      pendingRequests.close();
+    }
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java
@@ -87,7 +87,10 @@ class PendingRequests {
       this.resource = new RequestLimits(elementLimit, byteLimit);
       this.raftServerMetrics = raftServerMetrics;
 
+      raftServerMetrics.removeNumPendingRequestsGauge();
       raftServerMetrics.addNumPendingRequestsGauge(resource::getElementCount);
+
+      raftServerMetrics.removeNumPendingRequestsByteSize();
       raftServerMetrics.addNumPendingRequestsByteSize(resource::getByteSize);
     }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerMetrics.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerMetrics.java
@@ -210,8 +210,16 @@ public final class RaftServerMetrics extends RatisMetrics {
     registry.gauge(REQUEST_QUEUE_SIZE, () -> queueSize);
   }
 
+  boolean removeNumPendingRequestsGauge() {
+    return registry.remove(REQUEST_QUEUE_SIZE);
+  }
+
   void addNumPendingRequestsByteSize(Gauge byteSize) {
     registry.gauge(REQUEST_BYTE_SIZE, () -> byteSize);
+  }
+
+  boolean removeNumPendingRequestsByteSize() {
+    return registry.remove(REQUEST_BYTE_SIZE);
   }
 
   void onRequestByteSizeLimitHit() {


### PR DESCRIPTION
**What's the problem  ?**

![](https://issues.apache.org/jira/secure/attachment/13003174/13003174_screenshot-1.png)

**What's the reason ?**
One server was elected as leader twice. Every time leader will try to [addNumPendingRequestsByteSize {registry.gauge(REQUEST_BYTE_SIZE, () -> byteSize) } ](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java#L91) with a new `RequestLimits`. 
But in the second time, it can not re-guage again, because the `gauge` in metrics was implemented by `getOrAdd` as the following code shows. So it will first check whether `REQUEST_BYTE_SIZE` exist, if exist, it will not `gauge` `REQUEST_BYTE_SIZE`  again. So the `byteSize` is the old RequestLimits's,  and can not update when `addPendingRequest`, so assert failed.
```
    public Gauge gauge(String name, final MetricSupplier<Gauge> supplier) {
        return getOrAdd(name, new MetricBuilder<Gauge>() {
            @Override
            public Gauge newMetric() {
                return supplier.newMetric();
            }
            @Override
            public boolean isInstance(Metric metric) {
                return Gauge.class.isInstance(metric);
            }
        });
    }
```