### PR TITLE
RATIS-900. Fix Failed UT: RaftExceptionBaseTest.testHandleNotLeaderAndIOException

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
@@ -55,29 +55,16 @@ public abstract class RaftExceptionBaseTest<CLUSTER extends MiniRaftCluster>
 
   @Test
   public void testHandleNotLeaderException() throws Exception {
-    runWithNewCluster(NUM_PEERS, cluster -> runTestHandleNotLeaderException(false, cluster));
+    runWithNewCluster(NUM_PEERS, cluster -> runTestHandleNotLeaderException(cluster));
   }
 
-  /**
-   * Test handle both IOException and NotLeaderException
-   */
-  @Test
-  public void testHandleNotLeaderAndIOException() throws Exception {
-    runWithNewCluster(NUM_PEERS, cluster -> runTestHandleNotLeaderException(true, cluster));
-  }
-
-  void runTestHandleNotLeaderException(boolean killNewLeader, CLUSTER cluster) throws Exception {
+  void runTestHandleNotLeaderException(CLUSTER cluster) throws Exception {
     final RaftPeerId oldLeader = RaftTestUtil.waitForLeader(cluster).getId();
     try(final RaftClient client = cluster.createClient(oldLeader)) {
       sendMessage("m1", client);
 
       // enforce leader change
       final RaftPeerId newLeader = RaftTestUtil.changeLeader(cluster, oldLeader);
-
-      if (killNewLeader) {
-        // kill the new leader
-        cluster.killServer(newLeader);
-      }
 
       final RaftClientRpc rpc = client.getClientRpc();
       JavaUtils.attemptRepeatedly(() -> assertNotLeaderException(newLeader, "m2", oldLeader, rpc, cluster),


### PR DESCRIPTION
**What's the problem ?**
![image](https://user-images.githubusercontent.com/51938049/82792136-7e0e2180-9ea1-11ea-9ccb-1dba33c367eb.png)


**What's the reason ?**
In the test, the cluster first select an oldLeader such as s1, then force change to newLeader such as s2, and kill s2. Then client connect to s1 and expect s1 reply the info of real leader i.e. s2 in the NotLeaderException. But the s2 has been killed, ratis will triger a leader election, leader will change from s2 to s0, then s0 was included in the NotLeaderException rather than s2. so the test failed.

**How to fix ?**
I think this UT is outdated. We can not expect the leader will not change if we kill the leader.