### PR TITLE
RATIS-1055. Switch cases should end with an unconditional "break" statement

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -409,6 +409,8 @@ public class GrpcLogAppender extends LogAppender {
               getServer().getId(), installSnapshotEnabled, getFollowerId(), !installSnapshotEnabled);
           break;
         case UNRECOGNIZED:
+          LOG.error("Unrecongnized the reply result {}: Leader is {}, follower is {}",
+              reply.getResult(), getServer().getId(), getFollowerId());
           break;
         default:
           break;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -407,7 +407,9 @@ public class GrpcLogAppender extends LogAppender {
           LOG.error("{}: Configuration Mismatch ({}): Leader {} has it set to {} but follower {} has it set to {}",
               this, RaftServerConfigKeys.Log.Appender.INSTALL_SNAPSHOT_ENABLED_KEY,
               getServer().getId(), installSnapshotEnabled, getFollowerId(), !installSnapshotEnabled);
+          break;
         case UNRECOGNIZED:
+          break;
         default:
           break;
       }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Switch cases should end with an unconditional "break" statement

![image](https://user-images.githubusercontent.com/17329931/92549631-4e3a2c80-f28c-11ea-9fa4-95f3fc2e9097.png)


## What is the link to the Apache JIRA

RATIS-1055

## How was this patch tested?

No need.