### PR TITLE
RATIS-1047. Fix can not elect leader when higher priority server crash

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -348,7 +348,11 @@ class LeaderElection implements Runnable {
       waitForNum--;
     }
     // received all the responses
-    return logAndReturn(Result.REJECTED, responses, exceptions, -1);
+    if (conf.hasMajority(votedPeers, server.getId())) {
+      return logAndReturn(Result.PASSED, responses, exceptions, -1);
+    } else {
+      return logAndReturn(Result.REJECTED, responses, exceptions, -1);
+    }
   }
 
   @Override

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -158,6 +158,12 @@ public abstract class GroupManagementBaseTest extends BaseTest {
       Assert.assertTrue(leader.getId() == peers.get(suggestedLeaderIndex).getId());
     }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
 
+    cluster.killServer(peers.get(suggestedLeaderIndex).getId());
+    JavaUtils.attempt(() -> {
+      RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
+      Assert.assertTrue(leader.getId() != peers.get(suggestedLeaderIndex).getId());
+    }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
+
     cluster.shutdown();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

For example, s1, s2, s3's priority is (1, 2, 3). If s1 askForVotes, s2 reply success, but s3 crash, so exception happens.
Then election rejected at [return logAndReturn(Result.REJECTED, responses, exceptions, -1)](https://github.com/runzhiwang/incubator-ratis/blob/052e109bf33bedaf6754c6a26f55c2eb1d9dbae9/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java#L351)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1047


## How was this patch tested?

add test.

