### PR TITLE
RATIS-895. Fix Failed UT: runTestRetryOnStateMachineException

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftStateMachineExceptionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftStateMachineExceptionTests.java
@@ -30,6 +30,7 @@ import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.statemachine.TransactionContext;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Log4jUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -123,15 +124,15 @@ public abstract class RaftStateMachineExceptionTests<CLUSTER extends MiniRaftClu
         Assert.assertNotNull(reply.getStateMachineException());
       }
 
-      long leaderApplied = cluster.getLeader().getState().getLastAppliedIndex();
-      // make sure retry cache has the entry
       for (RaftServerImpl server : cluster.iterateServerImpls()) {
         LOG.info("check server " + server.getId());
-        if (server.getState().getLastAppliedIndex() < leaderApplied) {
-          Thread.sleep(1000);
-        }
-        Assert.assertNotNull(
-                RaftServerTestUtil.getRetryEntry(server, client.getId(), callId));
+
+        JavaUtils.attemptRepeatedly(() -> {
+          Assert.assertNotNull(
+              RaftServerTestUtil.getRetryEntry(server, client.getId(), callId));
+          return null;
+        }, 5, BaseTest.ONE_SECOND, "GetRetryEntry", LOG);
+
         final RaftLog log = server.getState().getLog();
         RaftTestUtil.logEntriesContains(log, oldLastApplied + 1, log.getNextIndex(), message);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

What's the problem ?
s1 received the request with callid: 999 at 2020-06-18 03:20:56,564, and after only 27ms i.e. 2020-06-18 03:20:56,591 unit test check the retry cache of s1 contain the request with callid: 999.  27ms is too short and s1 has not put the request in the retry cache, so test failed.
![image](https://user-images.githubusercontent.com/51938049/84982100-8982fe80-b168-11ea-8b8e-eb43a48150b3.png)

How to fix ?
Check many times whether the retry cache of s1 contain the request with callid: 999



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-895

## How was this patch tested?

Existed tests
