### PR TITLE
RATIS-1051. Use try-resource-block when saveMd5File

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/MD5FileUtil.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/MD5FileUtil.java
@@ -150,9 +150,10 @@ public abstract class MD5FileUtil {
     File md5File = getDigestFileForFile(dataFile);
     String md5Line = digestString + " *" + dataFile.getName() + "\n";
 
-    AtomicFileOutputStream afos = new AtomicFileOutputStream(md5File);
-    afos.write(md5Line.getBytes(StandardCharsets.UTF_8));
-    afos.close();
+    try (AtomicFileOutputStream afos
+         = new AtomicFileOutputStream(md5File)) {
+      afos.write(md5Line.getBytes(StandardCharsets.UTF_8));
+    }
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("Saved MD5 " + digestString + " to " + md5File);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use try-resource-block when saveMd5File

## What is the link to the Apache JIRA

RATIS-1051

## How was this patch tested?

No need.
