### PR TITLE
RATIS-1059. Avoid NPE when exportInfo is NULL in LogStateMachine.processArchiveLog

### DIFF
--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
@@ -623,12 +623,15 @@ public class LogStateMachine extends BaseStateMachine {
         loc = archiveLog.getLocation();
         ArchivalInfo exportInfo =
             exportMap.putIfAbsent(loc, new ArchivalInfo(loc));
-        if (exportInfo != null && exportInfo.getLastArchivedIndex() == archiveLog
-            .getLastArchivedRaftIndex()) {
-          throw new IllegalStateException("Export of " + logName + "for the given location " + loc
-              + "is already present and in " + exportInfo.getStatus());
+        if (exportInfo != null) {
+          if (exportInfo.getLastArchivedIndex() == archiveLog
+              .getLastArchivedRaftIndex()) {
+            throw new IllegalStateException("Export of " + logName + "for the given location " + loc
+                + "is already present and in " + exportInfo.getStatus());
+          } else {
+            exportInfo.updateArchivalInfo(archiveLog);
+          }
         }
-        exportInfo.updateArchivalInfo(archiveLog);
       }
       if (loc == null) {
         throw new IllegalArgumentException(isArchivalRequest ?


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid NPE when exportInfo is NULL in LogStateMachine.processArchiveLog. 

Detailed analysis see https://issues.apache.org/jira/browse/RATIS-1059

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1059

## How was this patch tested?

N/A