### PR TITLE
RATIS-1128. Update Configuration on InstallSnapshot

### DIFF
--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -202,6 +202,8 @@ message InstallSnapshotRequestProto {
     SnapshotChunkProto snapshotChunk = 3;
     NotificationProto notification = 4;
   }
+
+  LogEntryProto lastRaftConfigurationLogEntryProto = 5;
 }
 
 message InstallSnapshotReplyProto {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerConstants.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerConstants.java
@@ -24,6 +24,7 @@ public final class RaftServerConstants {
   @Deprecated
   public static final long INVALID_LOG_INDEX = RaftLog.INVALID_LOG_INDEX;
   public static final long DEFAULT_CALLID = 0;
+  public static final long DEFAULT_TERM = 0;
 
   private RaftServerConstants() {
     //Never constructed


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a Follower is lagging behind and needs to install snapshot to catch up, it can miss any configuration changes that were applied on the Leader. When installing snapshot, the configuration change must also be propagated and applied on the follower. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1128

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
