### PR TITLE
RATIS-943. Remove unused import in LogSegment

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -44,7 +44,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static org.apache.ratis.server.raftlog.RaftLog.INVALID_LOG_INDEX;
 
 /**
  * In-memory cache for a log segment file. All the updates will be first written


### PR DESCRIPTION
Fixed checkstyle violation - unused import in LogSegment

Spotted in https://github.com/apache/incubator-ratis/pull/108