### PR TITLE
RATIS-1126. Fix can not support more than 10 streams

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -406,6 +406,22 @@ public interface RaftServerConfigKeys {
     }
   }
 
+  interface DataStream {
+    String PREFIX = RaftServerConfigKeys.PREFIX + ".data-stream";
+
+    String ASYNC_THREAD_POOL_SIZE_KEY = PREFIX + ".async.thread.pool.size";
+    int ASYNC_THREAD_POOL_SIZE_DEFAULT = 4;
+
+    static int asyncThreadPoolSize(RaftProperties properties) {
+      return getInt(properties::getInt, ASYNC_THREAD_POOL_SIZE_KEY, ASYNC_THREAD_POOL_SIZE_DEFAULT, getDefaultLog(),
+          requireMin(0), requireMax(65536));
+    }
+
+    static void setAsyncThreadPoolSize(RaftProperties properties, int port) {
+      setInt(properties::setInt, ASYNC_THREAD_POOL_SIZE_KEY, port);
+    }
+  }
+
   /** server rpc timeout related */
   interface Rpc {
     String PREFIX = RaftServerConfigKeys.PREFIX + ".rpc";

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
@@ -44,13 +44,13 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
 
   @Test
   public void testDataStreamSingleServer() throws Exception {
-    runTestDataStream(1, 2, 3, 1_000_000, 10);
-    runTestDataStream(1, 2, 3, 1_000, 10_000);
+    runTestDataStream(1, 2, 20, 1_000_000, 10);
+    runTestDataStream(1, 2, 20, 1_000, 10_000);
   }
 
   @Test
   public void testDataStreamMultipleServer() throws Exception {
-    runTestDataStream(3, 2, 3, 1_000_000, 100);
-    runTestDataStream(3, 2, 3, 1_000, 10_000);
+    runTestDataStream(3, 2, 20, 1_000_000, 100);
+    runTestDataStream(3, 2, 20, 1_000, 10_000);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use new thread pool to support more than 10 streams

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1126

## How was this patch tested?

increase 10 streams to 20 streams