### PR TITLE
RATIS-1125. Fix TestDataStream

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -22,7 +22,6 @@ import org.apache.ratis.MiniRaftCluster;
 import org.apache.ratis.client.impl.DataStreamClientImpl;
 import org.apache.ratis.client.impl.DataStreamClientImpl.DataStreamOutputImpl;
 import org.apache.ratis.conf.RaftProperties;
-import org.apache.ratis.netty.NettyConfigKeys;
 import org.apache.ratis.proto.RaftProtos.*;
 import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.GroupInfoReply;
@@ -151,11 +150,9 @@ abstract class DataStreamBaseTest extends BaseTest {
 
   private List<DataStreamServerImpl> servers;
   private List<RaftPeer> peers;
-  private List<MultiDataStreamStateMachine> stateMachines;
+  private ConcurrentMap<RaftGroupId, MultiDataStreamStateMachine> stateMachines;
 
   protected RaftServer newRaftServer(RaftPeer peer, RaftProperties properties) {
-    final ConcurrentMap<RaftGroupId, StateMachine> stateMachines = new ConcurrentHashMap<>();
-
     return new RaftServer() {
       @Override
       public RaftPeerId getId() {
@@ -285,11 +282,8 @@ abstract class DataStreamBaseTest extends BaseTest {
         .map(id -> new RaftPeer(id, NetUtils.createLocalServerAddress()))
         .collect(Collectors.toList());
     servers = new ArrayList<>(peers.size());
-    stateMachines = new ArrayList<>(peers.size());
-    // start stream servers on raft peers.
+    stateMachines = new ConcurrentHashMap<>();
     for (int i = 0; i < peers.size(); i++) {
-      final MultiDataStreamStateMachine stateMachine = new MultiDataStreamStateMachine();
-      stateMachines.add(stateMachine);
       final RaftPeer peer = peers.get(i);
       final RaftServer server = newRaftServer(peer, properties);
       final DataStreamServerImpl streamServer = new DataStreamServerImpl(server, properties, null);
@@ -378,7 +372,7 @@ abstract class DataStreamBaseTest extends BaseTest {
     }
 
     final RaftClientRequest header = out.getHeader();
-    for (MultiDataStreamStateMachine s : stateMachines) {
+    for (MultiDataStreamStateMachine s : stateMachines.values()) {
       final SingleDataStream stream = s.getSingleDataStream(header.getCallId());
       if (stream == null) {
         continue;

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -283,6 +283,7 @@ abstract class DataStreamBaseTest extends BaseTest {
         .collect(Collectors.toList());
     servers = new ArrayList<>(peers.size());
     stateMachines = new ConcurrentHashMap<>();
+    // start stream servers on raft peers.
     for (int i = 0; i < peers.size(); i++) {
       final RaftPeer peer = peers.get(i);
       final RaftServer server = newRaftServer(peer, properties);


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestDataStream no long tests right state machine after RATIS-1124. It is because RaftServer uses its own map to keep state machine so the original state machines used to test server's writes no long work.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1125

## How was this patch tested?

UT
