### PR TITLE
RATIS-1088. SegmentedRaftLogWorker#closeLogSegment should also roll the open segment maintained in the cache.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -428,7 +428,7 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
 
   public abstract Metadata loadMetadata() throws IOException;
 
-  public abstract void syncWithSnapshot(long lastSnapshotIndex);
+  public abstract CompletableFuture<Long> syncWithSnapshot(long lastSnapshotIndex);
 
   public abstract boolean isConfigEntry(TermIndex ti);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/memory/MemoryRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/memory/MemoryRaftLog.java
@@ -217,7 +217,8 @@ public class MemoryRaftLog extends RaftLog {
   }
 
   @Override
-  public void syncWithSnapshot(long lastSnapshotIndex) {
+  public CompletableFuture<Long> syncWithSnapshot(long lastSnapshotIndex) {
+    return CompletableFuture.completedFuture(lastSnapshotIndex);
     // do nothing
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -401,4 +401,9 @@ public class LogSegment implements Comparable<Long> {
   boolean containsIndex(long index) {
     return startIndex <= index && endIndex >= index;
   }
+
+  boolean hasEntries() {
+    return numOfEntries() > 0;
+  }
+
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -493,21 +493,15 @@ public class SegmentedRaftLog extends RaftLog {
 
     // Close open log segment if entries are already included in snapshot
     LogSegment openSegment = cache.getOpenSegment();
-    long purgeIndex = lastSnapshotIndex;
     if (openSegment != null && openSegment.hasEntries()) {
-      LOG.debug("Found open segment {}, with end index {}, snapshotIndex {}",
-          openSegment, openSegment.getEndIndex(), lastSnapshotIndex);
+      LOG.debug("syncWithSnapshot : Found open segment {}, with end index {}," +
+              " snapshotIndex {}", openSegment, openSegment.getEndIndex(), lastSnapshotIndex);
       if (openSegment.getEndIndex() <= lastSnapshotIndex) {
         fileLogWorker.closeLogSegment(openSegment);
         cache.rollOpenSegment(true);
-        if (openSegment.getEndIndex() == lastSnapshotIndex) {
-          // Since purgeImpl does not delete any segment which has overlap,
-          // passing in snapshotIndex + 1.
-          purgeIndex = lastSnapshotIndex + 1;
-        }
       }
     }
-    return purgeImpl(purgeIndex);
+    return purgeImpl(lastSnapshotIndex);
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -494,8 +494,11 @@ public class SegmentedRaftLog extends RaftLog {
     // Close open log segment if entries are already included in snapshot
     LogSegment openSegment = cache.getOpenSegment();
     if (openSegment != null && openSegment.hasEntries()) {
-      LOG.debug("syncWithSnapshot : Found open segment {}, with end index {}," +
-              " snapshotIndex {}", openSegment, openSegment.getEndIndex(), lastSnapshotIndex);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("syncWithSnapshot : Found open segment {}, with end index {},"
+                + " snapshotIndex {}", openSegment, openSegment.getEndIndex(),
+            lastSnapshotIndex);
+      }
       if (openSegment.getEndIndex() <= lastSnapshotIndex) {
         fileLogWorker.closeLogSegment(openSegment);
         cache.rollOpenSegment(true);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -307,7 +307,12 @@ public class SegmentedRaftLogCache {
           sizeInBytes = 0;
         } else if (segmentIndex >= 0) {
           // we start to purge the closedSegments which do not overlap with index.
-          for (int i = segmentIndex - 1; i >= 0; i--) {
+          LogSegment overlappedSegment = segments.get(segmentIndex);
+          // if a segment's end index matches the passed in index, it is OK
+          // to purge that.
+          int startIndex = (overlappedSegment.getEndIndex() == index) ?
+              segmentIndex : segmentIndex - 1;
+          for (int i = startIndex; i >= 0; i--) {
             LogSegment segment = segments.remove(i);
             sizeInBytes -= segment.getTotalSize();
             list.add(SegmentFileInfo.newClosedSegmentFileInfo(segment));

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -398,7 +398,7 @@ public class TestSegmentedRaftLog extends BaseTest {
     int endTerm = 5;
     int segmentSize = 200;
     long endIndexOfClosedSegment = segmentSize * (endTerm - startTerm - 1) - 1;
-    long expectedIndex = segmentSize * (endTerm - startTerm - 2);
+    long expectedIndex = segmentSize * (endTerm - startTerm - 1);
     purgeAndVerify(startTerm, endTerm, segmentSize, 1, endIndexOfClosedSegment, expectedIndex);
   }
 
@@ -408,7 +408,7 @@ public class TestSegmentedRaftLog extends BaseTest {
     int endTerm = 5;
     int segmentSize = 200;
     long endIndexOfClosedSegment = segmentSize * (endTerm - startTerm - 1) - 1;
-    long expectedIndex = segmentSize * (endTerm - startTerm - 2);
+    long expectedIndex = segmentSize * (endTerm - startTerm - 1);
     RatisMetricRegistry metricRegistryForLogWorker = new RaftLogMetrics(memberId.toString()).getRegistry();
     purgeAndVerify(startTerm, endTerm, segmentSize, 1, endIndexOfClosedSegment, expectedIndex);
     Assert.assertTrue(metricRegistryForLogWorker.timer("purgeLog").getCount() > 0);

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
@@ -262,8 +262,9 @@ public class TestSegmentedRaftLogCache {
 
     int purgeIndex = (end - start) * segmentSize - 1;
 
-    // overlapped close segment will not purged.
-    TruncationSegments ts = cache.purge(purgeIndex);
+    // overlapped close segment will not purged. Passing in index - 1 since
+    // we purge a closed segment when end index == passed in purge index.
+    TruncationSegments ts = cache.purge(purgeIndex - 1);
     Assert.assertNull(ts.getToTruncate());
     Assert.assertEquals(end - start - 1, ts.getToDelete().length);
     Assert.assertEquals(1, cache.getNumOfSegments());


### PR DESCRIPTION
## What changes were proposed in this pull request?
While closing an open log segment using the SegmentedRaftLogWorker#closeLogSegment method, the corresponding cache segment also needs to be rolled (close and open a new empty one). Else, the cache will go out of sync with the on disk log segment state.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1049

## How was this patch tested?
Manually tested.
Unit tests pending.