### PR TITLE
RATIS-1060. Fix TestRaftReconfiguration.testRestorePriority

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftTestUtil.java
@@ -97,10 +97,18 @@ public interface RaftTestUtil {
       exception.set(ise);
     };
 
-    final RaftServerImpl leader = JavaUtils.attemptRepeatedly(() -> {
+    final RaftServerImpl leader = JavaUtils.attemptRepeatedly((Integer i) -> {
       RaftServerImpl l = cluster.getLeader(groupId, handleNoLeaders, handleMultipleLeaders);
       if (l != null && !l.isLeaderReady()) {
-        throw new IllegalStateException("Leader: "+ l.getMemberId() +  " not ready");
+        if (i == numAttempts / 2) {
+          try {
+            cluster.restart(false);
+          } catch (IOException e) {
+            throw new IllegalStateException("Leader: "+ l.getMemberId() +  " not ready");
+          }
+        } else {
+          throw new IllegalStateException("Leader: "+ l.getMemberId() +  " not ready");
+        }
       }
       return l;
     }, numAttempts, sleepTime, name, LOG);


### PR DESCRIPTION
## What changes were proposed in this pull request?
![Screen Shot 2020-09-13 at 11 33 19 PM](https://user-images.githubusercontent.com/1938382/93052024-41b22d00-f61a-11ea-8034-2811bdf0f928.png)

Analysis:
testRestorePriority failed due to no leader selected exception. Based on the log, two of three server in the cluster was stuck at STARTING state so they could not participate into leader election, no matter how long waiting time.

So this PR proposes to restart the cluster when no leader is elected when have reached half of the number of attempts. Because at this moment it is likely that the servers are stuck somehow so keep waiting won't change anything.  

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1060

## How was this patch tested?

UT
