### PR TITLE
RATIS-983. Check follower state before ask for votes

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -199,6 +199,9 @@ class LeaderElection implements Runnable {
       final long electionTerm;
       final RaftConfiguration conf;
       synchronized (server) {
+        if (!shouldRun()) {
+          break;
+        }
         electionTerm = state.initElection();
         conf = state.getRaftConf();
         state.persistMetadata();


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**
1. There are server s0, s1, s2, all start leader election. But s2 has not start askForVotes.

s0
```
2020-06-21 03:46:27,958 [Thread-7] INFO  impl.RoleInfo (RoleInfo.java:updateAndGet(143)) - s0: start LeaderElection
2020-06-21 03:46:27,963 [s0@group-D88B65C78887-LeaderElection1] INFO  impl.LeaderElection (LeaderElection.java:askForVotes(206)) - s0@group-D88B65C78887-LeaderElection1: begin an election at term 1 for -1: [s0:0.0.0.0:40443, s1:0.0.0.0:46669, s2:0.0.0.0:41589], old=null
```



s1
```
2020-06-21 03:46:27,990 [Thread-8] INFO  impl.RoleInfo (RoleInfo.java:updateAndGet(143)) - s1: start LeaderElection
2020-06-21 03:46:27,998 [s1@group-D88B65C78887-LeaderElection2] INFO  impl.LeaderElection (LeaderElection.java:askForVotes(206)) - s1@group-D88B65C78887-LeaderElection2: begin an election at term 1 for -1: [s0:0.0.0.0:40443, s1:0.0.0.0:46669, s2:0.0.0.0:41589], old=null
```

s2
`2020-06-21 03:46:28,064 [Thread-9] INFO  impl.RoleInfo (RoleInfo.java:updateAndGet(143)) - s2: start LeaderElection`



2. s0 was elected as leader


```
2020-06-21 03:46:28,093 [s0@group-D88B65C78887-LeaderElection1] INFO  impl.LeaderElection (LeaderElection.java:logAndReturn(61)) - s0@group-D88B65C78887-LeaderElection1: Election PASSED; received 2 response(s) [s0<-s1#0:FAIL-t1, s0<-s2#0:OK-t1] and 0 exception(s); s0@group-D88B65C78887:t1, leader=null, voted=s0, raftlog=s0@group-D88B65C78887-SegmentedRaftLog:OPENED:c-1,f-1,i0, conf=-1: [s0:0.0.0.0:40443, s1:0.0.0.0:46669, s2:0.0.0.0:41589], old=null
2020-06-21 03:46:28,093 [s0@group-D88B65C78887-LeaderElection1] INFO  impl.RoleInfo (RoleInfo.java:shutdownLeaderElection(134)) - s0: shutdown LeaderElection
2020-06-21T03:46:28.0975768Z 2020-06-21 03:46:28,094 [s0@group-D88B65C78887-LeaderElection1] INFO  impl.RaftServerImpl (RaftServerImpl.java:setRole(174)) - s0@group-D88B65C78887: changes role from CANDIDATE to LEADER at term 1 for changeToLeader
2020-06-21 03:46:28,094 [s0@group-D88B65C78887-LeaderElection1] INFO  impl.RaftServerImpl (ServerState.java:setLeader(255)) - s0@group-D88B65C78887: change Leader from null to s0 at term 1 for becomeLeader, leader elected after 474ms
```


3. s2 start askForVotes which did not start in step1. Then a new leader election happens.

`2020-06-21 03:46:28,096 [s2@group-D88B65C78887-LeaderElection3] INFO  impl.LeaderElection (LeaderElection.java:askForVotes(206)) - s2@group-D88B65C78887-LeaderElection3: begin an election at term 2 for -1: [s0:0.0.0.0:40443, s1:0.0.0.0:46669, s2:0.0.0.0:41589], old=null`

**What's the reason ?**
1. as the following code shows, when s2 askForVotes, it needs to synchronized (server). But the lock already held by [appendEntriesAsync](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L983), and in appendEntriesAsync s2 will change to follower at [changeToFollowerAndPersistMetadata(leaderTerm, "appendEntries")](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L997). Then appendEntriesAsync unlock and askForVotes got the lock of synchronized (server), and s2 begin a new leader election.
![image](https://user-images.githubusercontent.com/51938049/85223445-da5b5700-b3f5-11ea-98b5-e69aadc33a35.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-983

## How was this patch tested?

Existed tests.
