### PR TITLE
RATIS-1022. Clear servers when shutdown MiniRaftCluster

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/MiniRaftCluster.java
@@ -723,6 +723,9 @@ public abstract class MiniRaftCluster implements Closeable {
 
     Optional.ofNullable(timer.get()).ifPresent(Timer::cancel);
     ExitUtils.assertNotTerminated();
+
+    servers.clear();
+    
     LOG.info(getClass().getSimpleName() + " shutdown completed");
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

clear `servers` when shutdown MiniRaftCluster.
Otherwise, if we need to run test, for example `testMultiRaftGroup`, several times to debug, the second time will fail at `Preconditions.assertTrue(servers.put(id, s) == null);`.

![image](https://user-images.githubusercontent.com/51938049/89363585-2989ec80-d703-11ea-86d4-23b152eb87e9.png)

![image](https://user-images.githubusercontent.com/51938049/89363540-095a2d80-d703-11ea-8718-f461e949f30c.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1022

## How was this patch tested?

No need to add test.
