### PR TITLE
RATIS-1120. Terminate election in advance if majority peers reject

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
@@ -94,6 +94,16 @@ class PeerConfiguration {
     return num > size() / 2;
   }
 
+  boolean majorityRejectVotes(Collection<RaftPeerId> rejected) {
+    int num = size();
+    for (RaftPeerId other : rejected) {
+      if (contains(other)) {
+        num --;
+      }
+    }
+    return num <= size() / 2;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfiguration.java
@@ -206,6 +206,12 @@ public final class RaftConfiguration {
         (oldConf == null || oldConf.hasMajority(others, selfId));
   }
 
+  /** @return true if the rejects are in the majority(maybe half is enough in some cases). */
+  boolean majorityRejectVotes(Collection<RaftPeerId> rejects) {
+    return conf.majorityRejectVotes(rejects) ||
+            (oldConf != null && oldConf.majorityRejectVotes(rejects));
+  }
+
   @Override
   public String toString() {
     return logEntryIndex + ": " + conf + ", old=" + oldConf;

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/PeerConfigurationTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/PeerConfigurationTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.impl;
+
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PeerConfigurationTest {
+
+  @Test
+  public void testOddNodesQuorum() {
+    String localId = "0";
+    String node1 = "1";
+    String node2 = "2";
+    PeerConfiguration conf = new PeerConfiguration(raftPeers(localId, node1, node2));
+    // in odd quorum, half + self is majority
+    assertTrue(conf.hasMajority(raftPeerIds(node1), RaftPeerId.valueOf(localId)));
+    // in odd quorum, majority is impossible after half rejected
+    assertFalse(conf.majorityRejectVotes(raftPeerIds(node1)));
+  }
+
+  @Test
+  public void testEvenNodeQuorum() {
+    String localId = "0";
+    String node1 = "1";
+    String node2 = "2";
+    String node3 = "3";
+    PeerConfiguration conf = new PeerConfiguration(raftPeers(localId, node1, node2, node3));
+    // in even quorum, half + self is majority
+    assertFalse(conf.hasMajority(raftPeerIds(node1), RaftPeerId.valueOf(localId)));
+    assertTrue(conf.hasMajority(raftPeerIds(node1, node2), RaftPeerId.valueOf(localId)));
+    // in even quorum, majority is impossible after half rejected
+    assertFalse(conf.majorityRejectVotes(raftPeerIds(node1)));
+    assertTrue(conf.majorityRejectVotes(raftPeerIds(node1, node2)));
+  }
+
+  private Collection<RaftPeer> raftPeers(String... voters) {
+    return Arrays.stream(voters).map(voter -> new RaftPeer(RaftPeerId.valueOf(voter))).collect(Collectors.toSet());
+  }
+
+  private Collection<RaftPeerId> raftPeerIds(String... voters) {
+    return Arrays.stream(voters).map(RaftPeerId::valueOf).collect(Collectors.toSet());
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the leader election approach, the candidate will change to leader in advance if the majority voters vote for it. we can also terminate the approach if majority voters reject it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1120

## How was this patch tested?

unit test.
