### PR TITLE
RATIS-1042. Watch for commit calls are blocked for a long if no other message

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
@@ -383,6 +383,7 @@ public class LeaderState {
       watchRequests.update(ReplicationLevel.MAJORITY_COMMITTED, m.majority);
       watchRequests.update(ReplicationLevel.MAJORITY, m.max);
     });
+    notifySenders();
   }
 
   private void applyOldNewConf() {


### PR DESCRIPTION
Co-authored-by: Elek Márton <elek@apache.org>

## What changes were proposed in this pull request?

The PR initiates heartbeat if follower's commitIndex lags from leader's commitIndex. This helps in faster resolution of any pending watch requests in the leader. 

It also changes the waitTimes for the appender thread so that the thread does not sleep for a long time while there are pending watch requests in leader.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1042

## How was this patch tested?

Existing UT and by running teragen for Ozone