### PR TITLE
RATIS-953. XML Parsers should not be vulnerable to XXE attacks

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/conf/RaftProperties.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/RaftProperties.java
@@ -1140,6 +1140,8 @@ public class RaftProperties {
 
       DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
       docBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      docBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      docBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
       //ignore all comments inside the xml file
       docBuilderFactory.setIgnoringComments(true);
 
@@ -1312,6 +1314,8 @@ public class RaftProperties {
       StreamResult result = new StreamResult(out);
       TransformerFactory transFactory = TransformerFactory.newInstance();
       transFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      transFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      transFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
       Transformer transformer = transFactory.newTransformer();
 
       // Important to not hold Configuration log while writing result, since
@@ -1329,9 +1333,11 @@ public class RaftProperties {
   private synchronized Document asXmlDocument() throws IOException {
     Document doc;
     try {
-      DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-      documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      doc = documentBuilderFactory.newDocumentBuilder().newDocument();
+      DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+      docBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      docBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      docBuilderFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+      doc = docBuilderFactory.newDocumentBuilder().newDocument();
     } catch (ParserConfigurationException pe) {
       throw new IOException(pe);
     }

--- a/ratis-common/src/main/java/org/apache/ratis/conf/RaftProperties.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/RaftProperties.java
@@ -33,6 +33,7 @@ import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
 import org.xml.sax.SAXException;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -1138,6 +1139,7 @@ public class RaftProperties {
       name = wrapper.getName();
 
       DocumentBuilderFactory docBuilderFactory = DocumentBuilderFactory.newInstance();
+      docBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
       //ignore all comments inside the xml file
       docBuilderFactory.setIgnoringComments(true);
 
@@ -1309,6 +1311,7 @@ public class RaftProperties {
       DOMSource source = new DOMSource(doc);
       StreamResult result = new StreamResult(out);
       TransformerFactory transFactory = TransformerFactory.newInstance();
+      transFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
       Transformer transformer = transFactory.newTransformer();
 
       // Important to not hold Configuration log while writing result, since
@@ -1326,8 +1329,9 @@ public class RaftProperties {
   private synchronized Document asXmlDocument() throws IOException {
     Document doc;
     try {
-      doc =
-        DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+      DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+      documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      doc = documentBuilderFactory.newDocumentBuilder().newDocument();
     } catch (ParserConfigurationException pe) {
       throw new IOException(pe);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prevent external XML entities attacks:

1. Turn on "secure processing" for XML
2. Disable external DTD/schema explicitly

[SonarCloud](https://sonarcloud.io/organizations/apache/rules?open=java%3AS2755&rule_key=java%3AS2755) and SonarLint display slightly different instructions for fixing XXE.  This change applies both.

https://issues.apache.org/jira/browse/RATIS-953

## How was this patch tested?

Existing unit tests.

https://github.com/adoroszlai/incubator-ratis/runs/771645855