### PR TITLE
RATIS-957. Update .asf.yaml to define jira notifications strategy

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,3 +24,5 @@ github:
     squash:  true
     merge:   false
     rebase:  false
+  notifications:
+    jira_options: worklog label link


### PR DESCRIPTION
## What changes were proposed in this pull request?

Once a PR is opened, the corresponding Jira should get a new label "pull request available", the worklog should be updated and the PR should be linked in the jira.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-957


## How was this patch tested?

Followed instructions from INFRA, can be validated with the PR opened after this change is merged.
