### PR TITLE
RATIS-996. Include ratis-docs in source and binary tar.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,12 @@
     <dependencies>
       <!-- Internal dependencies -->
       <dependency>
+        <artifactId>ratis-docs</artifactId>
+        <groupId>org.apache.ratis</groupId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
         <artifactId>ratis-client</artifactId>
         <groupId>org.apache.ratis</groupId>
         <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
   </licenses>
 
   <modules>
+    <module>ratis-docs</module>
     <module>ratis-proto</module>
     <module>ratis-common</module>
     <module>ratis-client</module>
@@ -80,13 +81,12 @@
 
     <module>ratis-test</module>
 
-    <module>ratis-assembly</module>
     <module>ratis-examples</module>
     <module>ratis-replicated-map</module>
     <module>ratis-logservice</module>
     <module>ratis-metrics</module>
     <module>ratis-tools</module>
-    <module>ratis-docs</module>
+    <module>ratis-assembly</module>
   </modules>
 
   <pluginRepositories>

--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -178,6 +178,10 @@
       <optional>true</optional>
      </dependency>
     <dependency>
+      <artifactId>ratis-docs</artifactId>
+      <groupId>org.apache.ratis</groupId>
+    </dependency>
+    <dependency>
       <artifactId>ratis-proto</artifactId>
       <groupId>org.apache.ratis</groupId>
     </dependency>

--- a/ratis-assembly/src/main/assembly/bin.xml
+++ b/ratis-assembly/src/main/assembly/bin.xml
@@ -37,7 +37,6 @@
         <include>org.apache.ratis:ratis-logservice</include>
         <include>org.apache.ratis:ratis-netty</include>
         <include>org.apache.ratis:ratis-proto</include>
-        <include>org.apache.ratis:ratis-docs</include>
         <include>org.apache.ratis:ratis-replicated-map</include>
         <include>org.apache.ratis:ratis-server</include>
         <include>org.apache.ratis:ratis-test</include>
@@ -70,6 +69,13 @@
         <include>NOTICE</include>
       </includes>
       <fileMode>0644</fileMode>
+    </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../ratis-docs/target/classes/docs
+      </directory>
+      <outputDirectory>docs</outputDirectory>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
     </fileSet>
     <!-- Include dev support tools -->
     <fileSet>

--- a/ratis-assembly/src/main/assembly/bin.xml
+++ b/ratis-assembly/src/main/assembly/bin.xml
@@ -37,6 +37,7 @@
         <include>org.apache.ratis:ratis-logservice</include>
         <include>org.apache.ratis:ratis-netty</include>
         <include>org.apache.ratis:ratis-proto</include>
+        <include>org.apache.ratis:ratis-docs</include>
         <include>org.apache.ratis:ratis-replicated-map</include>
         <include>org.apache.ratis:ratis-server</include>
         <include>org.apache.ratis:ratis-test</include>

--- a/ratis-assembly/src/main/assembly/src.xml
+++ b/ratis-assembly/src/main/assembly/src.xml
@@ -38,6 +38,7 @@
         <include>org.apache.ratis:ratis-logservice</include>
         <include>org.apache.ratis:ratis-netty</include>
         <include>org.apache.ratis:ratis-proto</include>
+        <include>org.apache.ratis:ratis-docs</include>
         <include>org.apache.ratis:ratis-replicated-map</include>
         <include>org.apache.ratis:ratis-server</include>
         <include>org.apache.ratis:ratis-test</include>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently ratis-docs is not included in source and binary tar. Further ratis-docs is the last module built. This causes failure in package phase of ratis-assembly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-996

## How was this patch tested?

Build.
