### PR TITLE
RATIS-1117. Remove DataStreamClient.start() and DataStreamClientRpc.startClient().

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/DataStreamClient.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/DataStreamClient.java
@@ -28,18 +28,13 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 
 /**
- * A client interface that sends request to the streaming pipeline.
- * Associated with it will be a Netty Client.
+ * A user interface extending {@link DataStreamApi}.
  */
 public interface DataStreamClient extends DataStreamApi, Closeable {
-
   Logger LOG = LoggerFactory.getLogger(DataStreamClient.class);
 
   /** Return the rpc client instance **/
   DataStreamClientRpc getClientRpc();
-
-  /** start the client */
-  void start();
 
   static Builder newBuilder() {
     return new Builder();

--- a/ratis-client/src/main/java/org/apache/ratis/client/DataStreamClientRpc.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/DataStreamClientRpc.java
@@ -22,20 +22,18 @@ import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.DataStreamRequest;
 import org.apache.ratis.util.JavaUtils;
 
+import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * An api interface for to stream from client to server.
+ * A client interface for sending stream requests.
+ * The underlying implementation is pluggable, depending on the {@link org.apache.ratis.datastream.DataStreamType}.
+ * The implementations of this interface define how the requests are transported to the server.
  */
-public interface DataStreamClientRpc {
-
+public interface DataStreamClientRpc extends Closeable {
   /** Async call to send a request. */
   default CompletableFuture<DataStreamReply> streamAsync(DataStreamRequest request) {
     throw new UnsupportedOperationException(getClass() + " does not support "
         + JavaUtils.getCurrentStackTraceElement().getMethodName());
   }
-
-  void startClient();
-
-  void closeClient();
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/DisabledDataStreamClientFactory.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/DisabledDataStreamClientFactory.java
@@ -35,10 +35,7 @@ public class DisabledDataStreamClientFactory implements DataStreamClientFactory 
   public DataStreamClientRpc newDataStreamClientRpc(RaftPeer server, RaftProperties properties) {
     return new DataStreamClientRpc() {
       @Override
-      public void startClient() {}
-
-      @Override
-      public void closeClient() {}
+      public void close() {}
     };
   }
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -31,9 +31,8 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.proto.RaftProtos.DataStreamPacketHeaderProto.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
@@ -44,8 +43,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * allows client to create streams and send asynchronously.
  */
 public class DataStreamClientImpl implements DataStreamClient {
-  public static final Logger LOG = LoggerFactory.getLogger(DataStreamClientImpl.class);
-
   // TODO Similar to RaftClientImpl, pass ClientId and RaftGroupId/RaftGroup in constructor.
   private final ClientId clientId = ClientId.randomId();
   private final RaftGroupId groupId =  RaftGroupId.randomId();
@@ -117,12 +114,7 @@ public class DataStreamClientImpl implements DataStreamClient {
   }
 
   @Override
-  public void close(){
-    dataStreamClientRpc.closeClient();
-  }
-
-  @Override
-  public void start(){
-    dataStreamClientRpc.startClient();
+  public void close() throws IOException {
+    dataStreamClientRpc.close();
   }
 }

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -177,12 +177,10 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
   }
 
   static DataStreamClient newClient(RaftPeer peer, RaftProperties properties) {
-    final DataStreamClient client = DataStreamClient.newBuilder()
+    return DataStreamClient.newBuilder()
         .setRaftServer(peer)
         .setProperties(properties)
         .build();
-    client.start();
-    return client;
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamBase.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamBase.java
@@ -144,7 +144,6 @@ class TestDataStreamBase extends BaseTest {
 
   protected void setupClient(){
     client = new DataStreamClientImpl(peers.get(0), properties, null);
-    client.start();
   }
 
   protected void shutdown() throws IOException {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1117