### PR TITLE
RATIS-769. Ratis RaftGroupId should also include number of nodes in the log output.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroupMemberId.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroupMemberId.java
@@ -40,7 +40,7 @@ public final class RaftGroupMemberId {
   private RaftGroupMemberId(RaftPeerId peerId, RaftGroupId groupId, int numMembers) {
     this.peerId = Objects.requireNonNull(peerId, "peerId == null");
     this.groupId = Objects.requireNonNull(groupId, "groupId == null");
-    this.name = "p:" + peerId + "@g:" + groupId + "@s:" + numMembers;
+    this.name = "p:" + peerId + "@g:" + groupId + "@n:" + numMembers;
   }
 
   private RaftGroupMemberId(RaftPeerId peerId, RaftGroupId groupId) {

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroupMemberId.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroupMemberId.java
@@ -25,6 +25,10 @@ import java.util.Objects;
  * This is a value-based class.
  */
 public final class RaftGroupMemberId {
+  public static RaftGroupMemberId valueOf(RaftPeerId peerId, RaftGroupId groupId, int numMembers) {
+    return new RaftGroupMemberId(peerId, groupId, numMembers);
+  }
+
   public static RaftGroupMemberId valueOf(RaftPeerId peerId, RaftGroupId groupId) {
     return new RaftGroupMemberId(peerId, groupId);
   }
@@ -32,6 +36,12 @@ public final class RaftGroupMemberId {
   private final RaftPeerId peerId;
   private final RaftGroupId groupId;
   private final String name;
+
+  private RaftGroupMemberId(RaftPeerId peerId, RaftGroupId groupId, int numMembers) {
+    this.peerId = Objects.requireNonNull(peerId, "peerId == null");
+    this.groupId = Objects.requireNonNull(groupId, "groupId == null");
+    this.name = "p:" + peerId + "@g:" + groupId + "@s:" + numMembers;
+  }
 
   private RaftGroupMemberId(RaftPeerId peerId, RaftGroupId groupId) {
     this.peerId = Objects.requireNonNull(peerId, "peerId == null");

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -95,7 +95,7 @@ public class ServerState implements Closeable {
   ServerState(RaftPeerId id, RaftGroup group, RaftProperties prop,
               RaftServerImpl server, StateMachine stateMachine)
       throws IOException {
-    this.memberId = RaftGroupMemberId.valueOf(id, group.getGroupId());
+    this.memberId = RaftGroupMemberId.valueOf(id, group.getGroupId(), group.getPeers().size());
     this.server = server;
     RaftConfiguration initialConf = RaftConfiguration.newBuilder()
         .setConf(group.getPeers()).build();


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change adds the numbet of nodes in the group in the GroupMemberId toString

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-769

## How was this patch tested?
The output looks like s2@group-DC32E8D50A70@3

