### PR TITLE
RATIS-1008: SimpleStateMachine4Testing#blockWriteStateMachineData should not block heartbeats

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
@@ -61,6 +61,8 @@ import java.util.TreeMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -77,6 +79,7 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
       = "raft.test.simple.state.machine.take.snapshot";
   private static final boolean RAFT_TEST_SIMPLE_STATE_MACHINE_TAKE_SNAPSHOT_DEFAULT = false;
   private boolean notifiedAsLeader;
+  private final Executor executor = Executors.newCachedThreadPool();
 
   public static SimpleStateMachine4Testing get(RaftServerImpl s) {
     return (SimpleStateMachine4Testing)s.getStateMachine();
@@ -358,20 +361,26 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
 
   @Override
   public CompletableFuture<Void> write(LogEntryProto entry) {
-    blocking.await(Blocking.Type.WRITE_STATE_MACHINE_DATA);
-    return CompletableFuture.completedFuture(null);
+    return CompletableFuture.supplyAsync(() -> {
+      blocking.await(Blocking.Type.WRITE_STATE_MACHINE_DATA);
+      return null;
+    }, executor);
   }
 
   @Override
   public CompletableFuture<ByteString> read(LogEntryProto entry) {
-    blocking.await(Blocking.Type.READ_STATE_MACHINE_DATA);
-    return CompletableFuture.completedFuture(STATE_MACHINE_DATA);
+    return CompletableFuture.supplyAsync(() -> {
+      blocking.await(Blocking.Type.READ_STATE_MACHINE_DATA);
+      return null;
+    }, executor);
   }
 
   @Override
   public CompletableFuture<Void> flush(long index) {
-    blocking.await(Blocking.Type.FLUSH_STATE_MACHINE_DATA);
-    return CompletableFuture.completedFuture(null);
+    return CompletableFuture.supplyAsync(() -> {
+      blocking.await(Blocking.Type.FLUSH_STATE_MACHINE_DATA);
+      return null;
+    }, executor);
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/retry/TestExceptionDependentRetry.java
+++ b/ratis-test/src/test/java/org/apache/ratis/retry/TestExceptionDependentRetry.java
@@ -195,7 +195,7 @@ public class TestExceptionDependentRetry implements MiniRaftClusterWithGrpc.Fact
       Assert.fail("Test should have failed.");
     } catch (ExecutionException e) {
       RaftRetryFailureException rrfe = (RaftRetryFailureException) e.getCause();
-      Assert.assertEquals(6, rrfe.getAttemptCount());
+      Assert.assertEquals(16, rrfe.getAttemptCount());
     } finally {
       ((SimpleStateMachine4Testing)leader.getStateMachine()).unblockWriteStateMachineData();
       cluster.shutdown();

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -522,18 +522,22 @@ public class TestSegmentedRaftLog extends BaseTest {
 
       sm.blockFlushStateMachineData();
       raftLog.appendEntry(entries.get(next++));
-      {
-        sm.blockWriteStateMachineData();
-        final Thread t = startAppendEntryThread(raftLog, entries.get(next++));
-        TimeUnit.SECONDS.sleep(1);
-        Assert.assertTrue(t.isAlive());
-        sm.unblockWriteStateMachineData();
-      }
+
+      sm.blockWriteStateMachineData();
+      final Thread t = startAppendEntryThread(raftLog, entries.get(next++));
+      TimeUnit.SECONDS.sleep(1);
+      Assert.assertTrue(t.isAlive());
+      sm.unblockWriteStateMachineData();
+
       assertIndices(raftLog, flush, next);
       TimeUnit.SECONDS.sleep(1);
       assertIndices(raftLog, flush, next);
       sm.unblockFlushStateMachineData();
       assertIndicesMultipleAttempts(raftLog, flush + 2, next);
+
+      // raftLog.appendEntry(entry).get() won't return
+      // until sm.unblockFlushStateMachineData() was called.
+      t.join();
     }
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -522,20 +522,18 @@ public class TestSegmentedRaftLog extends BaseTest {
 
       sm.blockFlushStateMachineData();
       raftLog.appendEntry(entries.get(next++));
-
-      sm.blockWriteStateMachineData();
-      final Thread t = startAppendEntryThread(raftLog, entries.get(next++));
-      TimeUnit.SECONDS.sleep(1);
-      Assert.assertTrue(t.isAlive());
-      sm.unblockWriteStateMachineData();
-
+      {
+        sm.blockWriteStateMachineData();
+        final Thread t = startAppendEntryThread(raftLog, entries.get(next++));
+        TimeUnit.SECONDS.sleep(1);
+        Assert.assertTrue(t.isAlive());
+        sm.unblockWriteStateMachineData();
+      }
       assertIndices(raftLog, flush, next);
       TimeUnit.SECONDS.sleep(1);
       assertIndices(raftLog, flush, next);
       sm.unblockFlushStateMachineData();
       assertIndicesMultipleAttempts(raftLog, flush + 2, next);
-
-      t.join();
     }
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -522,19 +522,20 @@ public class TestSegmentedRaftLog extends BaseTest {
 
       sm.blockFlushStateMachineData();
       raftLog.appendEntry(entries.get(next++));
-      {
-        sm.blockWriteStateMachineData();
-        final Thread t = startAppendEntryThread(raftLog, entries.get(next++));
-        TimeUnit.SECONDS.sleep(1);
-        Assert.assertTrue(t.isAlive());
-        sm.unblockWriteStateMachineData();
-        t.join();
-      }
+
+      sm.blockWriteStateMachineData();
+      final Thread t = startAppendEntryThread(raftLog, entries.get(next++));
+      TimeUnit.SECONDS.sleep(1);
+      Assert.assertTrue(t.isAlive());
+      sm.unblockWriteStateMachineData();
+
       assertIndices(raftLog, flush, next);
       TimeUnit.SECONDS.sleep(1);
       assertIndices(raftLog, flush, next);
       sm.unblockFlushStateMachineData();
       assertIndicesMultipleAttempts(raftLog, flush + 2, next);
+
+      t.join();
     }
   }
 
@@ -588,7 +589,13 @@ public class TestSegmentedRaftLog extends BaseTest {
   }
 
   static Thread startAppendEntryThread(RaftLog raftLog, LogEntryProto entry) {
-    final Thread t = new Thread(() -> raftLog.appendEntry(entry));
+    final Thread t = new Thread(() -> {
+      try {
+        raftLog.appendEntry(entry).get();
+      } catch (Throwable e) {
+        // just ignore
+      }
+    });
     t.start();
     return t;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

If raft server use Grpc, when append entries blocked at follower side (e.g., by calling SimpleStateMachine4Testing::blockWriteStateMachineData), leader should still be able to send heartbeat (size of entries of append entries request be 0) to followers, and receive response of heartbeat from follower side.

But test case "testUpdateViaHeartbeat" shows that after calling SimpleStateMachine4Testing::blockWriteStateMachineData, leader do send heartbeats, but ServerRequestStreamObserver::onNext at GrpcServerProtocolService was not called, until follower finish handling the append entries request that blocked by blockWriteStateMachineData.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/RATIS/issues/RATIS-1008

## How was this patch tested?

CI
