### PR TITLE
RATIS-1118. Remove DataStreamServerRpc.start()

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/DataStreamServerRpc.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/DataStreamServerRpc.java
@@ -26,8 +26,5 @@ import java.io.Closeable;
  * Relays those streams to other servers after persisting
  */
 public interface DataStreamServerRpc extends RaftPeer.Add, Closeable {
-  /**
-   * start server
-   */
-  void start();
+
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/DisabledDataStreamServerFactory.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/DisabledDataStreamServerFactory.java
@@ -34,9 +34,6 @@ public class DisabledDataStreamServerFactory implements DataStreamServerFactory 
       RaftPeer server, StateMachine stateMachine, RaftProperties properties) {
     return new DataStreamServerRpc() {
       @Override
-      public void start() {}
-
-      @Override
       public void close() {}
 
       @Override
@@ -48,9 +45,6 @@ public class DisabledDataStreamServerFactory implements DataStreamServerFactory 
   public DataStreamServerRpc newDataStreamServerRpc(
       RaftServer server, StateMachine stateMachine, RaftProperties properties) {
     return new DataStreamServerRpc() {
-      @Override
-      public void start() {}
-
       @Override
       public void close() {}
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -320,7 +320,6 @@ public class RaftServerProxy implements RaftServer {
     lifeCycle.startAndTransition(() -> {
       LOG.info("{}: start RPC server", getId());
       getServerRpc().start();
-      getDataStreamServerRpc().start();
     }, IOException.class);
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamBase.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamBase.java
@@ -137,7 +137,6 @@ class TestDataStreamBase extends BaseTest {
         otherPeers.remove(peers.get(i));
         rpc.addRaftPeers(otherPeers);
       }
-      rpc.start();
       servers.add(streamServer);
     }
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/RATIS-1118
