### PR TITLE
Implement support for role tracking per raft-group

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/RaftPeerRoleTracker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/RaftPeerRoleTracker.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server;
+
+import org.apache.ratis.proto.RaftProtos;
+
+/** Callback interface for receiving role changes for a raft-group. */
+public interface RaftPeerRoleTracker {
+  /** Fired when a raft-peer starts changing its role. */
+  void transitioning(RaftProtos.RaftPeerRole oldRole, RaftProtos.RaftPeerRole newRole);
+
+  /** Fired when a raft-peer successfully completed transitioning to a new role. */
+  void transitioned(RaftProtos.RaftPeerRole newRole);
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/RaftServer.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/RaftServer.java
@@ -21,6 +21,7 @@ import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.rpc.RpcType;
+import org.apache.ratis.server.impl.RoleTrackerReference;
 import org.apache.ratis.server.impl.ServerFactory;
 import org.apache.ratis.server.impl.ServerImplUtils;
 import org.apache.ratis.server.protocol.RaftServerAsynchronousProtocol;
@@ -57,6 +58,10 @@ public interface RaftServer extends Closeable, RpcType.Get,
   void start() throws IOException;
 
   LifeCycle.State getLifeCycleState();
+
+  /** Adds a new tracker to receive peer state changes for this server. */
+  /** @return a closeable reference that keeps the tracker alive until closed. */
+  RoleTrackerReference registerRoleTracker(RaftGroupId groupId, RaftPeerRoleTracker roleTracker);
 
   /** @return a {@link Builder}. */
   static Builder newBuilder() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleTrackerReference.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleTrackerReference.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.impl;
+
+import org.apache.ratis.server.RaftPeerRoleTracker;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A role-tracker wrapping class that owns resources for the tracker.
+ * Closing a tracker by using its {@link AutoCloseable#close()} will release underlying raft resources.
+ */
+public class RoleTrackerReference extends CompletableFuture<Void> implements AutoCloseable {
+  private RaftServerImpl serverImpl;
+  private RaftPeerRoleTracker roleTracker;
+
+  /** Creates a new tracker reference wrapped over given role tracker. */
+  public RoleTrackerReference(RaftPeerRoleTracker roleTracker) {
+    this.roleTracker = roleTracker;
+  }
+
+  /** Called internally whenever this tracker is registered to an underlying raft-server-impl. */
+  public synchronized void registeredToServer(RaftServerImpl registeredServerImpl) {
+    this.serverImpl = registeredServerImpl;
+  }
+
+  @Override
+  public synchronized void close() throws Exception {
+    if (serverImpl != null) {
+      serverImpl.removeRoleTracker(roleTracker);
+    }
+  }
+}


### PR DESCRIPTION
For when raft-server functionality is leveraged in a single-leader topology, it is always useful to be able to know the local raft-server's role and make necessary transitions in cluster accordingly. This PR introduces a new `RaftServer#registerRoleTracker(RaftGroupId, RaftPeerRoleTracker)` API that allows mentioned tracking capability.

https://issues.apache.org/jira/browse/RATIS-1000
