### PR TITLE
RATIS-1109. Notify StateMachine on Configuration change

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1489,8 +1489,10 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
     }
     if (next.hasConfigurationEntry()) {
       // the reply should have already been set. only need to record
-      // the new conf in the metadata file.
+      // the new conf in the metadata file and notify the StateMachine.
       state.writeRaftConfiguration(next);
+      stateMachine.notifyConfigurationChange(next.getTerm(), next.getIndex(),
+            next.getConfigurationEntry());
     } else if (next.hasStateMachineLogEntry()) {
       // check whether there is a TransactionContext because we are the leader.
       TransactionContext trx = role.getLeaderState()

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -18,6 +18,9 @@
 package org.apache.ratis.statemachine;
 
 import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.proto.RaftProtos.RaftConfigurationProto;
+import org.apache.ratis.proto.RaftProtos.RoleInfoProto;
+import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
@@ -27,8 +30,6 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.impl.ServerProtoUtils;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.RaftStorage;
-import org.apache.ratis.proto.RaftProtos.RoleInfoProto;
-import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.LifeCycle;
 import org.slf4j.Logger;
@@ -264,7 +265,7 @@ public interface StateMachine extends Closeable {
 
   /**
    * Called to notify state machine about indexes which are processed
-   * internally by Raft Server, this currently happens when conf entries are
+   * internally by Raft Server, this currently happens when metadata entries are
    * processed in raft Server. This keep state machine to keep a track of index
    * updates.
    * @param term term of the current log entry
@@ -272,6 +273,20 @@ public interface StateMachine extends Closeable {
    */
   default void notifyIndexUpdate(long term, long index) {
 
+  }
+
+  /**
+   * Called to notify state machine about configuration changes to the Raft
+   * Server. This currently happens when conf entries are processed in raft
+   * server. This allows state machine to keep track of configuration changes
+   * on the raft server and also track the index updates corresponding to
+   * configuration changes.
+   * @param term term of the current log entry
+   * @param index index which is being updated
+   * @param newRaftConfiguration new configuration
+   */
+  default void notifyConfigurationChange(long term, long index,
+      RaftConfigurationProto newRaftConfiguration) {
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Ratis receives a Configuration change request (SetConfiguration), the StateMachine is only notified of index update.

CompletableFuture<Message> applyLogToStateMachine(LogEntryProto next) {
  if (!next.hasStateMachineLogEntry()) {
    stateMachine.notifyIndexUpdate(next.getTerm(), next.getIndex());
  } else if (next.hasStateMachineLogEntry()) {
  ......
This Jira aims to add a method in StateMachine interface to notify StateMachine about configuration change.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1109

## How was this patch tested?

No unit test. Tested on Ozone cluster.