### PR TITLE
RATIS-1006. Exclude Netty 3.10 from Ratis dependencies.

### DIFF
--- a/ratis-hadoop/pom.xml
+++ b/ratis-hadoop/pom.xml
@@ -88,6 +88,12 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/ratis-logservice/pom.xml
+++ b/ratis-logservice/pom.xml
@@ -187,6 +187,12 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- CLI dependencies -->
@@ -268,6 +274,12 @@
       <version>${hadoop.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -282,6 +294,12 @@
       <artifactId>hadoop-hdfs</artifactId>
       <version>${hadoop.version}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -289,6 +307,12 @@
       <version>${hadoop.version}</version>
       <scope>test</scope>
       <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Exclude Netty version 3.10 from Ratis dependency. This gets added as a transitive dependency from Hadoop

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1006

## How was this patch tested?
Build succeeds.
