### PR TITLE
RATIS-1067. Peer's support IPv6 address

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/NetUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/NetUtils.java
@@ -123,7 +123,7 @@ public interface NetUtils {
   }
 
   static String address2String(InetSocketAddress address) {
-    final StringBuilder b = new StringBuilder(address.getHostName());
+    final StringBuilder b = new StringBuilder(address.getAddress().getHostAddress());
     if (address.getAddress() instanceof Inet6Address) {
       b.insert(0, '[').append(']');
     }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
@@ -17,14 +17,14 @@
  */
 package org.apache.ratis.examples.common;
 
+import static org.apache.ratis.server.impl.RaftServerConstants.IPV6PATTERN;
+
 import com.beust.jcommander.Parameter;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Objects;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -37,24 +37,6 @@ import org.slf4j.LoggerFactory;
 public abstract class SubCommandBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(SubCommandBase.class);
-
-  static Pattern IPV6PATTERN = Pattern.compile(Stream.of("(",
-    "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|",          // 2001:0250:0207:0001:0000:0000:0000:ff02
-    "([0-9a-fA-F]{1,4}:){1,7}:|",                         // 1::
-    "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|",         // 2001::ff02
-    "([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|",  // 2001::0000:ff02
-    "([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|",  // 2001::0000:0000:ff02
-    "([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|",  // 2001::0000:0000:0000:ff02
-    "([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|",  // 2001::0001:0000:0000:0000:ff02
-    "[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|",       // 2001::0207:0001:0000:0000:0000:ff02
-    ":((:[0-9a-fA-F]{1,4}){1,7}|:)|",                     // ::0250:0207:0001:0000:0000:0000:ff02
-    "::(ffff(:0{1,4}){0,1}:){0,1}",
-    "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}",
-    "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|",          // ::ffff:255.255.255.255 ::ffff:0:255.255.255.255
-    "([0-9a-fA-F]{1,4}:){1,4}:",
-    "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}",
-    "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])",           // 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33
-    ")").collect(Collectors.joining()));
 
   @Parameter(names = {"--raftGroup",
       "-g"}, description = "Raft group identifier")

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
@@ -18,16 +18,43 @@
 package org.apache.ratis.examples.common;
 
 import com.beust.jcommander.Parameter;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
-
-import java.util.Objects;
-import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Base subcommand class which includes the basic raft properties.
  */
 public abstract class SubCommandBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SubCommandBase.class);
+
+  static Pattern IPV6_PATTERN = Pattern.compile(Stream.of("(",
+    "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|",          // 2001:0250:0207:0001:0000:0000:0000:ff02
+    "([0-9a-fA-F]{1,4}:){1,7}:|",                         // 1::
+    "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|",         // 2001::ff02
+    "([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|",  // 2001::0000:ff02
+    "([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|",  // 2001::0000:0000:ff02
+    "([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|",  // 2001::0000:0000:0000:ff02
+    "([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|",  // 2001::0001:0000:0000:0000:ff02
+    "[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|",       // 2001::0207:0001:0000:0000:0000:ff02
+    ":((:[0-9a-fA-F]{1,4}){1,7}|:)|",                     // ::0250:0207:0001:0000:0000:0000:ff02
+    "::(ffff(:0{1,4}){0,1}:){0,1}",
+    "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}",
+    "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|",          // ::ffff:255.255.255.255 ::ffff:0:255.255.255.255
+    "([0-9a-fA-F]{1,4}:){1,4}:",
+    "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}",
+    "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])",           // 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33
+    ")").collect(Collectors.joining()));
 
   @Parameter(names = {"--raftGroup",
       "-g"}, description = "Raft group identifier")
@@ -39,11 +66,8 @@ public abstract class SubCommandBase {
   private String peers;
 
   public static RaftPeer[] parsePeers(String peers) {
-    return Stream.of(peers.split(",")).map(address -> {
-      String[] addressParts = address.split(":");
-      return new RaftPeer(RaftPeerId.valueOf(addressParts[0]),
-          addressParts[1] + ":" + addressParts[2]);
-    }).toArray(RaftPeer[]::new);
+    return Stream.of(peers.split(",")).map(address -> parseRaftPeer(address))
+      .toArray(RaftPeer[]::new);
   }
 
   public RaftPeer[] getPeers() {
@@ -68,5 +92,25 @@ public abstract class SubCommandBase {
     }
     throw new IllegalArgumentException("Raft peer id " + raftPeerId + " is not part of the raft group definitions " +
             this.peers);
+  }
+
+  private static RaftPeer parseRaftPeer(String address) {
+    try {
+      if (IPV6_PATTERN.matcher(address).find()) {
+        String id = address.substring(0, address.indexOf(":"));
+        String host = address.substring(address.indexOf("[") + 1, address.lastIndexOf("]"));
+        String port = address.substring(address.lastIndexOf(":") + 1);
+        return new RaftPeer(RaftPeerId.valueOf(id),
+          new InetSocketAddress(Inet6Address.getByName(host), Integer.valueOf(port)));
+      } else {
+        String[] addressParts = address.split(":");
+        return new RaftPeer(RaftPeerId.valueOf(addressParts[0]),
+          new InetSocketAddress(Inet4Address.getByAddress(addressParts[1].getBytes()),
+            Integer.valueOf(addressParts[2])));
+      }
+    } catch (UnknownHostException ex) {
+      LOG.error("parse address {} failed",address);
+      throw new RuntimeException(ex);
+    }
   }
 }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
@@ -38,7 +38,7 @@ public abstract class SubCommandBase {
 
   private static final Logger LOG = LoggerFactory.getLogger(SubCommandBase.class);
 
-  static Pattern IPV6_PATTERN = Pattern.compile(Stream.of("(",
+  static Pattern IPV6PATTERN = Pattern.compile(Stream.of("(",
     "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|",          // 2001:0250:0207:0001:0000:0000:0000:ff02
     "([0-9a-fA-F]{1,4}:){1,7}:|",                         // 1::
     "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|",         // 2001::ff02
@@ -96,7 +96,7 @@ public abstract class SubCommandBase {
 
   private static RaftPeer parseRaftPeer(String address) {
     try {
-      if (IPV6_PATTERN.matcher(address).find()) {
+      if (IPV6PATTERN.matcher(address).find()) {
         String id = address.substring(0, address.indexOf(":"));
         String host = address.substring(address.indexOf("[") + 1, address.lastIndexOf("]"));
         String port = address.substring(address.lastIndexOf(":") + 1);

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestPeers.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestPeers.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ratis.examples.common;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestPeers {
+
+  static String[] ipv6Address = new String[]{
+    "2001:0250:0207:0001:0000:0000:0000:ff02",
+    "2001:250:207:1:0:0:0:ff02",
+    "2001::ff02",
+    "2001::0000:ff02",
+    "2001::0000:0000:ff02",
+    "2001::0000:0000:0000:ff02",
+    "2001::0001:0000:0000:0000:ff02",
+    "2001::0207:0001:0000:0000:0000:ff02",
+    "::0250:0207:0001:0000:0000:0000:ff02",
+    "::1",
+    "::255.255.255.255",
+    "::ffff:255.255.255.255",
+    "::ffff:0:255.255.255.255",
+    "2001:db8:3:4::192.0.2.33",
+    "64:ff9b::192.0.2.33",
+  };
+
+  static String[] expectedPeers = new String[]{
+    "nc:[0:250:207:1:0:0:0:ff02]:6000",
+    "nc:[0:0:0:0:ffff:0:ffff:ffff]:6000",
+    "nc:[2001:0:0:0:0:0:0:ff02]:6000",
+    "nc:[2001:0:0:1:0:0:0:ff02]:6000",
+    "nc:[2001:250:207:1:0:0:0:ff02]:6000",
+    "nc:[2001:0:207:1:0:0:0:ff02]:6000",
+    "nc:[2001:db8:3:4:0:0:c000:221]:6000",
+    "nc:[0:0:0:0:0:0:ffff:ffff]:6000",
+    "nc:[64:ff9b:0:0:0:0:c000:221]:6000",
+    "nc:[fe80:0:0:0:ccc:d6:1d51:db51]:6000"
+  };
+
+  @Test
+  public void testPatternIpv6() {
+    Assert.assertEquals(
+      Arrays.stream(ipv6Address).filter(s -> SubCommandBase.IPV6_PATTERN.matcher(s).find()).count(),
+      ipv6Address.length);
+  }
+
+  @Test
+  public void testParsePeers() {
+    List<String> actualPeers = Arrays
+      .stream(SubCommandBase.parsePeers(Stream.of(expectedPeers).collect(Collectors.joining(","))))
+      .map(s -> s.getId().toString() + ":" + s.getAddress()).collect(Collectors.toList());
+    Assert.assertArrayEquals(expectedPeers, actualPeers.toArray());
+  }
+}

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestPeers.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestPeers.java
@@ -62,7 +62,7 @@ public class TestPeers {
   @Test
   public void testPatternIpv6() {
     Assert.assertEquals(
-      Arrays.stream(ipv6Address).filter(s -> SubCommandBase.IPV6_PATTERN.matcher(s).find()).count(),
+      Arrays.stream(ipv6Address).filter(s -> SubCommandBase.IPV6PATTERN.matcher(s).find()).count(),
       ipv6Address.length);
   }
 

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestPeers.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/common/TestPeers.java
@@ -18,6 +18,8 @@
 
 package org.apache.ratis.examples.common;
 
+import static org.apache.ratis.server.impl.RaftServerConstants.IPV6PATTERN;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -62,7 +64,7 @@ public class TestPeers {
   @Test
   public void testPatternIpv6() {
     Assert.assertEquals(
-      Arrays.stream(ipv6Address).filter(s -> SubCommandBase.IPV6PATTERN.matcher(s).find()).count(),
+      Arrays.stream(ipv6Address).filter(s -> IPV6PATTERN.matcher(s).find()).count(),
       ipv6Address.length);
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerConstants.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerConstants.java
@@ -17,6 +17,9 @@
  */
 package org.apache.ratis.server.impl;
 
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.ratis.server.raftlog.RaftLog;
 
 public final class RaftServerConstants {
@@ -24,7 +27,25 @@ public final class RaftServerConstants {
   @Deprecated
   public static final long INVALID_LOG_INDEX = RaftLog.INVALID_LOG_INDEX;
   public static final long DEFAULT_CALLID = 0;
-
+  public static final Pattern IPV6PATTERN = Pattern.compile(Stream.of("(",
+    "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|",          // 2001:0250:0207:0001:0000:0000:0000:ff02
+    "([0-9a-fA-F]{1,4}:){1,7}:|",                         // 1::
+    "([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|",         // 2001::ff02
+    "([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|",  // 2001::0000:ff02
+    "([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|",  // 2001::0000:0000:ff02
+    "([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|",  // 2001::0000:0000:0000:ff02
+    "([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|",  // 2001::0001:0000:0000:0000:ff02
+    "[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|",       // 2001::0207:0001:0000:0000:0000:ff02
+    ":((:[0-9a-fA-F]{1,4}){1,7}|:)|",                     // ::0250:0207:0001:0000:0000:0000:ff02
+    "::(ffff(:0{1,4}){0,1}:){0,1}",
+    "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}",
+    "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|",
+    // ::ffff:255.255.255.255 ::ffff:0:255.255.255.255
+    "([0-9a-fA-F]{1,4}:){1,4}:",
+    "((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}",
+    "(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])",
+    // 2001:db8:3:4::192.0.2.33  64:ff9b::192.0.2.33
+    ")").collect(Collectors.joining()));
   private RaftServerConstants() {
     //Never constructed
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

For example, use the following parameters in the local networkv

```
--peers n0:[::1]:6000,n1:[::1]:6001,n2:[::1]:6002
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1067

## How was this patch tested?

unit tests for ipv6 regular expression matching
manual tests for example filestore
