### PR TITLE
RATIS-1066. Fixed example filestore client run failed

### DIFF
--- a/ratis-examples/src/main/bin/client.sh
+++ b/ratis-examples/src/main/bin/client.sh
@@ -32,4 +32,4 @@ shift
 subcommand="$1"
 shift
 
-java ${LOGGER_OPTS} -jar $ARTIFACT "$example" "$subcommand" $QUORUM_OPTS "$@"
+java ${LOGGER_OPTS} -jar $ARTIFACT "$example" "$subcommand" "$@"


### PR DESCRIPTION
## What changes were proposed in this pull request?

The docs[1] that describe client command will added duplicate peers parameters.
 
```
${BIN}/client.sh filestore loadgen --size 1024000 --numFiles 10 --peers ${PEERS}
Found xxx/incubator-ratis/ratis-examples/target/ratis-examples-1.1.0-SNAPSHOT.jar
Wrong parameters: Can only specify option --peers once.
 ```

I think the QUORUM_OPTS parameter should not be used in client.sh, just like server.sh.
 
[1] https://github.com/apache/incubator-ratis/blob/master/ratis-examples/README.md#filestore-client

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1066

## How was this patch tested?

manual tests
