### PR TITLE
RATIS-1050. Include build version descriptor in Ratis jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -839,6 +839,23 @@
           <includeReports>false</includeReports>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>create-metadata</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>target/classes</outputDirectory>
+              <outputName>ratis-version.properties</outputName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Include property file with the current git hash + build time in the Ratis jar files. Can be used by upstream project to display the exact version of Ratis. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1050

## How was this patch tested?


```
mvn clean install -DskipTests...
unzip -l .... target/....*.jar
```