### PR TITLE
RATIS-1102. Fix typo in MetricRegistriesImpl#create warning message

### DIFF
--- a/ratis-metrics/src/main/java/org/apache/ratis/metrics/impl/MetricRegistriesImpl.java
+++ b/ratis-metrics/src/main/java/org/apache/ratis/metrics/impl/MetricRegistriesImpl.java
@@ -64,7 +64,7 @@ public class MetricRegistriesImpl extends MetricRegistries {
       if (reporterRegistrations.isEmpty()) {
         LOG.warn(
             "First MetricRegistry has been created without registering reporters. You may need to call" +
-                " MetricRegistries.global().addReportRegistration(...) before.");
+                " MetricRegistries.global().addReporterRegistration(...) before.");
       }
       RatisMetricRegistry registry = factory.create(info);
       reporterRegistrations.forEach(reg -> reg.accept(registry));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/RATIS-1102

The warning message in `MetricRegistriesImpl#create` should read `addReport*er*Registration`. It was missing the "er". Confused me for a bit when I'm trying to follow the message.