### PR TITLE
RATIS-1025. Ratis logs may not be purged completely

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -508,7 +508,7 @@ public class SegmentedRaftLog extends RaftLog {
   public void close() throws IOException {
     try(AutoCloseableLock writeLock = writeLock()) {
       super.close();
-      cache.clear();
+      cache.close();
     }
     fileLogWorker.close();
     storage.close();

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -257,8 +257,7 @@ public class SegmentedRaftLog extends RaftLog {
       if (!cache.isEmpty() && cache.getEndIndex() < lastIndexInSnapshot) {
         LOG.warn("End log index {} is smaller than last index in snapshot {}",
             cache.getEndIndex(), lastIndexInSnapshot);
-        cache.clear();
-        // TODO purge all segment files
+        purgeImpl(lastIndexInSnapshot);
       }
     }
   }
@@ -487,7 +486,7 @@ public class SegmentedRaftLog extends RaftLog {
   @Override
   public void syncWithSnapshot(long lastSnapshotIndex) {
     fileLogWorker.syncWithSnapshot(lastSnapshotIndex);
-    // TODO purge log files and normal/tmp/corrupt snapshot files
+    // TODO purge normal/tmp/corrupt snapshot files
     // if the last index in snapshot is larger than the index of the last
     // log entry, we should delete all the log entries and their cache to avoid
     // gaps between log segments.
@@ -496,8 +495,8 @@ public class SegmentedRaftLog extends RaftLog {
     LogSegment openSegment = cache.getOpenSegment();
     if (openSegment != null && openSegment.getEndIndex() <= lastSnapshotIndex) {
       fileLogWorker.closeLogSegment(openSegment);
-      cache.clear();
     }
+    purgeImpl(lastSnapshotIndex);
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -246,7 +246,7 @@ public class SegmentedRaftLog extends RaftLog {
         // entries to the state machine
         boolean keepEntryInCache = (paths.size() - i++) <= cache.getMaxCachedSegments();
         final Timer.Context loadSegmentContext = getRaftLogMetrics().getRaftLogLoadSegmentTimer().time();
-        cache.loadSegment(pi, keepEntryInCache, logConsumer, lastIndexInSnapshot);
+        cache.loadSegment(pi, keepEntryInCache, logConsumer);
         loadSegmentContext.stop();
       }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -652,7 +652,7 @@ public class SegmentedRaftLogCache {
     return closedSegments.isEmpty() && openSegment == null;
   }
 
-  void clear() {
+  void close() {
     if (openSegment != null) {
       openSegment.clear();
       clearOpenSegment();

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -360,10 +360,10 @@ public class SegmentedRaftLogCache {
   }
 
   void loadSegment(LogPathAndIndex pi, boolean keepEntryInCache,
-      Consumer<LogEntryProto> logConsumer, long lastIndexInSnapshot) throws IOException {
+      Consumer<LogEntryProto> logConsumer) throws IOException {
     LogSegment logSegment = LogSegment.loadSegment(storage, pi.getPath().toFile(),
         pi.getStartIndex(), pi.getEndIndex(), pi.isOpen(), keepEntryInCache, logConsumer, raftLogMetrics);
-    if (logSegment != null && logSegment.getEndIndex() > lastIndexInSnapshot) {
+    if (logSegment != null) {
       addSegment(logSegment);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone Manager Ratis server tries to purge logs up to the snapshotIndex after a snapshot is taken. But it only purges the logs which have been cached in memory. This could lead to older logs not being purged and consuming disk space.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1025

## How was this patch tested?

Existing UT