### PR TITLE
RATIS-1001: add currentTerm to LeaderInfoProto for supporting SCM-HA.

### DIFF
--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -363,6 +363,7 @@ message ServerRpcProto {
 
 message LeaderInfoProto {
   repeated ServerRpcProto followerInfo = 1;
+  uint64 term = 2;
 }
 
 message FollowerInfoProto {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -430,6 +430,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
         ls.getLogAppenders().map(LogAppender::getFollower).forEach(f ->
             leader.addFollowerInfo(ServerProtoUtils.toServerRpcProto(
                 f.getPeer(), f.getLastRpcResponseTime().elapsedTimeMs())));
+        leader.setTerm(ls.getCurrentTerm());
         roleInfo.setLeaderInfo(leader);
       });
       break;


### PR DESCRIPTION
## What changes were proposed in this pull request?

During SCM-HA, SCM not only needs to know whether it is a leader, but also needs to know which term it is in charge of.

Assume such a case: underlying raft node was leader on term 1, then step down as follower on term 2, then init election and become leader again on term 3. If term is not exposed together with leader information, SCM can not distinguish a leader of term 1 from that of term 3.
 
BTW, according to nanda's design, leader SCM need propagate its term to Datanode, `RaftServerImpl::getRoleInfoProto()` will be a good place to expose term from Ratis to SCM

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1001

## How was this patch tested?

CI
