### PR TITLE
[WIP]RATIS-976. Fix Failed UT: runTestUpdateViaHeartbeat

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1038,7 +1038,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
         updateCommitInfoCache();
         final long n = isHeartbeat? state.getLog().getNextIndex(): entries[entries.length - 1].getIndex() + 1;
         final long matchIndex = entries.length != 0 ? entries[entries.length - 1].getIndex() :
-            RaftLog.INVALID_LOG_INDEX;
+            state.getLog().getNextIndex() - 1;
         reply = ServerProtoUtils.toAppendEntriesReplyProto(leaderId, getMemberId(), currentTerm,
             state.getLog().getLastCommittedIndex(), n, SUCCESS, callId, matchIndex,
             isHeartbeat);


### PR DESCRIPTION
## What changes were proposed in this pull request?
You can find from the following log: s3 reply to s1 with matchIndex = 2, but s1 Failed to read message in grpc (sometime happens), then s1 can not update the matchIndex of s3. If s3 reply to s1 with matchIndex=RaftLog.INVALID_LOG_INDEX in the following heartbeat and if s1 does not send s3 any entry in the future, then s1 can not update matchIndex of s3 forever.

```
2020-06-14T04:22:11.7540505Z 2020-06-14 04:22:11,753 [Thread-354] DEBUG impl.RaftServerImpl (RaftServerImpl.java:logAppendEntries(916)) - s1@group-A76B192662EC: succeeded to handle AppendEntries. Reply: s3<-s1#76:OK,SUCCESS,nextIndex:3,term:2,followerCommit:1,matchIndex:2
2020-06-14T04:22:11.7583399Z 2020-06-14 04:22:11,756 [grpc-default-executor-4] WARN  server.GrpcLogAppender (LogUtils.java:warn(122)) - s3@group-A76B192662EC->s1-AppendLogResponseHandler: Failed appendEntries: org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: CANCELLED: Failed to read message.

```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-976

## How was this patch tested?

Existed test
