### PR TITLE
RATIS-1029. NPE at MetricServerInterceptor.interceptCall

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerInterceptor.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerInterceptor.java
@@ -69,10 +69,8 @@ public class MetricServerInterceptor implements ServerInterceptor {
         identifier = defaultIdentifier;
       }
     }
-    else{
-         if(metrics == null){
-            metrics = new MessageMetrics(identifier, "server");
-         }
+    if (metrics == null) {
+      metrics = new MessageMetrics(identifier, "server");
     }
     String metricNamePrefix = getMethodMetricPrefix(method);
     ServerCall<R,S> monitoringCall = new MetricServerCall<>(call, metricNamePrefix, metrics);

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerInterceptor.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerInterceptor.java
@@ -62,14 +62,14 @@ public class MetricServerInterceptor implements ServerInterceptor {
       Metadata requestHeaders,
       ServerCallHandler<R, S> next) {
     MethodDescriptor<R, S> method = call.getMethodDescriptor();
-    if(identifier == null){
+    if (identifier == null) {
       try {
         identifier = peerIdSupplier.get().toString();
-      } catch (Exception e){
+      } catch (Exception e) {
         identifier = defaultIdentifier;
       }
-      metrics = new MessageMetrics(identifier, "server");
     }
+    metrics = new MessageMetrics(identifier, "server");
     String metricNamePrefix = getMethodMetricPrefix(method);
     ServerCall<R,S> monitoringCall = new MetricServerCall<>(call, metricNamePrefix, metrics);
     return new MetricServerCallListener<>(

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerInterceptor.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerInterceptor.java
@@ -69,7 +69,11 @@ public class MetricServerInterceptor implements ServerInterceptor {
         identifier = defaultIdentifier;
       }
     }
-    metrics = new MessageMetrics(identifier, "server");
+    else{
+         if(metrics == null){
+            metrics = new MessageMetrics(identifier, "server");
+         }
+    }
     String metricNamePrefix = getMethodMetricPrefix(method);
     ServerCall<R,S> monitoringCall = new MetricServerCall<>(call, metricNamePrefix, metrics);
     return new MetricServerCallListener<>(

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupInfoBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupInfoBaseTest.java
@@ -50,7 +50,7 @@ public abstract class GroupInfoBaseTest<CLUSTER extends MiniRaftCluster>
 
     List<RaftPeer> peers = cluster.getPeers();
 
-    //Multi-raft with the second group
+    // Multi-raft with the second group
     RaftGroup group2 = RaftGroup.valueOf(RaftGroupId.randomId(), peers);
     for(RaftPeer peer : peers) {
       try(final RaftClient client = cluster.createClient(peer.getId())) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
When identifier is not NULL, `metrics` variable will not be initialized: https://github.com/apache/incubator-ratis/blob/349c365e81d76b210df7a97704217178e3f7f826/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerInterceptor.java#L71


![Screen Shot 2020-08-08 at 10 51 24 PM](https://user-images.githubusercontent.com/1938382/89726036-e95c8f80-d9ca-11ea-9893-e9d59352efd2.png)


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1029

## How was this patch tested?

UT
