### PR TITLE
RATIS-1021. Fix failed UT: testMultipleLinearRandomRetry

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/retry/TestMultipleLinearRandomRetry.java
+++ b/ratis-test/src/test/java/org/apache/ratis/retry/TestMultipleLinearRandomRetry.java
@@ -60,6 +60,7 @@ public class TestMultipleLinearRandomRetry extends BaseTest {
 
   @Test
   public void testMultipleLinearRandomRetry() {
+    double precision = 0.00000001;
     final int[] counts = {10, 20, 30};
     final TimeDuration[] times = {HUNDRED_MILLIS, ONE_SECOND, FIVE_SECONDS};
     final MultipleLinearRandomRetry r = assertLegalInput("[10x100ms, 20x1s, 30x5s]", "100ms,10, 1s,20, 5s,30");
@@ -74,7 +75,7 @@ public class TestMultipleLinearRandomRetry extends BaseTest {
         final long d = expected.getDuration();
         LOG.info("times[{},{}] = {}, randomized={}", i, j, times[i], randomized);
         Assert.assertTrue(randomized.getDuration() >= d*0.5);
-        Assert.assertTrue(randomized.getDuration() < d*1.5);
+        Assert.assertTrue(randomized.getDuration() < (d*1.5 + precision));
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
`randomized.getDuration()` got from the following code, i.e. `rounded`. `multiplier` is a double value less than 1.5 in the test, such as 1.4999999, `duration` is 1000, then `product` will be 1499.9999, so `rounded` will be 1500, which is not less than `d*1.5`, i.e. 1500.

![image](https://user-images.githubusercontent.com/51938049/89360621-99947480-d6fb-11ea-8bcd-8f072f66780d.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1021

## How was this patch tested?

No need to add ut.
