### PR TITLE
RATIS-989. Avoid change state from CLOSING to EXCEPTION in LogAppender

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/LifeCycle.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/LifeCycle.java
@@ -101,7 +101,7 @@ public class LifeCycle {
     }
 
     /** Is the given transition valid? */
-    static boolean isValid(State from, State to) {
+    public static boolean isValid(State from, State to) {
       return PREDECESSORS.get(to).contains(from);
     }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
@@ -73,7 +73,7 @@ public class LogAppender {
         if (!isRunning()) {
           return;
         }
-        transLifeCycle(RUNNING);
+        transitionLifeCycle(RUNNING);
       }
       try {
         runAppenderImpl();
@@ -81,13 +81,13 @@ public class LogAppender {
         LOG.info(this + " was interrupted: " + e);
       } catch (RaftLogIOException e) {
         LOG.error(this + " failed RaftLog", e);
-        transLifeCycle(EXCEPTION);
+        transitionLifeCycle(EXCEPTION);
       } catch (IOException e) {
         LOG.error(this + " failed IOException", e);
-        transLifeCycle(EXCEPTION);
+        transitionLifeCycle(EXCEPTION);
       } catch (Throwable e) {
         LOG.error(this + " unexpected exception", e);
-        transLifeCycle(EXCEPTION);
+        transitionLifeCycle(EXCEPTION);
       } finally {
         synchronized (lifeCycle) {
           if (!lifeCycle.compareAndTransition(CLOSING, CLOSED)) {
@@ -112,7 +112,7 @@ public class LogAppender {
         if (lifeCycle.compareAndTransition(NEW, CLOSED)) {
           return;
         }
-        transLifeCycle(CLOSING);
+        transitionLifeCycle(CLOSING);
       }
       daemon.interrupt();
     }
@@ -122,7 +122,7 @@ public class LogAppender {
       return name;
     }
 
-    private boolean transLifeCycle(LifeCycle.State to) {
+    private boolean transitionLifeCycle(LifeCycle.State to) {
       synchronized (lifeCycle) {
         if (LifeCycle.State.isValid(lifeCycle.getCurrentState(), to)) {
           lifeCycle.transition(to);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
@@ -61,8 +61,10 @@ public class LogAppender {
 
     void start() {
       // The life cycle state could be already closed due to server shutdown.
-      if (lifeCycle.compareAndTransition(NEW, STARTING)) {
-        daemon.start();
+      synchronized (lifeCycle) {
+        if (lifeCycle.compareAndTransition(NEW, STARTING)) {
+          daemon.start();
+        }
       }
     }
 
@@ -71,7 +73,7 @@ public class LogAppender {
         if (!isRunning()) {
           return;
         }
-        lifeCycle.transition(RUNNING);
+        transLifeCycle(RUNNING);
       }
       try {
         runAppenderImpl();
@@ -79,19 +81,21 @@ public class LogAppender {
         LOG.info(this + " was interrupted: " + e);
       } catch (RaftLogIOException e) {
         LOG.error(this + " failed RaftLog", e);
-        lifeCycle.transition(EXCEPTION);
+        transLifeCycle(EXCEPTION);
       } catch (IOException e) {
         LOG.error(this + " failed IOException", e);
-        lifeCycle.transition(EXCEPTION);
+        transLifeCycle(EXCEPTION);
       } catch (Throwable e) {
         LOG.error(this + " unexpected exception", e);
-        lifeCycle.transition(EXCEPTION);
+        transLifeCycle(EXCEPTION);
       } finally {
-        if (!lifeCycle.compareAndTransition(CLOSING, CLOSED)) {
-          lifeCycle.transitionIfNotEqual(EXCEPTION);
-        }
-        if (lifeCycle.getCurrentState() == EXCEPTION) {
-          leaderState.restartSender(LogAppender.this);
+        synchronized (lifeCycle) {
+          if (!lifeCycle.compareAndTransition(CLOSING, CLOSED)) {
+            lifeCycle.transitionIfNotEqual(EXCEPTION);
+          }
+          if (lifeCycle.getCurrentState() == EXCEPTION) {
+            leaderState.restartSender(LogAppender.this);
+          }
         }
       }
     }
@@ -102,13 +106,13 @@ public class LogAppender {
 
     void stop() {
       synchronized (lifeCycle) {
-        if (!isRunning()) {
+        if (LifeCycle.States.CLOSING_OR_CLOSED.contains(lifeCycle.getCurrentState())) {
           return;
         }
         if (lifeCycle.compareAndTransition(NEW, CLOSED)) {
           return;
         }
-        lifeCycle.transition(CLOSING);
+        transLifeCycle(CLOSING);
       }
       daemon.interrupt();
     }
@@ -116,6 +120,16 @@ public class LogAppender {
     @Override
     public String toString() {
       return name;
+    }
+
+    private boolean transLifeCycle(LifeCycle.State to) {
+      synchronized (lifeCycle) {
+        if (LifeCycle.State.isValid(lifeCycle.getCurrentState(), to)) {
+          lifeCycle.transition(to);
+          return true;
+        }
+        return false;
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. allow EXCEPTION to CLOSING by 
![image](https://user-images.githubusercontent.com/51938049/85997167-c3db7e00-ba3b-11ea-9c27-17ca5d8e4168.png)

2. check LifeCycle.State.isValid(from, to) before state transition.

3. add synchronized to lifeCycle

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-989

## How was this patch tested?

Existed tests.
