### PR TITLE
RATIS-977. Fix gRPC failed to read message

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -176,7 +176,7 @@ public interface GrpcUtil {
   }
 
   static void warn(Logger log, Supplier<String> message, Throwable t) {
-    LogUtils.warn(log, message, unwrapThrowable(t), StatusRuntimeException.class, ServerNotReadyException.class);
+    LogUtils.warn(log, message, unwrapThrowable(t), ServerNotReadyException.class);
   }
 
   class StatusRuntimeExceptionMetadataBuilder {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcUtil.java
@@ -176,7 +176,7 @@ public interface GrpcUtil {
   }
 
   static void warn(Logger log, Supplier<String> message, Throwable t) {
-    LogUtils.warn(log, message, unwrapThrowable(t), ServerNotReadyException.class);
+    LogUtils.warn(log, message, unwrapThrowable(t), StatusRuntimeException.class, ServerNotReadyException.class);
   }
 
   class StatusRuntimeExceptionMetadataBuilder {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -95,7 +95,7 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
       responseObserver.onError(wrapException(e, request));
     }
 
-    private void handleReply(REPLY reply) {
+    private synchronized void handleReply(REPLY reply) {
       if (!isClosed.get()) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("{}: reply {}", getId(), replyToString(reply));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix thread unsafe reply.

What's the problem ?
1. when s3 ask s0 to append entry, then s0 finish append entry, and reply to s3.
`2020-06-15T02:09:05.5568987Z 2020-06-15 02:09:05,554 [Thread-82] DEBUG impl.RaftServerImpl (RaftServerImpl.java:logAppendEntries(916)) - s0@group-E95D39D4BA60: succeeded to handle AppendEntries. Reply: s3<-s0#9:OK,SUCCESS,nextIndex:2,term:2,followerCommit:0,matchIndex:1`

2. s3 failed to read message
`2020-06-15T02:09:05.6204785Z 2020-06-15 02:09:05,605 [grpc-default-executor-1] WARN  server.GrpcLogAppender (LogUtils.java:warn(122)) - s3@group-E95D39D4BA60->s0-AppendLogResponseHandler: Failed appendEntries: org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: CANCELLED: Failed to read message.`

3. Sometimes the stack trace  as follow, you can find error message: `Protocol message contained an invalid tag.`
```
2020-06-15T02:09:05.6092588Z org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: CANCELLED: Failed to read message.
2020-06-15T02:09:05.6092751Z 	at org.apache.ratis.thirdparty.io.grpc.Status.asRuntimeException(Status.java:533)
2020-06-15T02:09:05.6092920Z 	at org.apache.ratis.thirdparty.io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:449)
2020-06-15T02:09:05.6093083Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:426)
2020-06-15T02:09:05.6093245Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl.access$500(ClientCallImpl.java:66)
2020-06-15T02:09:05.6093420Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.close(ClientCallImpl.java:689)
2020-06-15T02:09:05.6093787Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.access$900(ClientCallImpl.java:577)
2020-06-15T02:09:05.6093967Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:670)
2020-06-15T02:09:05.6094134Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:643)
2020-06-15T02:09:05.6094300Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
2020-06-15T02:09:05.6094460Z 	at org.apache.ratis.thirdparty.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
2020-06-15T02:09:05.6094615Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2020-06-15T02:09:05.6094846Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2020-06-15T02:09:05.6094997Z 	at java.lang.Thread.run(Thread.java:748)
2020-06-15T02:09:05.6095159Z Caused by: org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: INTERNAL: Invalid protobuf byte sequence
2020-06-15T02:09:05.6095316Z 	at org.apache.ratis.thirdparty.io.grpc.Status.asRuntimeException(Status.java:524)
2020-06-15T02:09:05.6095480Z 	at org.apache.ratis.thirdparty.io.grpc.protobuf.lite.ProtoLiteUtils$MessageMarshaller.parse(ProtoLiteUtils.java:218)
2020-06-15T02:09:05.6095649Z 	at org.apache.ratis.thirdparty.io.grpc.protobuf.lite.ProtoLiteUtils$MessageMarshaller.parse(ProtoLiteUtils.java:118)
2020-06-15T02:09:05.6095816Z 	at org.apache.ratis.thirdparty.io.grpc.MethodDescriptor.parseResponse(MethodDescriptor.java:275)
2020-06-15T02:09:05.6095972Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:658)
2020-06-15T02:09:05.6096126Z 	... 6 more
2020-06-15T02:09:05.6096283Z Caused by: org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException: Protocol message contained an invalid tag (zero).
2020-06-15T02:09:05.6096473Z 	at org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException.invalidTag(InvalidProtocolBufferException.java:102)
2020-06-15T02:09:05.6096697Z 	at org.apache.ratis.thirdparty.com.google.protobuf.CodedInputStream$ArrayDecoder.readTag(CodedInputStream.java:627)
2020-06-15T02:09:05.6096864Z 	at org.apache.ratis.proto.RaftProtos$AppendEntriesReplyProto.<init>(RaftProtos.java:16335)
```
4. The other time the stack trance is as follow, the error message is: `While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length.`
```
2020-06-15T04:48:06.2768844Z 2020-06-15 04:48:06,264 [grpc-default-executor-8] ERROR server.GrpcLogAppender (GrpcLogAppender.java:onError(332)) - grpc error stack
2020-06-15T04:48:06.2769220Z org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: CANCELLED: Failed to read message.
2020-06-15T04:48:06.2769558Z 	at org.apache.ratis.thirdparty.io.grpc.Status.asRuntimeException(Status.java:533)
2020-06-15T04:48:06.2769901Z 	at org.apache.ratis.thirdparty.io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:449)
2020-06-15T04:48:06.2770245Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:426)
2020-06-15T04:48:06.2770692Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl.access$500(ClientCallImpl.java:66)
2020-06-15T04:48:06.2771051Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.close(ClientCallImpl.java:689)
2020-06-15T04:48:06.2771568Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.access$900(ClientCallImpl.java:577)
2020-06-15T04:48:06.2771947Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:670)
2020-06-15T04:48:06.2772301Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:643)
2020-06-15T04:48:06.2772635Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
2020-06-15T04:48:06.2772969Z 	at org.apache.ratis.thirdparty.io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
2020-06-15T04:48:06.2773301Z 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
2020-06-15T04:48:06.2773631Z 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
2020-06-15T04:48:06.2774050Z 	at java.lang.Thread.run(Thread.java:748)
2020-06-15T04:48:06.2774488Z Caused by: org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: INTERNAL: Invalid protobuf byte sequence
2020-06-15T04:48:06.2774799Z 	at org.apache.ratis.thirdparty.io.grpc.Status.asRuntimeException(Status.java:524)
2020-06-15T04:48:06.2775113Z 	at org.apache.ratis.thirdparty.io.grpc.protobuf.lite.ProtoLiteUtils$MessageMarshaller.parse(ProtoLiteUtils.java:218)
2020-06-15T04:48:06.2775431Z 	at org.apache.ratis.thirdparty.io.grpc.protobuf.lite.ProtoLiteUtils$MessageMarshaller.parse(ProtoLiteUtils.java:118)
2020-06-15T04:48:06.2775748Z 	at org.apache.ratis.thirdparty.io.grpc.MethodDescriptor.parseResponse(MethodDescriptor.java:275)
2020-06-15T04:48:06.2776618Z 	at org.apache.ratis.thirdparty.io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:658)
2020-06-15T04:48:06.2776889Z 	... 6 more
2020-06-15T04:48:06.2777205Z Caused by: org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException: While parsing a protocol message, the input ended unexpectedly in the middle of a field.  This could mean either that the input has been truncated or that an embedded message misreported its own length.
2020-06-15T04:48:06.2777518Z 	at org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException.truncatedMessage(InvalidProtocolBufferException.java:84)
2020-06-15T04:48:06.2777791Z 	at org.apache.ratis.thirdparty.com.google.protobuf.CodedInputStream$ArrayDecoder.readRawByte(CodedInputStream.java:1238)
2020-06-15T04:48:06.2778063Z 	at org.apache.ratis.thirdparty.com.google.protobuf.CodedInputStream$ArrayDecoder.readRawVarint64SlowPath(CodedInputStream.java:1126)
2020-06-15T04:48:06.2778328Z 	at org.apache.ratis.thirdparty.com.google.protobuf.CodedInputStream$ArrayDecoder.readRawVarint64(CodedInputStream.java:1119)
2020-06-15T04:48:06.2778588Z 	at org.apache.ratis.thirdparty.com.google.protobuf.CodedInputStream$ArrayDecoder.readUInt64(CodedInputStream.java:757)
2020-06-15T04:48:06.2778843Z 	at org.apache.ratis.proto.RaftProtos$AppendEntriesReplyProto.<init>(RaftProtos.java:16376)
2020-06-15T04:48:06.2779093Z 	at org.apache.ratis.proto.RaftProtos$AppendEntriesReplyProto.<init>(RaftProtos.java:16297)
2020-06-15T04:48:06.2779348Z 	at org.apache.ratis.proto.RaftProtos$AppendEntriesReplyProto$1.parsePartialFrom(RaftProtos.java:17411)
2020-06-15T04:48:06.2779582Z 	at org.apache.ratis.proto.RaftProtos$AppendEntriesReplyProto$1.parsePartialFrom(RaftProtos.java:17405)
2020-06-15T04:48:06.2779829Z 	at org.apache.ratis.thirdparty.com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:86)
2020-06-15T04:48:06.2780077Z 	at org.apache.ratis.thirdparty.com.google.protobuf.AbstractParser.parseFrom(AbstractParser.java:48)
2020-06-15T04:48:06.2780390Z 	at org.apache.ratis.thirdparty.io.grpc.protobuf.lite.ProtoLiteUtils$MessageMarshaller.parseFrom(ProtoLiteUtils.java:223)
2020-06-15T04:48:06.2783772Z 	at org.apache.ratis.thirdparty.io.grpc.protobuf.lite.ProtoLiteUtils$MessageMarshaller.parse(ProtoLiteUtils.java:215)
2020-06-15T04:48:06.2784921Z 	... 9 more
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-977

## How was this patch tested?

Existed tests.
