### PR TITLE
RATIS-948. Update Sonar statistics only from the Apache repo, not from the forks

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -50,6 +50,7 @@ jobs:
     steps:
         - uses: actions/checkout@master
         - run: ./dev-support/checks/sonar.sh
+          if: github.repository == 'apache/incubator-ratis'
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?



RATIS-940 enabled the Sonar check for all the commits but it doesn't work for forked repositories (unless somebody set an own SONAR_TOKEN).

The fix is the same as HDDS-2627, we can restrict the execution to the Apache repository.

Thanks to Lokesh Jain who reported this issue:

Example failure:

https://github.com/lokeshj1703/incubator-ratis/runs/716253801

Note: PRs are not affected as they work well (no sonar check there) only the builds of forked repos.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-948

## How was this patch tested?

We should wait until the first build is finished on my fork:

https://github.com/elek/incubator-ratis/actions/runs/117813626

Unit test can fail only after the (ignored) sonar check.