### PR TITLE
RATIS-957. Update .asf.yaml to define jira notifications strategy

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,5 +24,8 @@ github:
     squash:  true
     merge:   false
     rebase:  false
-  notifications:
-    jira_options: worklog label link
+notifications:
+  commits:      commits@ratis.apache.org
+  issues:       dev@ratis.apache.org
+  pullrequests: dev@ratis.apache.org
+  jira_options: link label worklog


### PR DESCRIPTION
## What changes were proposed in this pull request?

Although `.asf.yaml` was recently updated with `notifications` settings (#116), `pull-request-available` label and PR link are not being added to RATIS Jira issues.  This PR attempts to fix that.

Config was taken from repos where this works correctly (eg. [Hive](https://github.com/apache/hive/blob/master/.asf.yaml)), as well as from [Ratis current settings](https://gitbox.apache.org/schemes.cgi?incubator-ratis) (although `link label` seems to be [added automatically](https://github.com/apache/infrastructure-puppet/blob/6c5a88281d85d4b61156e21f1775a76d9af04b50/modules/gitbox/files/cgi-bin/schemes.cgi#L55) to that).

https://issues.apache.org/jira/browse/RATIS-957

## How was this patch tested?

Unfortunately there is no easy way to validate before merge.