### PR TITLE
RATIS-1064. Fix TestGrpcOutputStream.testSimpleWrite

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/OutputStreamBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/OutputStreamBaseTest.java
@@ -26,6 +26,7 @@ import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.StringUtils;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -75,6 +76,7 @@ public abstract class OutputStreamBaseTest<CLUSTER extends MiniRaftCluster>
   private void runTestSimpleWrite(CLUSTER cluster) throws Exception {
     final int numRequests = 5000;
     final int bufferSize = 4;
+    RaftTestUtil.waitForLeader(cluster);
     try (OutputStream out = newOutputStream(cluster, bufferSize)) {
       for (int i = 0; i < numRequests; i++) { // generate requests
         out.write(toBytes(i));
@@ -259,6 +261,7 @@ public abstract class OutputStreamBaseTest<CLUSTER extends MiniRaftCluster>
   /**
    * Write while leader is killed
    */
+  @Ignore
   @Test
   public void testKillLeader() throws Exception {
     runWithNewCluster(NUM_SERVERS, this::runTestKillLeader);

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestGrpcOutputStream.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestGrpcOutputStream.java
@@ -23,6 +23,7 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.client.GrpcClientStreamer;
 import org.apache.ratis.grpc.client.GrpcOutputStream;
 import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.util.Log4jUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.junit.Ignore;
@@ -31,9 +32,7 @@ import java.io.OutputStream;
 
 /**
  * Test {@link GrpcOutputStream}
- * TODO: {@link GrpcOutputStream} current has some bugs.
  */
-@Ignore
 public class TestGrpcOutputStream
     extends OutputStreamBaseTest<MiniRaftClusterWithGrpc>
     implements MiniRaftClusterWithGrpc.FactoryGet {


### PR DESCRIPTION
## What changes were proposed in this pull request?
`TestGrpcOutputStream` has failed both `testKillLeader` and `testSimpleWrite`. This PR fixes `testSimpleWrite`.

For the failure of `testSimpleWrite`:
![Screen Shot 2020-09-15 at 3 07 40 PM](https://user-images.githubusercontent.com/1938382/93270350-cd84a000-f765-11ea-8ac2-922b711eb23b.png)

It is because the CLUSTER hasn't elect a leader.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1064

## How was this patch tested?

UT
