### PR TITLE
RATIS-940. Add sonar check for ratis

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -49,6 +49,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - run: ./dev-support/checks/sonar.sh
+          env:
+            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - run: ./dev-support/checks/unit.sh
         - uses: actions/upload-artifact@master
           if: always()

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$DIR/../.." || exit 1
+
+if [ ! "$SONAR_TOKEN" ]; then
+  echo "SONAR_TOKEN environment variable should be set"
+  exit 1
+fi
+mvn -B verify -DskipShade -DskipTests -Dskip.yarn org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-ratis

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -20,4 +20,4 @@ if [ ! "$SONAR_TOKEN" ]; then
   echo "SONAR_TOKEN environment variable should be set"
   exit 1
 fi
-mvn -B verify -DskipShade -DskipTests -Dskip.yarn org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-ratis
+mvn -B verify -DskipTests -Dskip.yarn org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-ratis

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -20,4 +20,4 @@ if [ ! "$SONAR_TOKEN" ]; then
   echo "SONAR_TOKEN environment variable should be set"
   exit 1
 fi
-mvn -B verify -DskipTests -Dskip.yarn org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-ratis
+mvn -B verify -DskipShade -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-ratis


### PR DESCRIPTION
Ratis instance has been created in ASF's Sonar Cloud. This can now be used to analyze and improve the code quality. To ensure the analysis is automatically executed whenever there is a commit in master branch, we need to add a github action for Sonar check.
This PR aims to do that.

https://issues.apache.org/jira/browse/RATIS-940

For testing, I was able to add a token in my fork on incubator-ratis and confirm the script triggers analysis. For the incubator-ratis repo, ASF INFRA team helped to add the sonar cloud token in the repo settings via https://issues.apache.org/jira/browse/INFRA-20295
Once this PR is merged, I can confirm that the sonar check got enabled correctly.