### PR TITLE
RATIS-981: Step-down stale leader in case of split-brain

### DIFF
--- a/ratis-examples/src/test/java/org/apache/ratis/examples/ParameterizedBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/ParameterizedBaseTest.java
@@ -24,8 +24,10 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.MiniRaftClusterWithGrpc;
 import org.apache.ratis.hadooprpc.MiniRaftClusterWithHadoopRpc;
 import org.apache.ratis.netty.MiniRaftClusterWithNetty;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
 import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.util.TimeDuration;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -35,6 +37,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(Parameterized.class)
@@ -123,6 +126,11 @@ public abstract class ParameterizedBaseTest extends BaseTest {
     final RaftProperties prop = new RaftProperties();
     prop.setClass(MiniRaftCluster.STATEMACHINE_CLASS_KEY,
         stateMachineClass, StateMachine.class);
+
+    // make sure leadership check won't affect the test
+    RaftServerConfigKeys.Rpc.setTimeoutMin(prop, TimeDuration.valueOf(2, TimeUnit.SECONDS));
+    RaftServerConfigKeys.Rpc.setTimeoutMax(prop, TimeDuration.valueOf(4, TimeUnit.SECONDS));
+
     return getMiniRaftClusters(prop, clusterSize, clusterClasses);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
@@ -511,6 +511,8 @@ public class LeaderState {
               event.execute();
             } else if (inStagingState()) {
               checkStaging();
+            } else {
+              checkLeadership();
             }
           }
         }
@@ -785,6 +787,46 @@ public class LeaderState {
       lists.add(listForOld);
     }
     return lists;
+  }
+
+  /**
+   * See the thesis section 6.2: A leader in Raft steps down
+   * if an election timeout elapses without a successful
+   * round of heartbeats to a majority of its cluster.
+   */
+  private void checkLeadership() {
+    // The initial value of lastRpcResponseTime in FollowerInfo is set by
+    // LeaderState::addSenders(), which is fake and used to trigger an
+    // immediate round of AppendEntries request. To ensure that leader
+    // is stable, just ignore the check if become leader soon.
+    if (server.getRole().getRoleElapsedTimeMs() < 3 * server.getMaxTimeoutMs()) {
+      return;
+    }
+
+    final List<RaftPeerId> activePeers = senders.stream()
+        .filter(sender -> sender.getFollower()
+                                .getLastRpcResponseTime()
+                                .elapsedTimeMs() <= server.getMaxTimeoutMs())
+        .map(sender -> sender.getFollower().getPeer().getId())
+        .collect(Collectors.toList());
+
+    final RaftConfiguration conf = server.getRaftConf();
+
+    if (conf.hasMajority(activePeers, server.getId())) {
+      // leadership check passed
+      return;
+    }
+
+    List<FollowerInfo> followers = senders.stream()
+        .map(LogAppender::getFollower).collect(Collectors.toList());
+
+    LOG.warn(this + ": Lost leadership on term: " + currentTerm
+        + ". Election timeout: " + server.getMaxTimeoutMs() + "ms"
+        + ". In charge for: " + server.getRole().getRoleElapsedTimeMs() + "ms"
+        + ". Conf: " + conf + ". Followers: " + followers);
+
+    // become follower of next term.
+    stepDown(currentTerm + 1);
   }
 
   void replyPendingRequest(long logIndex, RaftClientReply reply) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
@@ -90,11 +90,8 @@ class PeerConfiguration {
       if (contains(other)) {
         num++;
       }
-      if (num > size() / 2) {
-        return true;
-      }
     }
-    return false;
+    return num > size() / 2;
   }
 
   @Override

--- a/ratis-server/src/test/java/org/apache/ratis/RaftAsyncTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftAsyncTests.java
@@ -367,7 +367,17 @@ public abstract class RaftAsyncTests<CLUSTER extends MiniRaftCluster> extends Ba
 
   @Test
   public void testAppendEntriesTimeout() throws Exception {
+    // make sure leadership check won't affect the test
+    final TimeDuration oldTimeoutMin = RaftServerConfigKeys.Rpc.timeoutMin(getProperties());
+    RaftServerConfigKeys.Rpc.setTimeoutMin(getProperties(), TimeDuration.valueOf(10, TimeUnit.SECONDS));
+    final TimeDuration oldTimeoutMax = RaftServerConfigKeys.Rpc.timeoutMax(getProperties());
+    RaftServerConfigKeys.Rpc.setTimeoutMax(getProperties(), TimeDuration.valueOf(20, TimeUnit.SECONDS));
+
     runWithNewCluster(NUM_SERVERS, this::runTestAppendEntriesTimeout);
+
+    // reset for the other tests
+    RaftServerConfigKeys.Rpc.setTimeoutMin(getProperties(), oldTimeoutMin);
+    RaftServerConfigKeys.Rpc.setTimeoutMax(getProperties(), oldTimeoutMax);
   }
 
   void runTestAppendEntriesTimeout(CLUSTER cluster) throws Exception {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -29,8 +29,10 @@ import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Log4jUtils;
+import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.function.CheckedBiConsumer;
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,6 +59,12 @@ public abstract class GroupManagementBaseTest extends BaseTest {
   }
 
   static final RaftProperties prop = new RaftProperties();
+
+  static {
+    // make sure leadership check won't affect the test
+    RaftServerConfigKeys.Rpc.setTimeoutMin(prop, TimeDuration.valueOf(2, TimeUnit.SECONDS));
+    RaftServerConfigKeys.Rpc.setTimeoutMax(prop, TimeDuration.valueOf(4, TimeUnit.SECONDS));
+  }
 
   public abstract MiniRaftCluster.Factory<? extends MiniRaftCluster> getClusterFactory();
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -418,8 +418,18 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
    */
   @Test
   public void testOverlappedSetConfRequests() throws Exception {
+    // make sure leadership check won't affect the test
+    final TimeDuration oldTimeoutMin = RaftServerConfigKeys.Rpc.timeoutMin(getProperties());
+    RaftServerConfigKeys.Rpc.setTimeoutMin(getProperties(), TimeDuration.valueOf(2, TimeUnit.SECONDS));
+    final TimeDuration oldTimeoutMax = RaftServerConfigKeys.Rpc.timeoutMax(getProperties());
+    RaftServerConfigKeys.Rpc.setTimeoutMax(getProperties(), TimeDuration.valueOf(4, TimeUnit.SECONDS));
+
     // originally 3 peers
     runWithNewCluster(3, this::runTestOverlappedSetConfRequests);
+
+    // reset for the other tests
+    RaftServerConfigKeys.Rpc.setTimeoutMin(getProperties(), oldTimeoutMin);
+    RaftServerConfigKeys.Rpc.setTimeoutMax(getProperties(), oldTimeoutMax);
   }
 
   void runTestOverlappedSetConfRequests(CLUSTER cluster) throws Exception {

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestLogAppenderWithGrpc.java
@@ -33,6 +33,7 @@ import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Log4jUtils;
+import org.apache.ratis.util.TimeDuration;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.ratis.RaftTestUtil.waitForLeader;
 
@@ -54,6 +56,11 @@ public class TestLogAppenderWithGrpc
   public void testPendingLimits() throws IOException, InterruptedException {
     int maxAppends = 10;
     RaftProperties properties = new RaftProperties();
+
+    // make sure leadership check won't affect the test
+    RaftServerConfigKeys.Rpc.setTimeoutMin(properties, TimeDuration.valueOf(10, TimeUnit.SECONDS));
+    RaftServerConfigKeys.Rpc.setTimeoutMax(properties, TimeDuration.valueOf(20, TimeUnit.SECONDS));
+
     properties.setClass(MiniRaftCluster.STATEMACHINE_CLASS_KEY,
         SimpleStateMachine4Testing.class, StateMachine.class);
     GrpcConfigKeys.Server.setLeaderOutstandingAppendsMax(properties, maxAppends);

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
@@ -22,6 +22,7 @@ import org.apache.ratis.RaftBasicTests;
 import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.impl.BlockRequestHandlingInjection;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -67,7 +68,17 @@ public class TestRaftWithGrpc
 
   @Test
   public void testUpdateViaHeartbeat() throws Exception {
+    // make sure leadership check won't affect the test
+    final TimeDuration oldTimeoutMin = RaftServerConfigKeys.Rpc.timeoutMin(getProperties());
+    RaftServerConfigKeys.Rpc.setTimeoutMin(getProperties(), TimeDuration.valueOf(10, TimeUnit.SECONDS));
+    final TimeDuration oldTimeoutMax = RaftServerConfigKeys.Rpc.timeoutMax(getProperties());
+    RaftServerConfigKeys.Rpc.setTimeoutMax(getProperties(), TimeDuration.valueOf(20, TimeUnit.SECONDS));
+
     runWithNewCluster(NUM_SERVERS, this::runTestUpdateViaHeartbeat);
+
+    // reset for the other tests
+    RaftServerConfigKeys.Rpc.setTimeoutMin(getProperties(), oldTimeoutMin);
+    RaftServerConfigKeys.Rpc.setTimeoutMax(getProperties(), oldTimeoutMax);
   }
 
   void runTestUpdateViaHeartbeat(MiniRaftClusterWithGrpc cluster) throws Exception {

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRetryCacheWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRetryCacheWithGrpc.java
@@ -31,10 +31,12 @@ import org.apache.ratis.server.impl.RaftServerProxy;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.util.TimeDuration;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TestRetryCacheWithGrpc
@@ -45,6 +47,11 @@ public class TestRetryCacheWithGrpc
   public void testRetryOnResourceUnavailableException()
       throws InterruptedException, IOException {
     RaftProperties properties = new RaftProperties();
+
+    // make sure leadership check won't affect the test
+    RaftServerConfigKeys.Rpc.setTimeoutMin(properties, TimeDuration.valueOf(1, TimeUnit.SECONDS));
+    RaftServerConfigKeys.Rpc.setTimeoutMax(properties, TimeDuration.valueOf(2, TimeUnit.SECONDS));
+
     properties.setClass(MiniRaftCluster.STATEMACHINE_CLASS_KEY,
         SimpleStateMachine4Testing.class, StateMachine.class);
     RaftServerConfigKeys.Write.setElementLimit(properties, 1);


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a leader can not hear from majority (including itself)
during last election timeout, it should step down and
become a follower of next term.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/RATIS/issues/RATIS-981

## How was this patch tested?

CI
