### PR TITLE
RATIS-958. Support multiple requests in a single MessageOutputStream.

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/MessageOutputStream.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/MessageOutputStream.java
@@ -25,7 +25,22 @@ import java.util.concurrent.ExecutionException;
 
 /** Stream {@link Message}(s) asynchronously. */
 public interface MessageOutputStream extends AutoCloseable {
-  CompletableFuture<RaftClientReply> sendAsync(Message message);
+  /**
+   * Send asynchronously the given message to this stream.
+   *
+   * If end-of-request is true, this message is the last message of the request.
+   * All the messages accumulated are considered as a single request.
+   *
+   * @param message the message to be sent.
+   * @param endOfRequest Is this an end-of-request?
+   * @return a future of the reply.
+   */
+  CompletableFuture<RaftClientReply> sendAsync(Message message, boolean endOfRequest);
+
+  /** The same as sendAsync(message, false). */
+  default CompletableFuture<RaftClientReply> sendAsync(Message message) {
+    return sendAsync(message, false);
+  }
 
   CompletableFuture<RaftClientReply> closeAsync();
 

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
@@ -175,8 +175,8 @@ public final class RaftClientImpl implements RaftClient {
     return UnorderedAsync.send(RaftClientRequest.watchRequestType(index, replication), this);
   }
 
-  CompletableFuture<RaftClientReply> streamAsync(long streamId, long messageId, Message message) {
-    return sendAsync(RaftClientRequest.streamRequestType(streamId, messageId, false), message, null);
+  CompletableFuture<RaftClientReply> streamAsync(long streamId, long messageId, Message message, boolean endOfRequest) {
+    return sendAsync(RaftClientRequest.streamRequestType(streamId, messageId, endOfRequest), message, null);
   }
 
   CompletableFuture<RaftClientReply> streamCloseAsync(long streamId, long messageId) {

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/StreamImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/StreamImpl.java
@@ -49,8 +49,8 @@ public final class StreamImpl implements StreamApi {
     }
 
     @Override
-    public CompletableFuture<RaftClientReply> sendAsync(Message message) {
-      return client.streamAsync(id, messageId.getAndIncrement(), message);
+    public CompletableFuture<RaftClientReply> sendAsync(Message message, boolean endOfRequest) {
+      return client.streamAsync(id, messageId.getAndIncrement(), message, endOfRequest);
     }
 
     @Override

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientRequest.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientRequest.java
@@ -40,11 +40,11 @@ public class RaftClientRequest extends RaftClientMessage {
     return WRITE_DEFAULT;
   }
 
-  public static Type streamRequestType(long streamId, long messageId, boolean close) {
+  public static Type streamRequestType(long streamId, long messageId, boolean endOfRequest) {
     return new Type(StreamRequestTypeProto.newBuilder()
         .setStreamId(streamId)
         .setMessageId(messageId)
-        .setClose(close)
+        .setEndOfRequest(endOfRequest)
         .build());
   }
 
@@ -84,7 +84,7 @@ public class RaftClientRequest extends RaftClientMessage {
     }
 
     public static Type valueOf(StreamRequestTypeProto stream) {
-      return streamRequestType(stream.getStreamId(), stream.getMessageId(), stream.getClose());
+      return streamRequestType(stream.getStreamId(), stream.getMessageId(), stream.getEndOfRequest());
     }
 
     /**
@@ -162,7 +162,7 @@ public class RaftClientRequest extends RaftClientMessage {
     }
 
     public static String toString(StreamRequestTypeProto s) {
-      return "Stream" + s.getStreamId() + "-" + s.getMessageId() + (s.getClose()? "-close": "");
+      return "Stream" + s.getStreamId() + "-" + s.getMessageId() + (s.getEndOfRequest()? "-eor": "");
     }
 
     @Override

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -249,7 +249,7 @@ message WriteRequestTypeProto {
 message StreamRequestTypeProto {
   uint64 streamId = 1;  // the id of this stream
   uint64 messageId = 2; // the message id within a particular stream.
-  bool close = 3;       // close the stream?
+  bool endOfRequest = 3;// Is this the end-of-request?
 }
 
 message ReadRequestTypeProto {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
@@ -345,8 +345,8 @@ public class LeaderState {
         .exceptionally(e -> exception2RaftClientReply(request, e));
   }
 
-  CompletableFuture<RaftClientRequest> streamCloseAsync(RaftClientRequest request) {
-    return streamRequests.streamCloseAsync(request)
+  CompletableFuture<RaftClientRequest> streamEndOfRequestAsync(RaftClientRequest request) {
+    return streamRequests.streamEndOfRequestAsync(request)
         .thenApply(bytes -> RaftClientRequest.toWriteRequest(request, Message.valueOf(bytes)));
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -588,8 +588,8 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
       // let the state machine handle read-only request from client
       RaftClientRequest.Type type = request.getType();
       if (type.is(RaftClientRequestProto.TypeCase.STREAM)) {
-        if (type.getStream().getClose()) {
-          final CompletableFuture<RaftClientRequest> f = streamCloseAsync(request);
+        if (type.getStream().getEndOfRequest()) {
+          final CompletableFuture<RaftClientRequest> f = streamEndOfRequestAsync(request);
           if (f.isCompletedExceptionally()) {
             return f.thenApply(r -> null);
           }
@@ -668,9 +668,9 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
             new RaftClientReply(request, generateNotLeaderException(), getCommitInfos())));
   }
 
-  private CompletableFuture<RaftClientRequest> streamCloseAsync(RaftClientRequest request) {
+  private CompletableFuture<RaftClientRequest> streamEndOfRequestAsync(RaftClientRequest request) {
     return role.getLeaderState()
-        .map(ls -> ls.streamCloseAsync(request))
+        .map(ls -> ls.streamEndOfRequestAsync(request))
         .orElse(null);
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-958