### PR TITLE
RATIS-964. Fix failed UT: testRestartLogAppender

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -127,7 +127,6 @@ public class GrpcLogAppender extends LogAppender {
     }
 
     Optional.ofNullable(appendLogRequestObserver).ifPresent(StreamObserver::onCompleted);
-    grpcServerMetrics.unregister();
   }
 
   private long getWaitTimeMs() {
@@ -154,6 +153,12 @@ public class GrpcLogAppender extends LogAppender {
         LOG.warn(this + ": Wait interrupted by " + ie);
       }
     }
+  }
+
+  @Override
+  public void stopAppender() {
+    grpcServerMetrics.unregister();
+    super.stopAppender();
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
@@ -173,7 +173,7 @@ public class LogAppender {
     return daemon.isRunning();
   }
 
-  void stopAppender() {
+  public void stopAppender() {
     daemon.stop();
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -125,9 +125,14 @@ public class TestLogAppenderWithGrpc
       }
     }
 
-    // assert INCONSISTENCY counter >= 1
-    // If old LogAppender die before new LogAppender start, INCONSISTENCY equal to 1,
-    // else INCONSISTENCY greater than 1
-    Assert.assertTrue(leaderMetrics.getRegistry().counter(counter).getCount() >= 1L);
+    final RaftServerImpl newLeader = waitForLeader(cluster);
+    if (leader == newLeader) {
+      final GrpcServerMetrics newleaderMetrics = new GrpcServerMetrics(leader.getMemberId().toString());
+
+      // assert INCONSISTENCY counter >= 1
+      // If old LogAppender die before new LogAppender start, INCONSISTENCY equal to 1,
+      // else INCONSISTENCY greater than 1
+      Assert.assertTrue(newleaderMetrics.getRegistry().counter(counter).getCount() >= 1L);
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**
Failed UT: testRestartLogAppender

**What's the reason ?**
[grpcServerMetrics.unregister()](https://github.com/apache/incubator-ratis/blob/master/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java#L130) was called when GrpcLogAppender become dead. If the order is: interrupt old GrpcLogAppender ->start new GrpcLogAppender -> grpcServerMetrics.onRequestInconsistency -> old GrpcLogAppender turn dead -> grpcServerMetrics.unregister when old GrpcLogAppender become dead -> unit test check the metric of grpcServerMetrics. Then the unit test failed, because grpcServerMetrics has been unregistered.

**How to fix ?**
grpcServerMetrics.unregister should be called before interrupt old GrpcLogAppender, then start new GrpcLogAppender will create a new grpcServerMetrics.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-964

## How was this patch tested?

Existed UT
