### PR TITLE
RATIS-1072: Should not shutdown and re-create channel/stub in GrpcServerProtocolClient when StreamObserver::onError() is called.

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -86,7 +86,6 @@ public class GrpcLogAppender extends LogAppender {
   }
 
   private synchronized void resetClient(AppendEntriesRequest request) {
-    rpcService.getProxies().resetProxy(getFollowerId());
     appendLogRequestObserver = null;
     firstResponseReceived = false;
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -87,9 +87,9 @@ public class GrpcLogAppender extends LogAppender {
 
   private synchronized void resetClient(AppendEntriesRequest request, boolean onError) {
     try {
-      rpcService.getProxies().getProxy(getFollowerId()).resetConnectBackoff();
+      getClient().resetConnectBackoff();
     } catch (IOException ie) {
-      LOG.warn(this + ": Failed to reset channel by " + ie);
+      LOG.warn(this + ": Failed to getClient for " + getFollowerId(), ie);
     }
 
     appendLogRequestObserver = null;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -86,6 +86,12 @@ public class GrpcLogAppender extends LogAppender {
   }
 
   private synchronized void resetClient(AppendEntriesRequest request) {
+    try {
+      rpcService.getProxies().getProxy(getFollowerId()).resetConnectBackoff();
+    } catch (IOException ie) {
+      LOG.warn(this + ": Failed to reset channel by " + ie);
+    }
+
     appendLogRequestObserver = null;
     firstResponseReceived = false;
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -110,4 +110,9 @@ public class GrpcServerProtocolClient implements Closeable {
     return asyncStub.withDeadlineAfter(requestTimeoutDuration.getDuration(), requestTimeoutDuration.getUnit())
         .installSnapshot(responseHandler);
   }
+
+  // short-circuit the backoff timer and make them reconnect immediately.
+  public void resetConnectBackoff() {
+    channel.resetConnectBackoff();
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Should not shutdown and re-create channel/stub in GrpcServerProtocolClient when StreamObserver::onError() is called.
It is un-necessary and dangerous.

For detail behind the change, please check https://github.com/grpc/grpc-java/issues/7442

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1072


Please check reply from grpc community:
https://github.com/grpc/grpc-java/issues/7442
https://github.com/grpc/grpc-java/issues/7449#issuecomment-697766246

## How was this patch tested?

CI
