### PR TITLE
RATIS-993. Support pre vote

### DIFF
--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -152,6 +152,7 @@ message RequestVoteRequestProto {
   RaftRpcRequestProto serverRequest = 1;
   uint64 candidateTerm = 2;
   TermIndexProto candidateLastEntry = 3;
+  bool preVote = 4;
 }
 
 message RequestVoteReplyProto {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
@@ -86,7 +86,7 @@ class FollowerState extends Daemon {
     return outstandingOp.get();
   }
 
-  boolean shouldWithholdVotes() {
+  boolean isCurrentLeaderValid() {
     return lastRpcTime.elapsedTime().compareTo(server.properties().minRpcTimeout()) < 0;
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
@@ -134,7 +134,7 @@ class FollowerState extends Daemon {
                 this, lastRpcTime.elapsedTime(), electionTimeout);
             server.getLeaderElectionMetrics().onLeaderElectionTimeout(); // Update timeout metric counters.
             // election timeout, should become a candidate
-            server.changeToCandidate();
+            server.changeToCandidate(false);
             break;
           }
         }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -64,10 +64,14 @@ class LeaderElection implements Runnable {
 
   private ResultAndTerm logAndReturn(Result result,
       Map<RaftPeerId, RequestVoteReplyProto> responses,
-      List<Exception> exceptions, long newTerm) {
-    LOG.info(this + ": Election " + result + "; received " + responses.size() + " response(s) "
-        + responses.values().stream().map(ServerStringUtils::toRequestVoteReplyString).collect(Collectors.toList())
-        + " and " + exceptions.size() + " exception(s); " + server.getState());
+      List<Exception> exceptions, long newTerm, boolean preVote) {
+    LOG.info("{}: {} {} received {} response(s):{}",
+        this,
+        preVote ? "Pre vote " : "Election ",
+        result,
+        responses.size(),
+        responses.values().stream().map(ServerStringUtils::toRequestVoteReplyString).collect(Collectors.toList()));
+
     int i = 0;
     for(Exception e : exceptions) {
       final int j = i++;
@@ -165,8 +169,21 @@ class LeaderElection implements Runnable {
 
     Timer.Context electionContext =
         server.getLeaderElectionMetrics().getLeaderElectionTimer().time();
+    boolean preVotePass = false;
     try {
-      askForVotes();
+      /**
+       * See the thesis section 9.6: In the Pre-Vote algorithm, a candidate
+       * only increments its term and start a real election if it first learns
+       * from a majority of the cluster that they would be willing to grant
+       * the candidate their votes (if the candidate’s log is sufficiently
+       * up-to-date, and the voters have not received heartbeats from a valid
+       * leader for at least a baseline election timeout).
+       */
+      preVotePass = askForPreVotes();
+
+      if (preVotePass) {
+        askForVotes();
+      }
     } catch(Exception e) {
       final LifeCycle.State state = lifeCycle.getCurrentState();
       if (state.isClosingOrClosed()) {
@@ -198,8 +215,79 @@ class LeaderElection implements Runnable {
     return shouldRun() && server.getState().getCurrentTerm() == electionTerm;
   }
 
+  private ResultAndTerm submitRequestAndWaitResult(
+      final ServerState state, final RaftConfigurationImpl conf, final long electionTerm, boolean preVote)
+      throws InterruptedException {
+    final ResultAndTerm r;
+    final Collection<RaftPeer> others = conf.getOtherPeers(server.getId());
+    if (others.isEmpty()) {
+      r = new ResultAndTerm(Result.PASSED, electionTerm);
+    } else {
+      TermIndex lastEntry = state.getLastEntry();
+      final Executor voteExecutor = new Executor(this, others.size());
+      try {
+        final int submitted = submitRequests(electionTerm, lastEntry, others, voteExecutor, preVote);
+        r = waitForResults(electionTerm, submitted, conf, voteExecutor, preVote);
+      } finally {
+        voteExecutor.shutdown();
+      }
+    }
+
+    return r;
+  }
+
   /**
    * After a peer changes its role to candidate, it invokes this method to
+   * send out requestVote rpc to all other peers.
+   */
+  private boolean askForPreVotes() throws InterruptedException, IOException {
+    final ServerState state = server.getState();
+    if (shouldRun()) {
+      // one round of request pre votes
+      final long electionTerm;
+      final RaftConfigurationImpl conf;
+      synchronized (server) {
+        if (!shouldRun()) {
+          return false;
+        }
+        state.setLeader(null, "initPreVote");
+        conf = state.getRaftConf();
+        electionTerm = state.getCurrentTerm();
+      }
+
+      LOG.info("{}: begin a pre vote at term {} for {}", this, electionTerm, conf);
+      final ResultAndTerm r = submitRequestAndWaitResult(state, conf, electionTerm, true);
+      LOG.info("{} pre votes result is {}.", this, r.result);
+
+      synchronized (server) {
+        if (!shouldRun(electionTerm)) {
+          return false; // term already passed or this should not run anymore.
+        }
+
+        switch (r.result) {
+          case PASSED:
+            return true;
+          case REJECTED:
+          case TIMEOUT:
+            server.changeToFollowerAndPersistMetadata(state.getCurrentTerm(), r.result);
+            return false;
+          case SHUTDOWN:
+            LOG.info("{} received shutdown response when requesting pre votes.", this);
+            server.getRaftServer().close();
+            return false;
+          case DISCOVERED_A_NEW_TERM:
+            LOG.error("{} should not happen {} when requesting pre votes.", this, r.result);
+            return false;
+          default: throw new IllegalArgumentException("Unable to process result " + r.result);
+        }
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * After a peer changes its role to candidate and pass pre vote, it invokes this method to
    * send out requestVote rpc to all other peers.
    */
   private void askForVotes() throws InterruptedException, IOException {
@@ -218,21 +306,7 @@ class LeaderElection implements Runnable {
       }
       LOG.info("{}: begin an election at term {} for {}", this, electionTerm, conf);
 
-      TermIndex lastEntry = state.getLastEntry();
-
-      final ResultAndTerm r;
-      final Collection<RaftPeer> others = conf.getOtherPeers(server.getId());
-      if (others.isEmpty()) {
-        r = new ResultAndTerm(Result.PASSED, electionTerm);
-      } else {
-        final Executor voteExecutor = new Executor(this, others.size());
-        try {
-          final int submitted = submitRequests(electionTerm, lastEntry, others, voteExecutor);
-          r = waitForResults(electionTerm, submitted, conf, voteExecutor);
-        } finally {
-          voteExecutor.shutdown();
-        }
-      }
+      final ResultAndTerm r = submitRequestAndWaitResult(state, conf, electionTerm, false);
 
       synchronized (server) {
         if (!shouldRun(electionTerm)) {
@@ -261,11 +335,11 @@ class LeaderElection implements Runnable {
   }
 
   private int submitRequests(final long electionTerm, final TermIndex lastEntry,
-      Collection<RaftPeer> others, Executor voteExecutor) {
+      Collection<RaftPeer> others, Executor voteExecutor, boolean preVote) {
     int submitted = 0;
     for (final RaftPeer peer : others) {
       final RequestVoteRequestProto r = ServerProtoUtils.toRequestVoteRequestProto(
-          server.getMemberId(), peer.getId(), electionTerm, lastEntry);
+          server.getMemberId(), peer.getId(), electionTerm, lastEntry, preVote);
       voteExecutor.submit(() -> server.getServerRpc().requestVote(r));
       submitted++;
     }
@@ -288,7 +362,7 @@ class LeaderElection implements Runnable {
   }
 
   private ResultAndTerm waitForResults(final long electionTerm, final int submitted,
-      RaftConfigurationImpl conf, Executor voteExecutor) throws InterruptedException {
+      RaftConfigurationImpl conf, Executor voteExecutor, boolean preVote) throws InterruptedException {
     final Timestamp timeout = Timestamp.currentTime().addTime(server.getRandomElectionTimeout());
     final Map<RaftPeerId, RequestVoteReplyProto> responses = new HashMap<>();
     final List<Exception> exceptions = new ArrayList<>();
@@ -303,9 +377,9 @@ class LeaderElection implements Runnable {
         if (conf.hasMajority(votedPeers, server.getId())) {
           // if some higher priority peer did not response when timeout, but candidate get majority,
           // candidate pass vote
-          return logAndReturn(Result.PASSED, responses, exceptions, -1);
+          return logAndReturn(Result.PASSED, responses, exceptions, -1, preVote);
         } else {
-          return logAndReturn(Result.TIMEOUT, responses, exceptions, -1);
+          return logAndReturn(Result.TIMEOUT, responses, exceptions, -1, preVote);
         }
       }
 
@@ -328,16 +402,16 @@ class LeaderElection implements Runnable {
           continue;
         }
         if (r.getShouldShutdown()) {
-          return logAndReturn(Result.SHUTDOWN, responses, exceptions, -1);
+          return logAndReturn(Result.SHUTDOWN, responses, exceptions, -1, preVote);
         }
-        if (r.getTerm() > electionTerm) {
+        if (!preVote && r.getTerm() > electionTerm) {
           return logAndReturn(Result.DISCOVERED_A_NEW_TERM, responses,
-              exceptions, r.getTerm());
+              exceptions, r.getTerm(), false);
         }
 
         // If any peer with higher priority rejects vote, candidate can not pass vote
         if (!r.getServerReply().getSuccess() && higherPriorityPeers.contains(replierId)) {
-          return logAndReturn(Result.REJECTED, responses, exceptions, -1);
+          return logAndReturn(Result.REJECTED, responses, exceptions, -1, preVote);
         }
 
         // remove higher priority peer, so that we check higherPriorityPeers empty to make sure
@@ -348,12 +422,12 @@ class LeaderElection implements Runnable {
           votedPeers.add(replierId);
           // If majority and all peers with higher priority have voted, candidate pass vote
           if (higherPriorityPeers.size() == 0 && conf.hasMajority(votedPeers, server.getId())) {
-            return logAndReturn(Result.PASSED, responses, exceptions, -1);
+            return logAndReturn(Result.PASSED, responses, exceptions, -1, preVote);
           }
         } else {
           rejectedPeers.add(replierId);
           if (conf.majorityRejectVotes(rejectedPeers)) {
-            return logAndReturn(Result.REJECTED, responses, exceptions, -1);
+            return logAndReturn(Result.REJECTED, responses, exceptions, -1, preVote);
           }
         }
       } catch(ExecutionException e) {
@@ -364,9 +438,9 @@ class LeaderElection implements Runnable {
     }
     // received all the responses
     if (conf.hasMajority(votedPeers, server.getId())) {
-      return logAndReturn(Result.PASSED, responses, exceptions, -1);
+      return logAndReturn(Result.PASSED, responses, exceptions, -1, preVote);
     } else {
-      return logAndReturn(Result.REJECTED, responses, exceptions, -1);
+      return logAndReturn(Result.REJECTED, responses, exceptions, -1, preVote);
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1000,7 +1000,7 @@ class RaftServerImpl implements RaftServer.Division,
     } else {
       // following a leader and not yet timeout
       return getInfo().isFollower() && state.hasLeader()
-          && role.getFollowerState().map(FollowerState::shouldWithholdVotes).orElse(false);
+          && role.getFollowerState().map(FollowerState::isCurrentLeaderValid).orElse(false);
     }
   }
 
@@ -1026,10 +1026,84 @@ class RaftServerImpl implements RaftServer.Division,
   public RequestVoteReplyProto requestVote(RequestVoteRequestProto r)
       throws IOException {
     final RaftRpcRequestProto request = r.getServerRequest();
-    return requestVote(RaftPeerId.valueOf(request.getRequestorId()),
-        ProtoUtils.toRaftGroupId(request.getRaftGroupId()),
-        r.getCandidateTerm(),
-        TermIndex.valueOf(r.getCandidateLastEntry()));
+    if (r.getPreVote()) {
+      return requestPreVote(RaftPeerId.valueOf(request.getRequestorId()),
+          ProtoUtils.toRaftGroupId(request.getRaftGroupId()),
+          r.getCandidateTerm(),
+          TermIndex.valueOf(r.getCandidateLastEntry()));
+    } else {
+      return requestVote(RaftPeerId.valueOf(request.getRequestorId()),
+          ProtoUtils.toRaftGroupId(request.getRaftGroupId()),
+          r.getCandidateTerm(),
+          TermIndex.valueOf(r.getCandidateLastEntry()));
+    }
+  }
+
+  private boolean isCurrentLeaderValid() {
+    if (getInfo().isLeader()) {
+      return role.getLeaderState().map(LeaderStateImpl::checkLeadership).orElse(false);
+    } else if (getInfo().isFollower()) {
+      return state.hasLeader()
+          && role.getFollowerState().map(FollowerState::isCurrentLeaderValid).orElse(false);
+    } else if (getInfo().isCandidate()) {
+      return false;
+    }
+
+    return false;
+  }
+
+  private RequestVoteReplyProto requestPreVote(
+      RaftPeerId candidateId, RaftGroupId candidateGroupId,
+      long candidateTerm, TermIndex candidateLastEntry) throws IOException {
+    CodeInjectionForTesting.execute(REQUEST_VOTE, getId(),
+        candidateId, candidateTerm, candidateLastEntry);
+    LOG.info("{}: receive preVote({}, {}, {}, {})",
+        getMemberId(), candidateId, candidateGroupId, candidateTerm, candidateLastEntry);
+    assertLifeCycleState(LifeCycle.States.RUNNING);
+    assertGroup(candidateId, candidateGroupId);
+
+    boolean preVoteGranted = false;
+    boolean shouldShutdown = false;
+    final RequestVoteReplyProto reply;
+    synchronized (this) {
+      boolean isCurrentLeaderValid = isCurrentLeaderValid();
+      RaftPeer candidate = getRaftConf().getPeer(candidateId);
+
+      if (candidate != null) {
+        int compare = ServerState.compareLog(state.getLastEntry(), candidateLastEntry);
+        int priority = getRaftConf().getPeer(getId()).getPriority();
+        LOG.info("{} priority:{} candidate:{} candidatePriority:{} compare:{}",
+            this, priority, candidate, candidate.getPriority(), compare);
+
+        // vote for candidate if:
+        // 1. current leader is not valid
+        // 2. log lags behind candidate or
+        //    log equals candidate's, and priority less or equal candidate's
+        if (!isCurrentLeaderValid &&
+            (compare < 0 || (compare == 0 && priority <= candidate.getPriority()))) {
+          preVoteGranted = true;
+          LOG.info("{} role:{} allow pre vote from:{}", getMemberId(), getRole(), candidateId);
+        } else {
+          LOG.info("{} role:{} reject pre vote from:{} because compare:{} isCurrentLeaderValid:{}",
+              getMemberId(), getRole(), candidateId, compare, isCurrentLeaderValid);
+        }
+      }
+
+      if (preVoteGranted) {
+        final FollowerState fs = role.getFollowerState().orElse(null);
+        if (fs != null) {
+          fs.updateLastRpcTime(FollowerState.UpdateType.REQUEST_VOTE);
+        }
+      } else if(shouldSendShutdown(candidateId, candidateLastEntry)) {
+        shouldShutdown = true;
+      }
+
+      reply = ServerProtoUtils.toRequestVoteReplyProto(candidateId, getMemberId(),
+          preVoteGranted, state.getCurrentTerm(), shouldShutdown);
+      LOG.info("{} replies to pre vote request: {}. Peer's state: {}",
+          getMemberId(), ServerStringUtils.toRequestVoteReplyString(reply), state);
+    }
+    return reply;
   }
 
   private RequestVoteReplyProto requestVote(

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
@@ -111,8 +111,8 @@ class RoleInfo {
     }
   }
 
-  void startLeaderElection(RaftServerImpl server) {
-    updateAndGet(leaderElection, new LeaderElection(server)).start();
+  void startLeaderElection(RaftServerImpl server, boolean force) {
+    updateAndGet(leaderElection, new LeaderElection(server, force)).start();
   }
 
   void shutdownLeaderElection() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
@@ -50,10 +50,11 @@ final class ServerProtoUtils {
   }
 
   static RequestVoteRequestProto toRequestVoteRequestProto(
-      RaftGroupMemberId requestorId, RaftPeerId replyId, long term, TermIndex lastEntry) {
+      RaftGroupMemberId requestorId, RaftPeerId replyId, long term, TermIndex lastEntry, boolean preVote) {
     final RequestVoteRequestProto.Builder b = RequestVoteRequestProto.newBuilder()
         .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId))
-        .setCandidateTerm(term);
+        .setCandidateTerm(term)
+        .setPreVote(preVote);
     Optional.ofNullable(lastEntry).map(TermIndex::toProto).ifPresent(b::setCandidateLastEntry);
     return b.build();
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -60,6 +60,7 @@ import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECT
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -361,6 +362,46 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
       assertEquals(LifeCycle.State.CLOSED, subject.getCurrentState());
     } catch (Exception e) {
       LOG.info("Error starting LeaderElection", e);
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testPreVote() {
+    try(final MiniRaftCluster cluster = newCluster(3)) {
+      cluster.start();
+
+      RaftServer.Division leader = waitForLeader(cluster);
+      final long savedTerm = leader.getInfo().getCurrentTerm();
+
+      try (RaftClient client = cluster.createClient(leader.getId())) {
+        client.io().send(new RaftTestUtil.SimpleMessage("message"));
+
+        final List<RaftServer.Division> followers = cluster.getFollowers();
+        assertEquals(followers.size(), 2);
+
+        RaftServer.Division follower = followers.get(0);
+        isolate(cluster, follower.getId());
+        // send message so that the isolated follower's log lag the others
+        client.io().send(new RaftTestUtil.SimpleMessage("message"));
+
+        // wait follower timeout and trigger pre vote
+        Thread.sleep(2000);
+        deIsolate(cluster, follower.getId());
+        Thread.sleep(2000);
+        // with pre vote leader will not step down
+        RaftServer.Division newleader = waitForLeader(cluster);
+        assertNotNull(newleader);
+        assertEquals(newleader.getId(), leader.getId());
+        // with pre vote, term will not change
+        assertEquals(leader.getInfo().getCurrentTerm(), savedTerm);
+
+        RaftClientReply reply = client.io().send(new RaftTestUtil.SimpleMessage("message"));
+        Assert.assertTrue(reply.isSuccess());
+      }
+
+      cluster.shutdown();
+    } catch (Exception e) {
       fail(e.getMessage());
     }
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedRequestReply.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedRequestReply.java
@@ -134,7 +134,6 @@ class SimulatedRequestReply<REQUEST extends RaftRpcMessage, REPLY extends RaftRp
     REQUEST request;
     try {
       // delay request for testing
-      RaftTestUtil.delay(q.delayTakeRequestTo::get);
       while (true) {
         request = q.takeRequest();
         Preconditions.assertTrue(qid.equals(request.getReplierId()));
@@ -149,6 +148,7 @@ class SimulatedRequestReply<REQUEST extends RaftRpcMessage, REPLY extends RaftRp
         }
         break;
       }
+      RaftTestUtil.delay(q.delayTakeRequestTo::get);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw IOUtils.toInterruptedIOException("", e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Implement **Preventing disruptions when a server rejoins the cluster** according to raft paper section 9.6.

2. In ozone, rejoin happen easily because the unstable network, for example sometimes one server's network is slow, it will try to trigger election, but which is unnecessary,  this can be prevented by this PR.

3. In this PR, before follower trigger leader election, it send pre-vote request to the other servers, if other server allow the follower to trigger leader election, it reply PASSED to the pre-vote request. If majority of the other servers allow the follower trigger leader election, the follower will trigger leader election.

4. The other server allow the follower to trigger leader election only when 1. the voters have not received heartbeats from a valid leader for at least a baseline election timeout. and 2. the follower's log is newer than voter's, or the follower's log is equal to voter's and follower's priority is not less than voter's
 
5. If the above condition can not satisfied, even though the follower trigger leader election, it can not be elected as a leader but it can step down the leader by it's bigger term, so we do not allow it trigger leader election.

6. If the follower is not in the conf, we will shutdown the follower.

Details of the paper:
```
One downside of Raft’s leader election algorithm is that a server that has been partitioned from the
cluster is likely to cause a disruption when it regains connectivity. When a server is partitioned, it
will not receive heartbeats. It will soon increment its term to start an election, although it won’t
be able to collect enough votes to become leader. When the server regains connectivity sometime
later, its larger term number will propagate to the rest of the cluster (either through the server’s
RequestVote requests or through its AppendEntries response). This will force the cluster leader to
step down, and a new election will have to take place to select a new leader. Fortunately, such events
are likely to be rare, and each will only cause one leader to step down.

If desired, Raft’s basic leader election algorithm can be extended with an additional phase to
prevent such disruptions, forming the Pre-Vote algorithm. In the Pre-Vote algorithm, a candidate
only increments its term if it first learns from a majority of the cluster that they would be willing
to grant the candidate their votes (if the candidate’s log is sufficiently up-to-date, and the voters
have not received heartbeats from a valid leader for at least a baseline election timeout). This was
inspired by ZooKeeper’s algorithm [42], in which a server must receive a majority of votes before
it calculates a new epoch and sends NewEpoch messages (however, in ZooKeeper servers do not
solicit votes, other servers offer them).

The Pre-Vote algorithm solves the issue of a partitioned server disrupting the cluster when it
rejoins. While a server is partitioned, it won’t be able to increment its term, since it can’t receive
permission from a majority of the cluster. Then, when it rejoins the cluster, it still won’t be able
to increment its term, since the other servers will have been receiving regular heartbeats from the
leader. Once the server receives a heartbeat from the leader itself, it will return to the follower state
(in the same term).

We recommend the Pre-Vote extension in deployments that would benefit from additional robustness.
We also tested it in various leader election scenarios in AvailSim, and it does not appear
to significantly harm election performance.

```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-993

## How was this patch tested?

add ut: testPreVote
