### PR TITLE
RATIS-942. Fix can not create raftLogMetrics in multi-raft

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -208,7 +208,7 @@ public class SegmentedRaftLog extends RaftLog {
     this.storage = storage;
     this.stateMachine = stateMachine;
     segmentMaxSize = RaftServerConfigKeys.Log.segmentSizeMax(properties).getSize();
-    this.raftLogMetrics = new RaftLogMetrics(memberId.getPeerId().toString());
+    this.raftLogMetrics = new RaftLogMetrics(memberId.toString());
     this.cache = new SegmentedRaftLogCache(memberId, storage, properties, raftLogMetrics);
     this.fileLogWorker = new SegmentedRaftLogWorker(memberId, stateMachine,
         submitUpdateCommitEvent, server, storage, properties, raftLogMetrics);

--- a/ratis-server/src/test/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogTestUtils.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogTestUtils.java
@@ -26,7 +26,7 @@ public interface SegmentedRaftLogTestUtils {
     Log4jUtils.setLogLevel(SegmentedRaftLogWorker.LOG, level);
   }
 
-  static String getLogFlushTimeMetric(RaftPeerId serverId) {
-    return SegmentedRaftLogWorker.class.getName() + "." + serverId + ".flush-time";
+  static String getLogFlushTimeMetric(String memberId) {
+    return SegmentedRaftLogWorker.class.getName() + "." + memberId + ".flush-time";
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/storage/RaftStorageTestUtils.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/storage/RaftStorageTestUtils.java
@@ -32,13 +32,13 @@ import java.util.function.Consumer;
 
 public interface RaftStorageTestUtils {
 
-  static String getLogFlushTimeMetric(RaftPeerId serverId) {
-    return getRaftLogFullMetric(serverId, RAFT_LOG_FLUSH_TIME);
+  static String getLogFlushTimeMetric(String memberId) {
+    return getRaftLogFullMetric(memberId, RAFT_LOG_FLUSH_TIME);
   }
 
-  static String getRaftLogFullMetric(RaftPeerId serverId, String metricName) {
+  static String getRaftLogFullMetric(String memberId, String metricName) {
     return RatisMetrics.RATIS_APPLICATION_NAME_METRICS + "." + RATIS_LOG_WORKER_METRICS
-        + "." + serverId + "." + metricName;
+        + "." + memberId + "." + metricName;
   }
 
   static void printLog(RaftLog log, Consumer<String> println) {

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/TestRaftLogMetrics.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/TestRaftLogMetrics.java
@@ -119,8 +119,8 @@ public class TestRaftLogMetrics extends BaseTest
   }
 
   static void assertFlushCount(RaftServerImpl server) throws Exception {
-    final String flushTimeMetric = RaftStorageTestUtils.getLogFlushTimeMetric(server.getId());
-    RatisMetricRegistry ratisMetricRegistry = new RaftLogMetrics((server.getId().toString())).getRegistry();
+    final String flushTimeMetric = RaftStorageTestUtils.getLogFlushTimeMetric(server.getMemberId().toString());
+    RatisMetricRegistry ratisMetricRegistry = new RaftLogMetrics(server.getMemberId().toString()).getRegistry();
     Timer tm = (Timer) ratisMetricRegistry.get(RAFT_LOG_FLUSH_TIME);
     Assert.assertNotNull(tm);
 
@@ -142,8 +142,8 @@ public class TestRaftLogMetrics extends BaseTest
   }
 
   static void assertRaftLogWritePathMetrics(RaftServerImpl server) throws Exception {
-    final String syncTimeMetric = RaftStorageTestUtils.getRaftLogFullMetric(server.getId(), RAFT_LOG_SYNC_TIME);
-    RatisMetricRegistry ratisMetricRegistry = new RaftLogMetrics((server.getId().toString())).getRegistry();
+    final String syncTimeMetric = RaftStorageTestUtils.getRaftLogFullMetric(server.getMemberId().toString(), RAFT_LOG_SYNC_TIME);
+    RatisMetricRegistry ratisMetricRegistry = new RaftLogMetrics(server.getMemberId().toString()).getRegistry();
 
     //Test sync count
     Timer tm = (Timer) ratisMetricRegistry.get(RAFT_LOG_SYNC_TIME);

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -199,7 +199,7 @@ public class TestSegmentedRaftLog extends BaseTest {
       Assert.assertArrayEquals(entries, entriesFromLog);
       Assert.assertEquals(entries[entries.length - 1], getLastEntry(raftLog));
 
-      RatisMetricRegistry metricRegistryForLogWorker = new RaftLogMetrics((memberId.getPeerId().toString())).getRegistry();
+      RatisMetricRegistry metricRegistryForLogWorker = new RaftLogMetrics(memberId.toString()).getRegistry();
 
       Timer raftLogSegmentLoadLatencyTimer = metricRegistryForLogWorker.timer("segmentLoadLatency");
       Assert.assertTrue(raftLogSegmentLoadLatencyTimer.getMeanRate() > 0);
@@ -409,7 +409,7 @@ public class TestSegmentedRaftLog extends BaseTest {
     int segmentSize = 200;
     long endIndexOfClosedSegment = segmentSize * (endTerm - startTerm - 1) - 1;
     long expectedIndex = segmentSize * (endTerm - startTerm - 2);
-    RatisMetricRegistry metricRegistryForLogWorker = new RaftLogMetrics((memberId.getPeerId().toString())).getRegistry();
+    RatisMetricRegistry metricRegistryForLogWorker = new RaftLogMetrics(memberId.toString()).getRegistry();
     purgeAndVerify(startTerm, endTerm, segmentSize, 1, endIndexOfClosedSegment, expectedIndex);
     Assert.assertTrue(metricRegistryForLogWorker.timer("purgeLog").getCount() > 0);
   }


### PR DESCRIPTION
**What's the problem ?**
when create `RaftLogMetrics`, it use `memberId.getPeerId()` to identify, the `peerId` comes from `RaftServerProxy::getId`. So if one Ratis node belongs to different group, the `peerId` is same for different `RaftLogMetrics`. When create the second `RaftLogMetrics` for the second group, it will not create, because it's been created by the first group.

**How to fix ?**
`memberId.toString()` will return `peerId + "@" + groupId`.

