### PR TITLE
RATIS-987. Fix Infinite install snapshot

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1242,24 +1242,29 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
         LOG.info("{}: notifyInstallSnapshot: nextIndex is {} but the leader's first available index is {}.",
             getMemberId(), state.getLog().getNextIndex(), firstAvailableLogIndex);
 
-        stateMachine.notifyInstallSnapshotFromLeader(getRoleInfoProto(), firstAvailableLogTermIndex)
-            .whenComplete((reply, exception) -> {
-              if (exception != null) {
-                LOG.warn("{}: Failed to notify StateMachine to InstallSnapshot. Exception: {}",
-                    getMemberId(), exception.getMessage());
-                inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
-                return;
-              }
+        try {
+          stateMachine.notifyInstallSnapshotFromLeader(getRoleInfoProto(), firstAvailableLogTermIndex)
+              .whenComplete((reply, exception) -> {
+                if (exception != null) {
+                  LOG.warn("{}: Failed to notify StateMachine to InstallSnapshot. Exception: {}",
+                      getMemberId(), exception.getMessage());
+                  inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
+                  return;
+                }
 
-              if (reply != null) {
-                LOG.info("{}: StateMachine successfully installed snapshot index {}. Reloading the StateMachine.",
-                    getMemberId(), reply.getIndex());
-                stateMachine.pause();
-                state.updateInstalledSnapshotIndex(reply);
-                state.reloadStateMachine(reply.getIndex());
-              }
-              inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
-            });
+                if (reply != null) {
+                  LOG.info("{}: StateMachine successfully installed snapshot index {}. Reloading the StateMachine.",
+                      getMemberId(), reply.getIndex());
+                  stateMachine.pause();
+                  state.updateInstalledSnapshotIndex(reply);
+                  state.reloadStateMachine(reply.getIndex());
+                }
+                inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
+              });
+        } catch (Throwable t) {
+          inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
+          throw t;
+        }
 
         if (LOG.isDebugEnabled()) {
           LOG.debug("{}: Snapshot Installation Request received and is in progress", getMemberId());


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**
1. This happens in ozone production with ratis-0.5.0
2. leader notify follower install snapshot-(t:3, i:999697) infinitely
![image](https://user-images.githubusercontent.com/51938049/85519402-06fcb200-b634-11ea-9d18-37037e4a7403.png)

3.  follower install snapshot but log `StateMachine installSnapshot is in progress` infinitely.
![image](https://user-images.githubusercontent.com/51938049/85519573-47f4c680-b634-11ea-8cb8-70ddb2c66b40.png)

What's the reason ?
1.  The log code of [StateMachine installSnapshot is in progress](https://github.com/apache/incubator-ratis/blob/ratis-0.5.0-rc0/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L1198) in ratis-0.5.0 as follow.
This log will be printed if [inProgressInstallSnapshotRequest.compareAndSet(null, firstAvailableLogTermIndex)](https://github.com/apache/incubator-ratis/blob/ratis-0.5.0-rc0/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L1157) return false, i.e. inProgressInstallSnapshotRequest != null. And the reason of inProgressInstallSnapshotRequest != null, is [stateMachine.notifyInstallSnapshotFromLeader](https://github.com/apache/incubator-ratis/blob/ratis-0.5.0-rc0/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java#L1178) throw exception in [ozone](https://github.com/apache/hadoop-ozone/blob/master/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java#L569).
Actually notifyInstallSnapshotFromLeader in ozone will close pipeline.
If throw exception in notifyInstallSnapshotFromLeader, inProgressInstallSnapshotRequest can not will set null forever, and pipeline also can not be closed. Then infinite install snapshot happens.
```
if (inProgressInstallSnapshotRequest.compareAndSet(null, firstAvailableLogTermIndex)) {

        ...

        stateMachine.notifyInstallSnapshotFromLeader(getRoleInfoProto(), firstAvailableLogTermIndex)
            .whenComplete((reply, exception) -> {
              if (exception != null) {
                LOG.error("{}: State Machine failed to install snapshot", getMemberId(), exception);
                inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
                return;
              }

              if (reply != null) {
                stateMachine.pause();
                state.reloadStateMachine(reply.getIndex(), leaderTerm);
                state.updateInstalledSnapshotIndex(reply);
              }
              inProgressInstallSnapshotRequest.compareAndSet(firstAvailableLogTermIndex, null);
            });

        return ServerProtoUtils.toInstallSnapshotReplyProto(leaderId, getMemberId(),
            currentTerm, InstallSnapshotResult.SUCCESS, -1);
}

LOG.info("{}: StateMachine installSnapshot is in progress: {}",
          getMemberId(), inProgressInstallSnapshotRequest.get());
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-987

## How was this patch tested?

Existed tests.
