### PR TITLE
RATIS-1023.During installing snapshot, when snapshot file is corrup…

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.util;
 
+import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.function.CheckedSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -143,5 +144,12 @@ public interface FileUtils {
         return FileVisitResult.CONTINUE;
       }
     });
+  }
+
+  // Rename a file by appending .corrupt to file name. This function does not guarantee
+  // that the rename operation is successful.
+  static void renameFileToCorrupt(File tmpSnapshotFile) {
+    File corruptedTempFile = new File(tmpSnapshotFile.getPath() + ".corrupt");
+    tmpSnapshotFile.renameTo(corruptedTempFile);
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ratis.util;
 
-import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.function.CheckedSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ratis-common/src/test/java/org/apache/ratis/util/FileUtilsTest.java
+++ b/ratis-common/src/test/java/org/apache/ratis/util/FileUtilsTest.java
@@ -15,17 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ratis.server.storage;
+package org.apache.ratis.util;
 
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import org.apache.ratis.util.FileUtils;
 import org.junit.Test;
 
 /** Test methods of SnapshotManager. */
-public class SnapshotManagerTest {
+public class FileUtilsTest {
 
   @Test
   public void testRenameToCorrupt() throws IOException {
@@ -34,7 +33,7 @@ public class SnapshotManagerTest {
     if (corruptFile.exists()) {
       FileUtils.deleteFully(corruptFile);
     }
-    SnapshotManager.renameFileToCorrupt(srcFile);
+    FileUtils.renameFileToCorrupt(srcFile);
     srcFile.deleteOnExit();
     corruptFile.deleteOnExit();
     assertTrue(corruptFile.exists());

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogServiceClient.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogServiceClient.java
@@ -72,7 +72,7 @@ public class LogServiceClient implements AutoCloseable {
     /**
      * Constuctor (with configuration). Build raft client for meta quorum
      * @param metaQuorum
-     * @param config log serice configuration
+     * @param config log service configuration
      * @param properties
      */
     public LogServiceClient(String metaQuorum, LogServiceConfiguration config, RaftProperties properties) {

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
@@ -120,7 +120,7 @@ public class TestMetaServer {
 
     @Before
     public void before() {
-        //ensure workers before each test
+        // ensure workers before each test
         if (workers.size() < 3) {
             cluster.createWorkers(3 - workers.size());
         }

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
@@ -29,7 +29,6 @@ import org.apache.ratis.proto.RaftProtos.FileChunkProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.statemachine.StateMachine;
-import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.MD5FileUtil;

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
@@ -118,7 +118,7 @@ public class SnapshotManager {
           LOG.warn("The snapshot md5 digest {} does not match expected {}",
               digest, expectedDigest);
           // rename the temp snapshot file to .corrupt
-          renameFileToCorrupt(tmpSnapshotFile);
+          FileUtils.renameFileToCorrupt(tmpSnapshotFile);
           throw new CorruptedFileException(
               tmpSnapshotFile, "MD5 mismatch for snapshot-" + lastIncludedIndex
               + " installation");
@@ -134,13 +134,5 @@ public class SnapshotManager {
       dir.getStateMachineDir().delete();
       tmpDir.renameTo(dir.getStateMachineDir());
     }
-  }
-
-  // Rename a file by appending .corrupt to file name. This function does not guarantee
-  // that the rename operation is successful.
-  @VisibleForTesting
-  static void renameFileToCorrupt(File tmpSnapshotFile) {
-    File corruptedTempFile = new File(tmpSnapshotFile.getPath() + ".corrupt");
-    tmpSnapshotFile.renameTo(corruptedTempFile);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
@@ -28,6 +28,7 @@ import org.apache.ratis.proto.RaftProtos.FileChunkProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.IOUtils;
 import org.apache.ratis.util.MD5FileUtil;
@@ -115,7 +116,8 @@ public class SnapshotManager {
         if (!digest.equals(expectedDigest)) {
           LOG.warn("The snapshot md5 digest {} does not match expected {}",
               digest, expectedDigest);
-          //TODO: rename the temp snapshot file to .corrupt
+          // rename the temp snapshot file to .corrupt
+          renameFileToCorrupt(tmpSnapshotFile);
           throw new IOException("MD5 mismatch for snapshot-" + lastIncludedIndex
               + " installation");
         } else {
@@ -130,5 +132,13 @@ public class SnapshotManager {
       dir.getStateMachineDir().delete();
       tmpDir.renameTo(dir.getStateMachineDir());
     }
+  }
+
+  // Rename a file by appending .corrupt to file name. This function does not guarantee
+  // that the rename operation is successful.
+  @VisibleForTesting
+  static void renameFileToCorrupt(File tmpSnapshotFile) {
+    File corruptedTempFile = new File(tmpSnapshotFile.getPath() + ".corrupt");
+    tmpSnapshotFile.renameTo(corruptedTempFile);
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
@@ -22,6 +22,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 
+import org.apache.ratis.io.CorruptedFileException;
 import org.apache.ratis.io.MD5Hash;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.proto.RaftProtos.FileChunkProto;
@@ -118,7 +119,8 @@ public class SnapshotManager {
               digest, expectedDigest);
           // rename the temp snapshot file to .corrupt
           renameFileToCorrupt(tmpSnapshotFile);
-          throw new IOException("MD5 mismatch for snapshot-" + lastIncludedIndex
+          throw new CorruptedFileException(
+              tmpSnapshotFile, "MD5 mismatch for snapshot-" + lastIncludedIndex
               + " installation");
         } else {
           MD5FileUtil.saveMD5File(tmpSnapshotFile, digest);

--- a/ratis-server/src/test/java/org/apache/ratis/server/storage/SnapshotManagerTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/storage/SnapshotManagerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.storage;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import org.junit.Test;
+
+/** Test methods of SnapshotManager. */
+public class SnapshotManagerTest {
+
+  @Test
+  public void testRenameToCorrupt() throws IOException {
+    File srcFile = File.createTempFile("snapshot.1_20", null);
+    File corruptFile = new File(srcFile.getPath() + ".corrupt");
+    if (corruptFile.exists()) {
+      corruptFile.delete();
+    }
+    SnapshotManager.renameFileToCorrupt(srcFile);
+    srcFile.deleteOnExit();
+    corruptFile.deleteOnExit();
+    assertTrue(corruptFile.exists());
+  }
+}

--- a/ratis-server/src/test/java/org/apache/ratis/server/storage/SnapshotManagerTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/storage/SnapshotManagerTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import org.apache.ratis.util.FileUtils;
 import org.junit.Test;
 
 /** Test methods of SnapshotManager. */
@@ -31,7 +32,7 @@ public class SnapshotManagerTest {
     File srcFile = File.createTempFile("snapshot.1_20", null);
     File corruptFile = new File(srcFile.getPath() + ".corrupt");
     if (corruptFile.exists()) {
-      corruptFile.delete();
+      FileUtils.deleteFully(corruptFile);
     }
     SnapshotManager.renameFileToCorrupt(srcFile);
     srcFile.deleteOnExit();


### PR DESCRIPTION
…ted, rename the temp snapshot file to .corrupt.

## What changes were proposed in this pull request?
It is possible that snapshot file contains corrupted data, in this case within `installSnapshot`, we can rename the temp snapshot file with `.corrupt` before throwing an exception.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1023

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
unit test
