### PR TITLE
RATIS-1108. Add SupportedDataStreamType.DISABLED

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/datastream/SupportedDataStreamType.java
+++ b/ratis-common/src/main/java/org/apache/ratis/datastream/SupportedDataStreamType.java
@@ -21,6 +21,7 @@ import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.util.ReflectionUtils;
 
 public enum SupportedDataStreamType implements DataStreamFactory {
+  DISABLED("org.apache.ratis.server.impl.DisabledDataStreamFactory"),
   NETTY("org.apache.ratis.netty.NettyDataStreamFactory");
 
   private final String factoryClassName;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DisabledDataStreamFactory.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DisabledDataStreamFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.impl;
+
+import org.apache.ratis.client.DataStreamClientFactory;
+import org.apache.ratis.client.DataStreamClientRpc;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.datastream.SupportedDataStreamType;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.server.DataStreamServerFactory;
+import org.apache.ratis.server.DataStreamServerRpc;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.statemachine.StateMachine;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/** A stream factory that does nothing when data stream is disabled. */
+public class DisabledDataStreamFactory implements DataStreamServerFactory, DataStreamClientFactory {
+    public DisabledDataStreamFactory(Parameters parameters){}
+
+    @Override
+    public DataStreamClientRpc newDataStreamClientRpc(RaftPeer server, RaftProperties properties) {
+      return new DataStreamClientRpc() {
+        @Override
+        public void startClient() {}
+
+        @Override
+        public void closeClient() {}
+      };
+    }
+
+    @Override
+    public DataStreamServerRpc newDataStreamServerRpc(
+        RaftPeer server, StateMachine stateMachine, RaftProperties properties) {
+      return new DataStreamServerRpc() {
+        @Override
+        public void start() {}
+
+        @Override
+        public void close() throws IOException {}
+
+        @Override
+        public void addRaftPeers(Collection<RaftPeer> peers) {}
+      };
+    }
+
+    @Override
+    public DataStreamServerRpc newDataStreamServerRpc(
+        RaftServer server, StateMachine stateMachine, RaftProperties properties) {
+      return new DataStreamServerRpc() {
+        @Override
+        public void start() {}
+
+        @Override
+        public void close() throws IOException {}
+
+        @Override
+        public void addRaftPeers(Collection<RaftPeer> peers) {}
+      };
+    }
+
+    @Override
+    public SupportedDataStreamType getDataStreamType() {
+        return SupportedDataStreamType.DISABLED;
+    }
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/DisabledDataStreamFactory.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/DisabledDataStreamFactory.java
@@ -28,56 +28,55 @@ import org.apache.ratis.server.DataStreamServerRpc;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.statemachine.StateMachine;
 
-import java.io.IOException;
 import java.util.Collection;
 
 /** A stream factory that does nothing when data stream is disabled. */
 public class DisabledDataStreamFactory implements DataStreamServerFactory, DataStreamClientFactory {
-    public DisabledDataStreamFactory(Parameters parameters){}
+  public DisabledDataStreamFactory(Parameters parameters) {}
 
-    @Override
-    public DataStreamClientRpc newDataStreamClientRpc(RaftPeer server, RaftProperties properties) {
-      return new DataStreamClientRpc() {
-        @Override
-        public void startClient() {}
+  @Override
+  public DataStreamClientRpc newDataStreamClientRpc(RaftPeer server, RaftProperties properties) {
+    return new DataStreamClientRpc() {
+      @Override
+      public void startClient() {}
 
-        @Override
-        public void closeClient() {}
-      };
-    }
+      @Override
+      public void closeClient() {}
+    };
+  }
 
-    @Override
-    public DataStreamServerRpc newDataStreamServerRpc(
-        RaftPeer server, StateMachine stateMachine, RaftProperties properties) {
-      return new DataStreamServerRpc() {
-        @Override
-        public void start() {}
+  @Override
+  public DataStreamServerRpc newDataStreamServerRpc(
+      RaftPeer server, StateMachine stateMachine, RaftProperties properties) {
+    return new DataStreamServerRpc() {
+      @Override
+      public void start() {}
 
-        @Override
-        public void close() throws IOException {}
+      @Override
+      public void close() {}
 
-        @Override
-        public void addRaftPeers(Collection<RaftPeer> peers) {}
-      };
-    }
+      @Override
+      public void addRaftPeers(Collection<RaftPeer> peers) {}
+    };
+  }
 
-    @Override
-    public DataStreamServerRpc newDataStreamServerRpc(
-        RaftServer server, StateMachine stateMachine, RaftProperties properties) {
-      return new DataStreamServerRpc() {
-        @Override
-        public void start() {}
+  @Override
+  public DataStreamServerRpc newDataStreamServerRpc(
+      RaftServer server, StateMachine stateMachine, RaftProperties properties) {
+    return new DataStreamServerRpc() {
+      @Override
+      public void start() {}
 
-        @Override
-        public void close() throws IOException {}
+      @Override
+      public void close() {}
 
-        @Override
-        public void addRaftPeers(Collection<RaftPeer> peers) {}
-      };
-    }
+      @Override
+      public void addRaftPeers(Collection<RaftPeer> peers) {}
+    };
+  }
 
-    @Override
-    public SupportedDataStreamType getDataStreamType() {
-        return SupportedDataStreamType.DISABLED;
-    }
+  @Override
+  public SupportedDataStreamType getDataStreamType() {
+    return SupportedDataStreamType.DISABLED;
+  }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamBase.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamBase.java
@@ -17,15 +17,6 @@
  */
 package org.apache.ratis.datastream;
 
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.WritableByteChannel;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.stream.Collectors;
 import org.apache.ratis.BaseTest;
 import org.apache.ratis.MiniRaftCluster;
 import org.apache.ratis.client.api.DataStreamOutput;
@@ -42,6 +33,16 @@ import org.apache.ratis.statemachine.impl.BaseStateMachine;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.NetUtils;
 import org.junit.Assert;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 class TestDataStreamBase extends BaseTest {
   static final int MODULUS = 23;

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.datastream;
+
+import org.apache.ratis.RaftConfigKeys;
+import org.apache.ratis.conf.RaftProperties;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TestDataStreamDisabled extends TestDataStreamBase {
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Before
+  public void setup() {
+    properties = new RaftProperties();
+    RaftConfigKeys.DataStream.setType(properties, SupportedDataStreamType.DISABLED);
+  }
+
+  @Test
+  public void testDataStreamSingleServer() throws Exception {
+    exception.expect(UnsupportedOperationException.class);
+    runTestDataStream(1, 1_000_000, 100);
+    runTestDataStream(1,1_000, 10_000);
+  }
+}

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
@@ -23,11 +23,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.internal.matchers.Contains;
-import org.mockito.internal.matchers.StartsWith;
-
-import static org.mockito.Matchers.contains;
-import static org.mockito.Matchers.startsWith;
 
 public class TestDataStreamDisabled extends TestDataStreamBase {
   @Rule

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
@@ -45,11 +45,8 @@ public class TestDataStreamDisabled extends TestDataStreamBase {
       // stream() will create a header request, thus it will hit UnsupportedOperationException due to
       // DisabledDataStreamFactory.
       client.stream();
-
     } finally {
       shutdown();
     }
-
-
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
@@ -35,10 +35,21 @@ public class TestDataStreamDisabled extends TestDataStreamBase {
   }
 
   @Test
-  public void testDataStreamSingleServer() throws Exception {
-    exception.expect(UnsupportedOperationException.class);
-    exception.expectMessage("org.apache.ratis.server.impl.DisabledDataStreamFactory$1 does not support streamAsync");
-    runTestDataStream(1, 1_000_000, 100);
-    runTestDataStream(1,1_000, 10_000);
+  public void testDataStreamDisabled() throws Exception {
+    setupRaftPeers(1);
+    try {
+      setupServer();
+      setupClient();
+      exception.expect(UnsupportedOperationException.class);
+      exception.expectMessage("org.apache.ratis.server.impl.DisabledDataStreamFactory$1 does not support streamAsync");
+      // stream() will create a header request, thus it will hit UnsupportedOperationException due to
+      // DisabledDataStreamFactory.
+      client.stream();
+
+    } finally {
+      shutdown();
+    }
+
+
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
@@ -23,6 +23,11 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.internal.matchers.Contains;
+import org.mockito.internal.matchers.StartsWith;
+
+import static org.mockito.Matchers.contains;
+import static org.mockito.Matchers.startsWith;
 
 public class TestDataStreamDisabled extends TestDataStreamBase {
   @Rule
@@ -37,6 +42,7 @@ public class TestDataStreamDisabled extends TestDataStreamBase {
   @Test
   public void testDataStreamSingleServer() throws Exception {
     exception.expect(UnsupportedOperationException.class);
+    exception.expectMessage("org.apache.ratis.server.impl.DisabledDataStreamFactory$1 does not support streamAsync");
     runTestDataStream(1, 1_000_000, 100);
     runTestDataStream(1,1_000, 10_000);
   }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ratis.datastream;
+
+import org.apache.ratis.RaftConfigKeys;
+import org.apache.ratis.conf.RaftProperties;
+import org.junit.Before;
+import org.junit.Test;
+
+
+public class TestDataStreamNetty extends TestDataStreamBase {
+  @Before
+  public void setup() {
+    properties = new RaftProperties();
+    RaftConfigKeys.DataStream.setType(properties, SupportedDataStreamType.NETTY);
+  }
+
+  @Test
+  public void testDataStreamSingleServer() throws Exception {
+    runTestDataStream(1, 1_000_000, 100);
+    runTestDataStream(1,1_000, 10_000);
+  }
+
+  @Test
+  public void testDataStreamMultipleServer() throws Exception {
+    runTestDataStream(3, 1_000_000, 100);
+    runTestDataStream(3, 1_000, 10_000);
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add SupportedDataStreamType.DISABLED to control whether datastream server is enabled. It is because running a DataStream server in RaftServer has a cost thus it might be better to allow enable/disable it that depends on needs. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1108

## How was this patch tested?

UT
