### PR TITLE
RATIS-1007. Add try catch in AutoCloseableLock to avoid can not unlock

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/AutoCloseableLock.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/AutoCloseableLock.java
@@ -40,8 +40,13 @@ public final class AutoCloseableLock implements AutoCloseable {
   }
 
   public static AutoCloseableLock acquire(final Lock lock, Runnable preUnlock) {
-    lock.lock();
-    return new AutoCloseableLock(lock, preUnlock);
+    try {
+      lock.lock();
+      return new AutoCloseableLock(lock, preUnlock);
+    } catch (Throwable t) {
+      lock.unlock();
+      throw t;
+    }
   }
 
   private final Lock underlying;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the following code, if `lock.lock()` succeed, but exception happen when `new AutoCloseableLock(lock, preUnlock)`,
the lock can not be unlock forever.

```
public static AutoCloseableLock acquire(final Lock lock, Runnable preUnlock) {
    lock.lock();
    return new AutoCloseableLock(lock, preUnlock);
 }
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1007

## How was this patch tested?

Existed ut
