### PR TITLE
RATIS-965. Adds new JMX metric for getting Groups a server is part of

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/RaftServerMXBean.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/RaftServerMXBean.java
@@ -54,5 +54,9 @@ public interface RaftServerMXBean {
    */
   List<String> getFollowers();
 
+  /**
+   * Gets the Groups of the Server.
+   */
+  List<String> getGroups();
 
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1462,5 +1462,11 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
       return role.getLeaderState().map(LeaderState::getFollowers).orElse(Collections.emptyList())
           .stream().map(RaftPeer::toString).collect(Collectors.toList());
     }
+
+    @Override
+    public List<String> getGroups() {
+      return proxy.getGroupIds().stream().map(RaftGroupId::toString)
+          .collect(Collectors.toList());
+    }
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/server/impl/TestRaftServerJmx.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/impl/TestRaftServerJmx.java
@@ -95,6 +95,9 @@ public class TestRaftServerJmx extends BaseTest {
       public String getRole() { return null; }
       @Override
       public List<String> getFollowers() { return null; }
+      @Override
+      public List<String> getGroups() { return null; }
+
     };
     final RaftPeerId id = RaftPeerId.valueOf(name);
     final RaftGroupId groupId = RaftGroupId.randomId();


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR added a new jmx metric to show the Groups a server is part of.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/RATIS/issues/RATIS-965

## How was this patch tested?

Manual test. I have tested this using Java Mission Control to check weather metrics are properly emitting or not. 
