### PR TITLE
RATIS-1104.Should check "bytewritten" from remote writes to peers to determine whether current stream write is successful

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -194,11 +194,11 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
     return new ChannelInboundHandlerAdapter(){
       @Override
       public void channelRead(ChannelHandlerContext ctx, Object msg) throws IOException {
-        final DataStreamRequestByteBuf request = (DataStreamRequestByteBuf)msg;
+        final DataStreamRequestByteBuf request = (DataStreamRequestByteBuf) msg;
         final ByteBuf buf = request.slice();
         final boolean isHeader = request.getStreamOffset() == -1;
 
-        final CompletableFuture<Long> localWrite = isHeader?
+        final CompletableFuture<Long> localWrite = isHeader ?
                 streams.computeIfAbsent(request.getStreamId(), id -> getDataStreamFuture(buf)).thenApply(stream -> 0L)
                 : streams.get(request.getStreamId()).thenApply(stream -> writeTo(buf, stream));
 
@@ -207,34 +207,43 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
           // do not need to forward header request
           final List<DataStreamOutput> outs = proxies.getDataStreamOutput();
           peersStreamOutput.put(request.getStreamId(), outs);
-          for(DataStreamOutput out : outs) {
+          for (DataStreamOutput out : outs) {
             remoteWrites.add(out.getHeaderFuture());
           }
         } else {
           // body
-          for(DataStreamOutput out : peersStreamOutput.get(request.getStreamId())) {
+          for (DataStreamOutput out : peersStreamOutput.get(request.getStreamId())) {
             remoteWrites.add(out.writeAsync(request.slice().nioBuffer()));
           }
         }
 
         JavaUtils.allOf(remoteWrites).thenCombine(localWrite, (v, bytesWritten) -> {
               buf.release();
-              for (CompletableFuture<DataStreamReply> replyFuture : remoteWrites) {
-                try {
-                  DataStreamReply reply = replyFuture.get();
-                  if (!reply.isSuccess() || reply.getBytesWritten() != bytesWritten) {
-                    sendReplyNotSuccess(request, ctx);
-                    return null;
-                  }
-                } catch (InterruptedException | ExecutionException e) {
-                  IOUtils.asIOException(e);
+              try {
+                if (!checkSuccessRemoteWrite(remoteWrites, bytesWritten)) {
+                  sendReplyNotSuccess(request, ctx);
+                } else {
+                  sendReply(request, bytesWritten, ctx);
                 }
+              } catch (ExecutionException | InterruptedException e) {
+                IOUtils.asIOException(e);
               }
-              sendReply(request, bytesWritten, ctx);
               return null;
         });
       }
     };
+  }
+
+  private boolean checkSuccessRemoteWrite(
+          List<CompletableFuture<DataStreamReply>> replyFutures, long bytesWritten)
+          throws ExecutionException, InterruptedException {
+    for (CompletableFuture<DataStreamReply> replyFuture : replyFutures) {
+      DataStreamReply reply = replyFuture.get();
+      if (!reply.isSuccess() || reply.getBytesWritten() != bytesWritten) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private ChannelInitializer<SocketChannel> getInitializer(){

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -191,7 +191,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
   }
 
   private void sendReply(List<CompletableFuture<DataStreamReply>> remoteWrites,
-              DataStreamRequestByteBuf request, long bytesWritten, ChannelHandlerContext ctx) {
+      DataStreamRequestByteBuf request, long bytesWritten, ChannelHandlerContext ctx) {
     try {
       if (!checkSuccessRemoteWrite(remoteWrites, bytesWritten)) {
         sendReplyNotSuccess(request, ctx);
@@ -201,7 +201,6 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
     } catch (ExecutionException | InterruptedException e) {
       IOUtils.asIOException(e);
     }
-
   }
 
   private ChannelInboundHandler getServerHandler(){

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -18,7 +18,6 @@
 
 package org.apache.ratis.netty.server;
 
-import java.util.concurrent.ExecutionException;
 import org.apache.ratis.client.DataStreamClient;
 import org.apache.ratis.client.api.DataStreamOutput;
 import org.apache.ratis.client.impl.ClientProtoUtils;
@@ -60,6 +59,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 public class NettyServerStreamRpc implements DataStreamServerRpc {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a correctness check that compares the `byteswritten` to peers with current `byteswritten` locally.  If remote write is not successful or `byteswritten` is not equal, should return a reply with "not success".

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1104

## How was this patch tested?

UT
