### PR TITLE
RATIS-1036. ratis_leader_election_electionCount metric is similar to …

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -497,7 +497,6 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
     }
     // start election
     role.startLeaderElection(this);
-    leaderElectionMetrics.onNewLeaderElection();
   }
 
   @Override

--- a/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
@@ -18,8 +18,7 @@
 
 package org.apache.ratis.server.metrics;
 
-import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECTION_COUNT_METRIC;
-import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECTION_LATENCY;
+import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LAST_LEADER_ELECTION_ELAPSED_TIME;
 import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECTION_TIMEOUT_COUNT_METRIC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -58,21 +57,11 @@ public class TestLeaderElectionMetrics {
   }
 
   @Test
-  public void testOnNewLeaderElection() throws Exception {
-    long numLeaderElections = ratisMetricRegistry.counter(
-        LEADER_ELECTION_COUNT_METRIC).getCount();
-    assertTrue(numLeaderElections == 0);
-    leaderElectionMetrics.onNewLeaderElection();
-    numLeaderElections = ratisMetricRegistry.counter(LEADER_ELECTION_COUNT_METRIC).getCount();
-    assertEquals(1, numLeaderElections);
-  }
-
-  @Test
   public void testOnLeaderElectionCompletion() throws Exception {
-    leaderElectionMetrics.onLeaderElectionCompletion(500L);
+    leaderElectionMetrics.onNewLeaderElectionCompletion();
     Long leaderElectionLatency = (Long) ratisMetricRegistry.getGauges((s, metric) ->
-        s.contains(LEADER_ELECTION_LATENCY)).values().iterator().next().getValue();
-    assertEquals(500L, leaderElectionLatency.longValue());
+        s.contains(LAST_LEADER_ELECTION_ELAPSED_TIME)).values().iterator().next().getValue();
+    assertTrue(leaderElectionLatency > 0L);
   }
 
   @Test


### PR DESCRIPTION
…ratis_leader_election_electionTimeoutCount.

## What changes were proposed in this pull request?

- ratis_leader_election_electionCount metric should track the number of leader elections and not the election timeouts.
- Add last Leader Election Time metric.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1036
https://issues.apache.org/jira/browse/RATIS-1049

## How was this patch tested?
Unit testing.