### PR TITLE
RATIS-1101. Fix Failed UT: RaftBasicTests.runTestOldLeaderNotCommit:IndexOutOfBounds

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
@@ -228,9 +228,14 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
 
     List<RaftServerImpl> followers = cluster.getFollowers();
     final RaftServerImpl followerToCommit = followers.get(0);
-    for (int i = 1; i < NUM_SERVERS - 1; i++) {
-      RaftServerImpl follower = followers.get(i);
-      cluster.killServer(follower.getId());
+    try {
+      for (int i = 1; i < NUM_SERVERS - 1; i++) {
+        RaftServerImpl follower = followers.get(i);
+        cluster.killServer(follower.getId());
+      }
+    } catch (IndexOutOfBoundsException e) {
+      throw new org.junit.AssumptionViolatedException("The assumption is follower.size() = NUM_SERVERS - 1, "
+              + "actual NUM_SERVERS is " + NUM_SERVERS + ", and actual follower.size() is " + followers.size(), e);
     }
 
     SimpleMessage[] messages = SimpleMessage.create(1);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Seeing a flaky instance of `RaftBasicTests.runTestOldLeaderNotCommit` due to `IndexOutOfBounds` (https://github.com/apache/incubator-ratis/pull/225/checks?check_run_id=1281324912).

The exception is from 
```
      for (int i = 1; i < NUM_SERVERS - 1; i++) {
        RaftServerImpl follower = followers.get(i);
        cluster.killServer(follower.getId());
      }
```
where it turned out i exceeded the range of followers size. This might be due to slow machine/process so followers are not enough.

Per suggestion from @szetszwo  we can use `org.junit.AssumptionViolatedException` to not fail this test in this special case.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1101

## How was this patch tested?
UT
