### PR TITLE
RATIS-992. Avoid foreach in hot spot newAppendEntriesRequestProto

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
@@ -162,6 +162,10 @@ public class LeaderState {
       return senders.stream();
     }
 
+    List<LogAppender> getSenders() {
+      return senders;
+    }
+
     void forEach(Consumer<LogAppender> action) {
       senders.forEach(action);
     }
@@ -400,9 +404,10 @@ public class LeaderState {
   }
 
   void updateFollowerCommitInfos(CommitInfoCache cache, List<CommitInfoProto> protos) {
-    senders.stream().map(LogAppender::getFollower)
-        .map(f -> cache.update(f.getPeer(), f.getCommitIndex()))
-        .forEach(protos::add);
+    for (LogAppender sender : senders.getSenders()) {
+      FollowerInfo info = sender.getFollower();
+      protos.add(cache.update(info.getPeer(), info.getCommitIndex()));
+    }
   }
 
   AppendEntriesRequestProto newAppendEntriesRequestProto(RaftPeerId targetId,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid foreach in hot spot newAppendEntriesRequestProto

![image](https://user-images.githubusercontent.com/51938049/86352912-1f567780-bc99-11ea-8d67-76c0e950125d.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-992

## How was this patch tested?

Existed ut.
