### PR TITLE
RATIS-904. Fix Failed UT: testFileStoreAsync

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
@@ -224,6 +224,13 @@ abstract class FileInfo {
     }
 
     private int write(long offset, ByteString data, boolean close) throws IOException {
+      // If leader finish write data with offset = 4096 and writeSize become 8192,
+      // and 2 follower has not written the data with offset = 4096,
+      // then start a leader election. So client will retry send the data with offset = 4096,
+      // then offset < writeSize in leader.
+      if (offset < writeSize) {
+        return data.size();
+      }
       if (offset != writeSize) {
         throw new IOException("Offset/size mismatched: offset = " + offset
             + " != writeSize = " + writeSize + ", path=" + getRelativePath());

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreAsyncBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreAsyncBaseTest.java
@@ -59,8 +59,8 @@ public abstract class FileStoreAsyncBaseTest<CLUSTER extends MiniRaftCluster>
     final FileStoreClient client = new FileStoreClient(cluster.getGroup(), getProperties());
     final ExecutorService executor = Executors.newFixedThreadPool(20);
 
-    testSingleFile("foo", SizeInBytes.valueOf("10M"), executor, client);
-    testMultipleFiles("file", 100, SizeInBytes.valueOf("1M"), executor, client);
+    testSingleFile("foo", SizeInBytes.valueOf("2M"), executor, client);
+    testMultipleFiles("file", 20, SizeInBytes.valueOf("1M"), executor, client);
 
     executor.shutdown();
     client.close();

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreBaseTest.java
@@ -75,8 +75,8 @@ public abstract class FileStoreBaseTest<CLUSTER extends MiniRaftCluster>
     final CheckedSupplier<FileStoreClient, IOException> newClient =
         () -> new FileStoreClient(cluster.getGroup(), getProperties());
 
-    testSingleFile("foo", SizeInBytes.valueOf("10M"), newClient);
-    testMultipleFiles("file", 100, SizeInBytes.valueOf("1M"), newClient);
+    testSingleFile("foo", SizeInBytes.valueOf("2M"), newClient);
+    testMultipleFiles("file", 20, SizeInBytes.valueOf("1M"), newClient);
 
     cluster.shutdown();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. It's hard to finish write one 10M file and hundred 1M file in 100 seconds, if the leader re-election happens when write, timeout will happens.

2. `if (offset < writeSize)`  we can not throw exception. For example,  if leader finish write data with (offset = 4096, length = 4096), then writeSize of leader become 8192, and 2 follower has not written the data with (offset = 4096, length = 4096), then start a leader re-election, and the old leader elected as a new leader . So client will retry send the data with (offset = 4096, length = 4096), then (offset = 4096) < (writeSize=8192) in leader.  If we throw exception, leader can not write successfully forever.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-904

## How was this patch tested?

Existed test.