### PR TITLE
RATIS-867. Fix failed UT: TestMetaServer#testListLogs

### DIFF
--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogServiceClient.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogServiceClient.java
@@ -57,17 +57,26 @@ public class LogServiceClient implements AutoCloseable {
      * @param metaQuorum
      */
     public LogServiceClient(String metaQuorum) {
-        this(metaQuorum, LogServiceConfiguration.create());
+        this(metaQuorum, LogServiceConfiguration.create(), new RaftProperties());
+    }
+
+    /**
+     * Constuctor. Build raft client for meta quorum
+     * @param metaQuorum
+     * @param properties
+     */
+    public LogServiceClient(String metaQuorum, RaftProperties properties) {
+        this(metaQuorum, LogServiceConfiguration.create(), properties);
     }
 
     /**
      * Constuctor (with configuration). Build raft client for meta quorum
      * @param metaQuorum
      * @param config log serice configuration
+     * @param properties
      */
-    public LogServiceClient(String metaQuorum, LogServiceConfiguration config) {
+    public LogServiceClient(String metaQuorum, LogServiceConfiguration config, RaftProperties properties) {
         Set<RaftPeer> peers = getPeersFromQuorum(metaQuorum);
-        RaftProperties properties = new RaftProperties();
         RaftGroup meta = RaftGroup.valueOf(Constants.META_GROUP_ID, peers);
         client = RaftClient.newBuilder()
                 .setRaftGroup(meta)

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java
@@ -57,6 +57,7 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.statemachine.TransactionContext;
 import org.apache.ratis.statemachine.impl.BaseStateMachine;
+import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.util.AutoCloseableLock;
 import org.apache.ratis.util.Daemon;
@@ -118,6 +119,11 @@ public class MetaStateMachine extends BaseStateMachine {
         super.initialize(server, groupId, storage);
         peerHealthChecker = new Daemon(new PeerHealthChecker(),"peer-Health-Checker");
         peerHealthChecker.start();
+    }
+
+    @VisibleForTesting
+    public void setProperties(RaftProperties properties) {
+      this.properties = properties;
     }
 
     @Override

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
@@ -81,17 +81,20 @@ public class TestMetaServer {
             ((MetaStateMachine)master.getMetaStateMachine()).setProperties(properties));
 
         client = new LogServiceClient(cluster.getMetaIdentity(), properties) {
-          @Override public LogStream createLog(LogName logName) throws IOException {
+          @Override
+          public LogStream createLog(LogName logName) throws IOException {
             createCount.incrementAndGet();
             return super.createLog(logName);
           }
 
-          @Override public void deleteLog(LogName logName) throws IOException {
+          @Override
+          public void deleteLog(LogName logName) throws IOException {
             deleteCount.incrementAndGet();
             super.deleteLog(logName);
           }
 
-          @Override public List<LogInfo> listLogs() throws IOException {
+          @Override
+          public List<LogInfo> listLogs() throws IOException {
             listCount.incrementAndGet();
             return super.listLogs();
           }

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
@@ -18,6 +18,8 @@
 
 package org.apache.ratis.logservice.server;
 
+import org.apache.ratis.client.RaftClientConfigKeys;
+import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.logservice.api.*;
 import org.apache.ratis.logservice.api.LogStream.State;
 import org.apache.ratis.logservice.api.LogServiceClient;
@@ -62,35 +64,51 @@ public class TestMetaServer {
     static AtomicInteger createCount = new AtomicInteger();
     static AtomicInteger deleteCount = new AtomicInteger();
     static AtomicInteger listCount = new AtomicInteger();
-    LogServiceClient client = new LogServiceClient(cluster.getMetaIdentity()){
-        @Override public LogStream createLog(LogName logName) throws IOException {
-            createCount.incrementAndGet();
-            return super.createLog(logName);
-        }
+    static LogServiceClient client = null;
 
-        @Override public void deleteLog(LogName logName) throws IOException {
-            deleteCount.incrementAndGet();
-            super.deleteLog(logName);
-        }
-
-        @Override public List<LogInfo> listLogs() throws IOException {
-            listCount.incrementAndGet();
-            return super.listLogs();
-        }
-
-    };
     @BeforeClass
     public static void beforeClass() {
         cluster = new LogServiceCluster(3);
         cluster.createWorkers(3);
         workers = cluster.getWorkers();
         assert(workers.size() == 3);
+
+        RaftProperties properties = new RaftProperties();
+        RaftClientConfigKeys.Rpc.setRequestTimeout(properties, TimeDuration.valueOf(15, TimeUnit.SECONDS));
+
+
+        cluster.getMasters().parallelStream().forEach(master ->
+            ((MetaStateMachine)master.getMetaStateMachine()).setProperties(properties));
+
+        client = new LogServiceClient(cluster.getMetaIdentity(), properties) {
+          @Override public LogStream createLog(LogName logName) throws IOException {
+            createCount.incrementAndGet();
+            return super.createLog(logName);
+          }
+
+          @Override public void deleteLog(LogName logName) throws IOException {
+            deleteCount.incrementAndGet();
+            super.deleteLog(logName);
+          }
+
+          @Override public List<LogInfo> listLogs() throws IOException {
+            listCount.incrementAndGet();
+            return super.listLogs();
+          }
+        };
     }
 
     @AfterClass
     public static void afterClass() {
         if (cluster != null) {
           cluster.close();
+        }
+
+        if (client != null) {
+          try {
+            client.close();
+          } catch (Exception ignored) {
+          }
         }
     }
 

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
@@ -76,7 +76,6 @@ public class TestMetaServer {
         RaftProperties properties = new RaftProperties();
         RaftClientConfigKeys.Rpc.setRequestTimeout(properties, TimeDuration.valueOf(15, TimeUnit.SECONDS));
 
-
         cluster.getMasters().parallelStream().forEach(master ->
             ((MetaStateMachine)master.getMetaStateMachine()).setProperties(properties));
 


### PR DESCRIPTION
**What's the problem ?**

```
ava.lang.AssertionError: expected:<19> but was:<20>
	at org.apache.ratis.logservice.server.TestMetaServer.testJMXCount(TestMetaServer.java:339)
	at org.apache.ratis.logservice.server.TestMetaServer.testListLogs(TestMetaServer.java:331)
```


**What's the reason ?**
1. when create log, it will call [RaftClientImpl::sendRequestWithRetry](https://github.com/apache/incubator-ratis/blob/master/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java#L285), if throw TimeoutIOException, it will retry at [final RaftClientReply reply = sendRequest(request)](https://github.com/apache/incubator-ratis/blob/master/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java#L296), So JMXCount will increase many times at [timerContext = metricRegistry.timer(type.name()).time()](https://github.com/apache/incubator-ratis/blob/master/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java#L224) when retry happens.  Then JMXCount i.e. 20 not equal to createCount i.e. 19

2. The TimeoutIOException is as follows:
`org.apache.ratis.protocol.TimeoutIOException: deadline exceeded after 2.999977899s. [buffered_nanos=1460409, remote_addr=localhost/127.0.0.1:9001]`

3.  The reason of TimeoutIOException is when create log, it will call [client.groupAdd](https://github.com/apache/incubator-ratis/blob/master/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java#L325). When add a new group, the following code [file.write(jvmName.getBytes(StandardCharsets.UTF_8))](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageDirectory.java#L342) and [((FileOutputStream)out).getChannel().force(true)](https://github.com/apache/incubator-ratis/blob/master/ratis-common/src/main/java/org/apache/ratis/util/AtomicFileOutputStream.java#L65) will both force sync data to disk. The force sync to disk sometimes cost more than 2 seconds, but the timeout threshold of groupAdd is 3 seconds, so TimeoutIOException happens.

**How to fix ?**
Increase the timeout threshold from 3 seconds to 15 seconds.