### PR TITLE
RATIS-1041. Change client to try the servers according to the priority

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClient.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClient.java
@@ -42,6 +42,9 @@ public interface RaftClient extends Closeable {
   /** @return the id of this client. */
   ClientId getId();
 
+  /** @return the cluster leaderId recorded by this client. */
+  RaftPeerId getLeaderId();
+
   /** @return the client rpct. */
   RaftClientRpc getClientRpc();
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -112,6 +112,8 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     final RaftGroup newGroup = RaftGroup.valueOf(RaftGroupId.randomId(), peersWithPriority);
     LOG.info("add new group: " + newGroup);
     try (final RaftClient client = cluster.createClient(newGroup)) {
+      // Before request, client try leader with the highest priority
+      Assert.assertTrue(client.getLeaderId() == peersWithPriority.get(suggestedLeaderIndex).getId());
       for (RaftPeer p : newGroup.getPeers()) {
         client.groupAdd(newGroup, p.getId());
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change client to try the servers according to the priority

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1041

## How was this patch tested?

Check leader is the peer with highest priority as soon as create client. 
