### PR TITLE
RATIS-1077. Unify metric name convention

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/GrpcServerMetrics.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/GrpcServerMetrics.java
@@ -33,19 +33,19 @@ public class GrpcServerMetrics extends RatisMetrics {
   public static final String RATIS_GRPC_METRICS_LOG_APPENDER_LATENCY =
       "%s_latency";
   public static final String RATIS_GRPC_METRICS_LOG_APPENDER_SUCCESS =
-      "%s_success_reply_count";
+      "%s_successReplyCount";
   public static final String RATIS_GRPC_METRICS_LOG_APPENDER_NOT_LEADER =
-      "%s_not_leader_reply_count";
+      "%s_notLeaderReplyCount";
   public static final String RATIS_GRPC_METRICS_LOG_APPENDER_INCONSISTENCY =
-      "%s_inconsistency_reply_count";
+      "%s_inconsistencyReplyCount";
   public static final String RATIS_GRPC_METRICS_LOG_APPENDER_TIMEOUT =
-      "%s_append_entry_timeout_count";
+      "%s_appendEntryTimeoutCount";
   public static final String RATIS_GRPC_METRICS_LOG_APPENDER_PENDING_COUNT
-      = "%s_pending_log_requests_count";
+      = "%s_pendingLogRequestsCount";
 
-  public static final String RATIS_GRPC_METRICS_REQUEST_RETRY_COUNT = "num_retries";
-  public static final String RATIS_GRPC_METRICS_REQUESTS_TOTAL = "num_requests";
-  public static final String RATIS_GRPC_INSTALL_SNAPSHOT_COUNT = "num_install_snapshot";
+  public static final String RATIS_GRPC_METRICS_REQUEST_RETRY_COUNT = "numRetries";
+  public static final String RATIS_GRPC_METRICS_REQUESTS_TOTAL = "numRequests";
+  public static final String RATIS_GRPC_INSTALL_SNAPSHOT_COUNT = "numInstallSnapshot";
 
   public GrpcServerMetrics(String serverId) {
     registry = getMetricRegistryForGrpcServer(serverId);

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftSnapshotWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftSnapshotWithGrpc.java
@@ -41,7 +41,7 @@ public class TestRaftSnapshotWithGrpc extends RaftSnapshotBaseTest {
         "ratis_grpc", "log_appender", "Metrics for Ratis Grpc Log Appender");
     Optional<RatisMetricRegistry> metricRegistry = MetricRegistries.global().get(info);
     Assert.assertTrue(metricRegistry.isPresent());
-    Counter installSnapshotCounter = metricRegistry.get().counter("num_install_snapshot");
+    Counter installSnapshotCounter = metricRegistry.get().counter("numInstallSnapshot");
     Assert.assertNotNull(installSnapshotCounter);
     Assert.assertTrue(installSnapshotCounter.getCount() >= 1);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are two convention of metric naming convention 
`public static final String RAFT_LOG_WORKER_QUEUE_SIZE = "workerQueueSize";` (for example, in [RaftLogMetrics](https://github.com/apache/incubator-ratis/blob/master/ratis-server/src/main/java/org/apache/ratis/server/metrics/RaftLogMetrics.java#L44))
`public static final String RATIS_GRPC_METRICS_REQUEST_RETRY_COUNT = "num_retries";`

We can have a unified convention.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1077

## How was this patch tested?

UT
