### PR TITLE
RATIS-1092. Move the group management methods from RaftClient to a new interface

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClient.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClient.java
@@ -19,6 +19,7 @@ package org.apache.ratis.client;
 
 import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.client.api.DataStreamApi;
+import org.apache.ratis.client.api.GroupManagementApi;
 import org.apache.ratis.client.api.MessageStreamApi;
 import org.apache.ratis.client.impl.ClientImplUtils;
 import org.apache.ratis.conf.Parameters;
@@ -49,6 +50,9 @@ public interface RaftClient extends Closeable {
 
   /** @return the {@link RaftClientRpc}. */
   RaftClientRpc getClientRpc();
+
+  /** Get the {@link GroupManagementApi} for the given server. */
+  GroupManagementApi getGroupManagementApi(RaftPeerId server);
 
   /** @return the {@link MessageStreamApi}. */
   MessageStreamApi getMessageStreamApi();
@@ -100,19 +104,6 @@ public interface RaftClient extends Closeable {
 
   /** Send set configuration request to the raft service. */
   RaftClientReply setConfiguration(RaftPeer[] serversInNewConf) throws IOException;
-
-  /** Send groupAdd request to the given server (not the raft service). */
-  RaftClientReply groupAdd(RaftGroup newGroup, RaftPeerId server) throws IOException;
-
-  /** Send groupRemove request to the given server (not the raft service). */
-  RaftClientReply groupRemove(RaftGroupId groupId, boolean deleteDirectory,
-      boolean renameDirectory, RaftPeerId server) throws IOException;
-
-  /** Send getGroupList request to the given server.*/
-  GroupListReply getGroupList(RaftPeerId server) throws IOException;
-
-  /** Send getGroupInfo request to the given server.*/
-  GroupInfoReply getGroupInfo(RaftGroupId group, RaftPeerId server) throws IOException;
 
   /** @return a {@link Builder}. */
   static Builder newBuilder() {

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/GroupManagementApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/GroupManagementApi.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.client.api;
+
+import org.apache.ratis.protocol.GroupInfoReply;
+import org.apache.ratis.protocol.GroupListReply;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+
+import java.io.IOException;
+
+/**
+ * APIs to support group management operations such as add, remove, list and info to a particular server.
+ */
+public interface GroupManagementApi {
+  /** Add a new group. */
+  RaftClientReply add(RaftGroup newGroup) throws IOException;
+
+  /** Remove a group. */
+  RaftClientReply remove(RaftGroupId groupId, boolean deleteDirectory, boolean renameDirectory) throws IOException;
+
+  /** List all the groups.*/
+  GroupListReply list() throws IOException;
+
+  /** Get the info of the given group.*/
+  GroupInfoReply info(RaftGroupId group) throws IOException;
+}

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/GroupManagementImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/GroupManagementImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.client.impl;
+
+import org.apache.ratis.client.api.GroupManagementApi;
+import org.apache.ratis.protocol.GroupInfoReply;
+import org.apache.ratis.protocol.GroupInfoRequest;
+import org.apache.ratis.protocol.GroupListReply;
+import org.apache.ratis.protocol.GroupListRequest;
+import org.apache.ratis.protocol.GroupManagementRequest;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.util.Preconditions;
+
+import java.io.IOException;
+import java.util.Objects;
+
+class GroupManagementImpl implements GroupManagementApi {
+  private final RaftPeerId server;
+  private final RaftClientImpl client;
+
+  GroupManagementImpl(RaftPeerId server, RaftClientImpl client) {
+    this.server = Objects.requireNonNull(server, "server == null");
+    this.client = Objects.requireNonNull(client, "client == null");
+  }
+
+  @Override
+  public RaftClientReply add(RaftGroup newGroup) throws IOException {
+    Objects.requireNonNull(newGroup, "newGroup == null");
+
+    final long callId = RaftClientImpl.nextCallId();
+    client.addServers(newGroup.getPeers().stream());
+    return client.sendRequest(GroupManagementRequest.newAdd(client.getId(), server, callId, newGroup));
+  }
+
+  @Override
+  public RaftClientReply remove(RaftGroupId groupId, boolean deleteDirectory, boolean renameDirectory)
+      throws IOException {
+    Objects.requireNonNull(groupId, "groupId == null");
+
+    final long callId = RaftClientImpl.nextCallId();
+    return client.sendRequest(GroupManagementRequest.newRemove(client.getId(), server,
+        callId, groupId, deleteDirectory, renameDirectory));
+  }
+
+  @Override
+  public GroupListReply list() throws IOException {
+    final long callId = RaftClientImpl.nextCallId();
+    final RaftClientReply reply = client.sendRequest(
+        new GroupListRequest(client.getId(), server, client.getGroupId(), callId));
+    Preconditions.assertTrue(reply instanceof GroupListReply, () -> "Unexpected reply: " + reply);
+    return (GroupListReply)reply;
+  }
+
+  @Override
+  public GroupInfoReply info(RaftGroupId groupId) throws IOException {
+    if (groupId == null) {
+      groupId = client.getGroupId();
+    }
+    final long callId = RaftClientImpl.nextCallId();
+    final RaftClientReply reply = client.sendRequest(
+        new GroupInfoRequest(client.getId(), server, groupId, callId));
+    Preconditions.assertTrue(reply instanceof GroupInfoReply, () -> "Unexpected reply: " + reply);
+    return (GroupInfoReply)reply;
+  }
+}

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/UnorderedAsync.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/UnorderedAsync.java
@@ -77,7 +77,7 @@ public interface UnorderedAsync {
       try {
         LOG.debug("{}: attempt #{} receive~ {}", clientId, attemptCount, reply);
         final RaftException replyException = reply != null? reply.getException(): null;
-        reply = client.handleLeaderException(request, reply, null);
+        reply = client.handleLeaderException(request, reply);
         if (reply != null) {
           f.complete(reply);
           return;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java
@@ -263,7 +263,7 @@ public class MetaStateMachine extends BaseStateMachine {
             raftPeers.stream().forEach(peer -> {
                 try (RaftClient client = RaftClient.newBuilder().setProperties(properties)
                     .setClientId(ClientId.randomId()).setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build()){
-                    client.groupRemove(raftGroup.getGroupId(), true, false, peer.getId());
+                    client.getGroupManagementApi(peer.getId()).remove(raftGroup.getGroupId(), true, false);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -319,7 +319,7 @@ public class MetaStateMachine extends BaseStateMachine {
                 for (RaftPeer peer : peers) {
                     try (RaftClient client = RaftClient.newBuilder().setProperties(properties)
                         .setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build()) {
-                        client.groupAdd(raftGroup, peer.getId());
+                        client.getGroupManagementApi(peer.getId()).add(raftGroup);
                     } catch (IOException e) {
                         LOG.error("Failed to add Raft group ({}) for new Log({})",
                             raftGroup.getGroupId(), name, e);
@@ -338,7 +338,7 @@ public class MetaStateMachine extends BaseStateMachine {
                         }
                         try (RaftClient client = RaftClient.newBuilder().setProperties(properties)
                             .setRaftGroup(RaftGroup.valueOf(logServerGroupId, peer)).build()) {
-                            client.groupRemove(raftGroup.getGroupId(), true, false, peer.getId());
+                            client.getGroupManagementApi(peer.getId()).remove(raftGroup.getGroupId(), true, false);
                         } catch (IOException e) {
                             LOG.error("Failed to clean up Raft group ({}) for peer ({}), "
                                 + "ignoring exception", raftGroup.getGroupId(), peer, e);

--- a/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftExceptionBaseTest.java
@@ -161,8 +161,8 @@ public abstract class RaftExceptionBaseTest<CLUSTER extends MiniRaftCluster>
           GroupMismatchException.class);
 
       testFailureCase("groupRemove(..) with another group id",
-          () -> client.groupRemove(anotherGroup.getGroupId(), false, false,
-              clusterGroup.getPeers().iterator().next().getId()),
+          () -> client.getGroupManagementApi(clusterGroup.getPeers().iterator().next().getId())
+              .remove(anotherGroup.getGroupId(), false, false),
           GroupMismatchException.class);
     }
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupInfoBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupInfoBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,6 +21,7 @@ import org.apache.log4j.Level;
 import org.apache.ratis.BaseTest;
 import org.apache.ratis.MiniRaftCluster;
 import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.api.GroupManagementApi;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.util.Log4jUtils;
@@ -54,23 +55,24 @@ public abstract class GroupInfoBaseTest<CLUSTER extends MiniRaftCluster>
     RaftGroup group2 = RaftGroup.valueOf(RaftGroupId.randomId(), peers);
     for(RaftPeer peer : peers) {
       try(final RaftClient client = cluster.createClient(peer.getId())) {
-        client.groupAdd(group2, peer.getId());
+        client.getGroupManagementApi(peer.getId()).add(group2);
       }
     }
     // check that all the peers return the list where both groups are included. And able to return GroupInfo
     // for each of them.
     for (RaftPeer peer : peers) {
       try (final RaftClient client = cluster.createClient(peer.getId())) {
-        GroupListReply info = client.getGroupList(peer.getId());
+        final GroupManagementApi api = client.getGroupManagementApi(peer.getId());
+        final GroupListReply info = api.list();
         List<RaftGroupId> groupList = info.getGroupIds().stream()
             .filter(id -> group.getGroupId().equals(id)).collect(Collectors.toList());
         assert (groupList.size() == 1);
-        final GroupInfoReply gi = client.getGroupInfo(groupList.get(0), peer.getId());
+        final GroupInfoReply gi = api.info(groupList.get(0));
         assert (sameGroup(group, gi.getGroup()));
         groupList = info.getGroupIds().stream()
             .filter(id -> group2.getGroupId().equals(id)).collect(Collectors.toList());
         assert (groupList.size() == 1);
-        final GroupInfoReply gi2 = client.getGroupInfo(groupList.get(0), peer.getId());
+        final GroupInfoReply gi2 = api.info(groupList.get(0));
         assert (sameGroup(group2, gi2.getGroup()));
       }
     }
@@ -101,7 +103,7 @@ public abstract class GroupInfoBaseTest<CLUSTER extends MiniRaftCluster>
         continue;
       }
       try(final RaftClient client = cluster.createClient(peer.getId())) {
-        GroupListReply info = client.getGroupList(peer.getId());
+        final GroupListReply info = client.getGroupManagementApi(peer.getId()).list();
         Assert.assertEquals(1, info.getGroupIds().stream().filter(id -> group.getGroupId().equals(id)).count());
         for(CommitInfoProto i : info.getCommitInfos()) {
           if (RaftPeerId.valueOf(i.getServer().getId()).equals(killedFollower)) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -105,7 +105,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
       LOG.info("add new group: " + newGroup);
       try (final RaftClient client = cluster.createClient(newGroup)) {
         for (RaftPeer p : newGroup.getPeers()) {
-          client.groupAdd(newGroup, p.getId());
+          client.getGroupManagementApi(p.getId()).add(newGroup);
         }
       }
 

--- a/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
+++ b/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -187,7 +187,7 @@ public class TestStateMachine extends BaseTest implements MiniRaftClusterWithSim
         LOG.info("add new group: " + newGroup);
         try (final RaftClient client = cluster.createClient(newGroup)) {
           for (RaftPeer p : newGroup.getPeers()) {
-            client.groupAdd(newGroup, p.getId());
+            client.getGroupManagementApi(p.getId()).add(newGroup);
           }
         }
       }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1092