### PR TITLE
RATIS-1052. Fix the testDisconnectLeader assertion

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -163,7 +163,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         Thread.sleep(1000);
         isolate(cluster, leader.getId());
         RaftClientReply reply = client.send(new RaftTestUtil.SimpleMessage("message"));
-        Assert.assertNotEquals(reply.getReplierId(), leader.getId());
+        Assert.assertNotEquals(reply.getReplierId(), leader.getId().toString());
         Assert.assertTrue(reply.isSuccess());
       } finally {
         deIsolate(cluster, leader.getId());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the testDisconnectLeader assertion in LeaderElectionTests.java, now the logic of that assertion is forever success, so, I fix it by this PR.

## What is the link to the Apache JIRA

RATIS-1052

## How was this patch tested?

It is already a test.
