### PR TITLE
RATIS-1058. Avoid NPE when response is null in CombinedClientProtocolServerSideTranslatorPB.sendClient

### DIFF
--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolServerSideTranslatorPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolServerSideTranslatorPB.java
@@ -79,7 +79,7 @@ public class CombinedClientProtocolServerSideTranslatorPB
     }
     return ClientReplyProto.newBuilder()
         .setType(type)
-        .setResponse(ByteString.copyFrom(response.toByteArray()))
+        .setResponse(response == null ? ByteString.EMPTY : ByteString.copyFrom(response.toByteArray()))
         .build();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid NPE when response is null in CombinedClientProtocolServerSideTranslatorPB.sendClient.

Detailed analysis see https://issues.apache.org/jira/browse/RATIS-1058.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1058

## How was this patch tested?

N/A
