### PR TITLE
RATIS-868. Fix Failed UT: TestRaftWithSimulatedRpc#testWithLoad

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedRequestReply.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedRequestReply.java
@@ -130,19 +130,23 @@ class SimulatedRequestReply<REQUEST extends RaftRpcMessage, REPLY extends RaftRp
       throw new IOException("The RPC of " + qid + " has already shutdown.");
     }
 
-    final REQUEST request;
+    REQUEST request;
     try {
       // delay request for testing
       RaftTestUtil.delay(q.delayTakeRequestTo::get);
+      while (true) {
+        request = q.takeRequest();
+        Preconditions.assertTrue(qid.equals(request.getReplierId()));
 
-      request = q.takeRequest();
-      Preconditions.assertTrue(qid.equals(request.getReplierId()));
-
-      // block request for testing
-      final EventQueue<REQUEST, REPLY> reqQ = queues.get(request.getRequestorId());
-      if (reqQ != null) {
-        RaftTestUtil.delay(reqQ.delayTakeRequestFrom::get);
-        RaftTestUtil.block(reqQ.blockTakeRequestFrom::get);
+        final EventQueue<REQUEST, REPLY> reqQ = queues.get(request.getRequestorId());
+        if (reqQ != null) {
+          // discard request for testing
+          if (reqQ.blockTakeRequestFrom.get()) {
+            continue;
+          }
+          RaftTestUtil.delay(reqQ.delayTakeRequestFrom::get);
+        }
+        break;
       }
     } catch (InterruptedException e) {
       throw IOUtils.toInterruptedIOException("", e);

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedRequestReply.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedRequestReply.java
@@ -140,7 +140,7 @@ class SimulatedRequestReply<REQUEST extends RaftRpcMessage, REPLY extends RaftRp
 
         final EventQueue<REQUEST, REPLY> reqQ = queues.get(request.getRequestorId());
         if (reqQ != null) {
-          // discard request for testing
+          // Doing a busy wait here until got request from requestor which was not blocked.
           if (reqQ.blockTakeRequestFrom.get()) {
             continue;
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?
What's the problem ?
The [threads](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/test/java/org/apache/ratis/server/simulation/RequestHandler.java#L48) in one RequestHandler only process the requests which were sent to one server such as s2.
So request1 from s1 to s2, request2 from s3 to s2 are both processed by one RequestHandler. 
When change oldLeader such as s1, if [q.takeRequest()](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedRequestReply.java#L138) return request1, request1.getRequestorId() will return s1, because blockTakeRequestFrom was set true when [changeLeader](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java#L386), so thread was blocked at  [RaftTestUtil.block(reqQ.blockTakeRequestFrom::get)](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedRequestReply.java#L145), if a lot of request from s1 to s2, then all the [threads](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/test/java/org/apache/ratis/server/simulation/RequestHandler.java#L48) in RequestHandler will be blocked, and the request from other server to s2 can not be sent by the blocked thread. So new leader can not be elected.

How to fix ?
When block oldLeader such as s1, we can discard all the request sent by s1 to other servers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-868

## How was this patch tested?

Existed test.
