### PR TITLE
RATIS-1095. Move the related methods from RaftClientImpl to the corresponding impls.

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/AsyncApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/AsyncApi.java
@@ -28,7 +28,7 @@ import org.apache.ratis.protocol.RaftPeerId;
  */
 public interface AsyncApi {
   /**
-   * Async call to send the given message to the raft service.
+   * Send the given message asynchronously to the raft service.
    * The message may change the state of the service.
    * For readonly messages, use {@link #sendReadOnly(Message)} instead.
    *
@@ -37,12 +37,32 @@ public interface AsyncApi {
    */
   CompletableFuture<RaftClientReply> send(Message message);
 
-  /** Async call to send the given readonly message to the raft service. */
+  /**
+   * Send the given readonly message asynchronously to the raft service.
+   *
+   * @param message The request message.
+   * @return a future of the reply.
+   */
   CompletableFuture<RaftClientReply> sendReadOnly(Message message);
 
-  /** Async call to send the given stale-read message to the given server (not the raft service). */
+  /**
+   * Send the given stale-read message asynchronously to the given server (not the raft service).
+   * If the server commit index is larger than or equal to the given min-index, the request will be processed.
+   * Otherwise, the server returns a {@link org.apache.ratis.protocol.exceptions.StaleReadException}.
+   *
+   * @param message The request message.
+   * @param minIndex The minimum log index that the server log must have already committed.
+   * @param server The target server
+   * @return a future of the reply.
+   */
   CompletableFuture<RaftClientReply> sendStaleRead(Message message, long minIndex, RaftPeerId server);
 
-  /** Async call to watch the given index to satisfy the given replication level. */
+  /**
+   * Watch the given index asynchronously to satisfy the given replication level.
+   *
+   * @param index The log index to be watched.
+   * @param replication The replication level required.
+   * @return a future of the reply.
+   */
   CompletableFuture<RaftClientReply> watch(long index, ReplicationLevel replication);
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/AsyncApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/AsyncApi.java
@@ -24,7 +24,10 @@ import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeerId;
 
 /**
- * APIs to support asynchronous operations such as send message, send (stale)read message and watch request.
+ * Asynchronous API to support operations
+ * such as sending message, read-message, stale-read-message and watch-request.
+ *
+ * Note that this API and {@link BlockingApi} support the same set of operations.
  */
 public interface AsyncApi {
   /**

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/BlockingApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/BlockingApi.java
@@ -37,12 +37,30 @@ public interface BlockingApi {
    */
   RaftClientReply send(Message message) throws IOException;
 
-  /** Send the given readonly message to the raft service. */
+  /**
+   * Send the given readonly message to the raft service.
+   *
+   * @param message The request message.
+   * @return the reply.
+   */
   RaftClientReply sendReadOnly(Message message) throws IOException;
 
-  /** Send the given stale-read message to the given server (not the raft service). */
+  /**
+   * Send the given stale-read message to the given server (not the raft service).
+   *
+   * @param message The request message.
+   * @param minIndex The minimum log index that the server log must have already committed.
+   * @param server The target server
+   * @return the reply.
+   */
   RaftClientReply sendStaleRead(Message message, long minIndex, RaftPeerId server) throws IOException;
 
-  /** Watch the given index to satisfy the given replication level. */
+  /**
+   * Watch the given index to satisfy the given replication level.
+   *
+   * @param index The log index to be watched.
+   * @param replication The replication level required.
+   * @return the reply.
+   */
   RaftClientReply watch(long index, ReplicationLevel replication) throws IOException;
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/BlockingApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/BlockingApi.java
@@ -24,7 +24,10 @@ import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeerId;
 
 /**
- * APIs to support blocking operations such as send message, send (stale)read message and watch request.
+ * Blocking API to support operations
+ * such as sending message, read-message, stale-read-message and watch-request.
+ *
+ * Note that this API and {@link AsyncApi} support the same set of operations.
  */
 public interface BlockingApi {
   /**
@@ -47,6 +50,8 @@ public interface BlockingApi {
 
   /**
    * Send the given stale-read message to the given server (not the raft service).
+   * If the server commit index is larger than or equal to the given min-index, the request will be processed.
+   * Otherwise, the server throws a {@link org.apache.ratis.protocol.exceptions.StaleReadException}.
    *
    * @param message The request message.
    * @param minIndex The minimum log index that the server log must have already committed.

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/AsyncImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/AsyncImpl.java
@@ -34,19 +34,24 @@ class AsyncImpl implements AsyncApi {
     this.client = Objects.requireNonNull(client, "client == null");
   }
 
+  CompletableFuture<RaftClientReply> send(
+      RaftClientRequest.Type type, Message message, RaftPeerId server) {
+    return client.getOrderedAsync().send(type, message, server);
+  }
+
   @Override
   public CompletableFuture<RaftClientReply> send(Message message) {
-    return client.sendAsync(RaftClientRequest.writeRequestType(), message, null);
+    return send(RaftClientRequest.writeRequestType(), message, null);
   }
 
   @Override
   public CompletableFuture<RaftClientReply> sendReadOnly(Message message) {
-    return client.sendAsync(RaftClientRequest.readRequestType(), message, null);
+    return send(RaftClientRequest.readRequestType(), message, null);
   }
 
   @Override
   public CompletableFuture<RaftClientReply> sendStaleRead(Message message, long minIndex, RaftPeerId server) {
-    return client.sendAsync(RaftClientRequest.staleReadRequestType(minIndex), message, server);
+    return send(RaftClientRequest.staleReadRequestType(minIndex), message, server);
   }
 
   @Override

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/BlockingImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/BlockingImpl.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 /** Blocking api implementations. */
 class BlockingImpl implements BlockingApi {
-  Logger LOG = LoggerFactory.getLogger(BlockingApi.class);
+  Logger LOG = LoggerFactory.getLogger(BlockingImpl.class);
 
   private final RaftClientImpl client;
 

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/BlockingImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/BlockingImpl.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 /** Blocking api implementations. */
 class BlockingImpl implements BlockingApi {
-  Logger LOG = LoggerFactory.getLogger(BlockingImpl.class);
+  static final Logger LOG = LoggerFactory.getLogger(BlockingImpl.class);
 
   private final RaftClientImpl client;
 

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/BlockingImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/BlockingImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,16 +18,30 @@
 package org.apache.ratis.client.impl;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
 import org.apache.ratis.client.api.BlockingApi;
+import org.apache.ratis.client.retry.ClientRetryEvent;
+import org.apache.ratis.proto.RaftProtos.RaftClientRequestProto.TypeCase;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.protocol.exceptions.GroupMismatchException;
+import org.apache.ratis.protocol.exceptions.StateMachineException;
+import org.apache.ratis.retry.RetryPolicy;
+import org.apache.ratis.util.TimeDuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Blocking api implementations. */
 class BlockingImpl implements BlockingApi {
+  Logger LOG = LoggerFactory.getLogger(BlockingApi.class);
+
   private final RaftClientImpl client;
 
   BlockingImpl(RaftClientImpl client) {
@@ -36,22 +50,89 @@ class BlockingImpl implements BlockingApi {
 
   @Override
   public RaftClientReply send(Message message) throws IOException {
-    return client.send(RaftClientRequest.writeRequestType(), message, null);
+    return send(RaftClientRequest.writeRequestType(), message, null);
   }
 
   @Override
   public RaftClientReply sendReadOnly(Message message) throws IOException {
-    return client.send(RaftClientRequest.readRequestType(), message, null);
+    return send(RaftClientRequest.readRequestType(), message, null);
   }
 
   @Override
   public RaftClientReply sendStaleRead(Message message, long minIndex, RaftPeerId server)
       throws IOException {
-    return client.send(RaftClientRequest.staleReadRequestType(minIndex), message, server);
+    return send(RaftClientRequest.staleReadRequestType(minIndex), message, server);
   }
 
   @Override
   public RaftClientReply watch(long index, ReplicationLevel replication) throws IOException {
-    return client.send(RaftClientRequest.watchRequestType(index, replication), null, null);
+    return send(RaftClientRequest.watchRequestType(index, replication), null, null);
+  }
+
+  private RaftClientReply send(RaftClientRequest.Type type, Message message, RaftPeerId server)
+      throws IOException {
+    if (!type.is(TypeCase.WATCH)) {
+      Objects.requireNonNull(message, "message == null");
+    }
+
+    final long callId = RaftClientImpl.nextCallId();
+    return sendRequestWithRetry(() -> client.newRaftClientRequest(server, callId, message, type, null));
+  }
+
+  RaftClientReply sendRequestWithRetry(Supplier<RaftClientRequest> supplier) throws IOException {
+    RaftClientImpl.PendingClientRequest pending = new RaftClientImpl.PendingClientRequest() {
+      @Override
+      public RaftClientRequest newRequestImpl() {
+        return supplier.get();
+      }
+    };
+    while (true) {
+      final RaftClientRequest request = pending.newRequest();
+      IOException ioe = null;
+      try {
+        final RaftClientReply reply = sendRequest(request);
+
+        if (reply != null) {
+          return reply;
+        }
+      } catch (GroupMismatchException | StateMachineException e) {
+        throw e;
+      } catch (IOException e) {
+        ioe = e;
+      }
+
+      pending.incrementExceptionCount(ioe);
+      ClientRetryEvent event = new ClientRetryEvent(request, ioe, pending);
+      final RetryPolicy retryPolicy = client.getRetryPolicy();
+      final RetryPolicy.Action action = retryPolicy.handleAttemptFailure(event);
+      TimeDuration sleepTime = client.getEffectiveSleepTime(ioe, action.getSleepTime());
+
+      if (!action.shouldRetry()) {
+        throw (IOException)client.noMoreRetries(event);
+      }
+
+      try {
+        sleepTime.sleep();
+      } catch (InterruptedException e) {
+        throw new InterruptedIOException("retry policy=" + retryPolicy);
+      }
+    }
+  }
+
+  RaftClientReply sendRequest(RaftClientRequest request) throws IOException {
+    LOG.debug("{}: send {}", client.getId(), request);
+    RaftClientReply reply;
+    try {
+      reply = client.getClientRpc().sendRequest(request);
+    } catch (GroupMismatchException gme) {
+      throw gme;
+    } catch (IOException ioe) {
+      client.handleIOException(request, ioe);
+      throw ioe;
+    }
+    LOG.debug("{}: receive {}", client.getId(), reply);
+    reply = client.handleLeaderException(request, reply);
+    reply = RaftClientImpl.handleRaftException(reply, Function.identity());
+    return reply;
   }
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/GroupManagementImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/GroupManagementImpl.java
@@ -47,7 +47,7 @@ class GroupManagementImpl implements GroupManagementApi {
 
     final long callId = RaftClientImpl.nextCallId();
     client.addServers(newGroup.getPeers().stream());
-    return client.sendRequest(GroupManagementRequest.newAdd(client.getId(), server, callId, newGroup));
+    return client.io().sendRequest(GroupManagementRequest.newAdd(client.getId(), server, callId, newGroup));
   }
 
   @Override
@@ -56,14 +56,14 @@ class GroupManagementImpl implements GroupManagementApi {
     Objects.requireNonNull(groupId, "groupId == null");
 
     final long callId = RaftClientImpl.nextCallId();
-    return client.sendRequest(GroupManagementRequest.newRemove(client.getId(), server,
+    return client.io().sendRequest(GroupManagementRequest.newRemove(client.getId(), server,
         callId, groupId, deleteDirectory, renameDirectory));
   }
 
   @Override
   public GroupListReply list() throws IOException {
     final long callId = RaftClientImpl.nextCallId();
-    final RaftClientReply reply = client.sendRequest(
+    final RaftClientReply reply = client.io().sendRequest(
         new GroupListRequest(client.getId(), server, client.getGroupId(), callId));
     Preconditions.assertTrue(reply instanceof GroupListReply, () -> "Unexpected reply: " + reply);
     return (GroupListReply)reply;
@@ -75,7 +75,7 @@ class GroupManagementImpl implements GroupManagementApi {
       groupId = client.getGroupId();
     }
     final long callId = RaftClientImpl.nextCallId();
-    final RaftClientReply reply = client.sendRequest(
+    final RaftClientReply reply = client.io().sendRequest(
         new GroupInfoRequest(client.getId(), server, groupId, callId));
     Preconditions.assertTrue(reply instanceof GroupInfoReply, () -> "Unexpected reply: " + reply);
     return (GroupInfoReply)reply;

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/MessageStreamImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/MessageStreamImpl.java
@@ -23,6 +23,8 @@ import org.apache.ratis.client.api.MessageStreamApi;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftClientRequest;
+import org.apache.ratis.protocol.RaftClientRequest.Type;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.SizeInBytes;
 import org.slf4j.Logger;
@@ -48,14 +50,18 @@ public final class MessageStreamImpl implements MessageStreamApi {
       this.id = id;
     }
 
+    private Type getStreamRequestType(boolean endOfRequest) {
+      return RaftClientRequest.streamRequestType(id, messageId.getAndIncrement(), endOfRequest);
+    }
+
     @Override
     public CompletableFuture<RaftClientReply> sendAsync(Message message, boolean endOfRequest) {
-      return client.streamAsync(id, messageId.getAndIncrement(), message, endOfRequest);
+      return client.async().send(getStreamRequestType(endOfRequest), message, null);
     }
 
     @Override
     public CompletableFuture<RaftClientReply> closeAsync() {
-      return client.streamCloseAsync(id, messageId.getAndIncrement());
+      return client.async().send(getStreamRequestType(true), null, null);
     }
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1095