### PR TITLE
RATIS-1018. Fix Failed UT: testGroupInfo

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupInfoBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupInfoBaseTest.java
@@ -89,9 +89,7 @@ public abstract class GroupInfoBaseTest<CLUSTER extends MiniRaftCluster>
       // send more messages and check last reply
       final RaftClientReply reply = sendMessages(numMessages, cluster);
       for(CommitInfoProto i : reply.getCommitInfos()) {
-        if (RaftPeerId.valueOf(i.getServer().getId()).equals(killedFollower)) {
-          Assert.assertTrue(i.getCommitIndex() <= maxCommit);
-        } else {
+        if (!RaftPeerId.valueOf(i.getServer().getId()).equals(killedFollower)) {
           Assert.assertTrue(i.getCommitIndex() > maxCommit);
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove following assert
```
if (RaftPeerId.valueOf(i.getServer().getId()).equals(killedFollower)) {
   Assert.assertTrue(i.getCommitIndex() <= maxCommit);
}
```

As the image shows, `killedFollower` is s0, after client receive RaftClientReply, s0 can still increase commit index if it receive metadata entry, then the commit index of s0 maybe greater than the max index in RaftClientReply.

![image](https://user-images.githubusercontent.com/51938049/89276864-b8045c80-d676-11ea-944b-4f3a01783c8f.png)

![image](https://user-images.githubusercontent.com/51938049/89276878-bc307a00-d676-11ea-8c44-4c42e2202feb.png)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1018

## How was this patch tested?

No need to add unit tests.
