### PR TITLE
RATIS-1129. Move out the RPC related APIs from DataStreamOutput.

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/DataStreamOutputRpc.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/DataStreamOutputRpc.java
@@ -15,16 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.ratis.client.api;
+package org.apache.ratis.client;
 
-import org.apache.ratis.io.CloseAsync;
+import org.apache.ratis.client.api.DataStreamOutput;
 import org.apache.ratis.protocol.DataStreamReply;
 
-import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
-/** An asynchronous output stream supporting zero buffer copying. */
-public interface DataStreamOutput extends CloseAsync<DataStreamReply> {
-  /** Send out the data in the buffer asynchronously */
-  CompletableFuture<DataStreamReply> writeAsync(ByteBuffer buf);
+/** An RPC interface which extends the user interface {@link DataStreamOutput}. */
+public interface DataStreamOutputRpc extends DataStreamOutput {
+  /** Get the future of the header request. */
+  CompletableFuture<DataStreamReply> getHeaderFuture();
+
+  /** Peer close asynchronously. */
+  CompletableFuture<DataStreamReply> closeForwardAsync();
+
+  /** Create a transaction asynchronously once the stream data is replicated to all servers */
+  CompletableFuture<DataStreamReply> startTransactionAsync();
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/MessageStreamApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/MessageStreamApi.java
@@ -31,11 +31,11 @@ import java.util.concurrent.CompletableFuture;
  * the leader creates a raft log entry for the request
  * and then replicates the log entry to all the followers.
  *
- * Note that this API is similar to {@link org.apache.ratis.client.RaftClient#sendAsync(Message)}
+ * Note that this API is similar to {@link AsyncApi#send(Message)}
  * except that {@link MessageStreamApi} divides a (large) message into multiple (small) sub-messages in the stream
- * but {@link org.apache.ratis.client.RaftClient#sendAsync(Message)} sends the entire message in a single RPC.
+ * but {@link AsyncApi#send(Message)} sends the entire message in a single RPC.
  * For sending large messages,
- * {@link MessageStreamApi} is more efficient than {@link org.apache.ratis.client.RaftClient#sendAsync(Message)}}.
+ * {@link MessageStreamApi} is more efficient than {@link AsyncApi#send(Message)}}.
  *
  * Note also that this API is different from {@link DataStreamApi} in the sense that
  * this API streams messages only to the leader

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -21,7 +21,7 @@ import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.client.DataStreamClient;
 import org.apache.ratis.client.DataStreamClientFactory;
 import org.apache.ratis.client.DataStreamClientRpc;
-import org.apache.ratis.client.api.DataStreamOutput;
+import org.apache.ratis.client.DataStreamOutputRpc;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.datastream.SupportedDataStreamType;
@@ -61,7 +61,7 @@ public class DataStreamClientImpl implements DataStreamClient {
     this.orderedStreamAsync = new OrderedStreamAsync(clientId, dataStreamClientRpc, properties);
   }
 
-  public class DataStreamOutputImpl implements DataStreamOutput {
+  public class DataStreamOutputImpl implements DataStreamOutputRpc {
     private final RaftClientRequest header;
     private final CompletableFuture<DataStreamReply> headerFuture;
 
@@ -122,12 +122,12 @@ public class DataStreamClientImpl implements DataStreamClient {
   }
 
   @Override
-  public DataStreamOutput stream() {
+  public DataStreamOutputRpc stream() {
     return stream(groupId);
   }
 
   @Override
-  public DataStreamOutput stream(RaftGroupId gid) {
+  public DataStreamOutputRpc stream(RaftGroupId gid) {
     return new DataStreamOutputImpl(gid);
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -150,16 +150,10 @@ abstract class DataStreamBaseTest extends BaseTest {
     }
   }
 
-  class Server {
+  static class Server {
     private final RaftPeer peer;
     private final RaftServer raftServer;
     private final DataStreamServerImpl dataStreamServer;
-
-    Server(RaftPeer peer) {
-      this.peer = peer;
-      this.raftServer = newRaftServer(peer, properties);
-      this.dataStreamServer = new DataStreamServerImpl(raftServer, null);
-    }
 
     Server(RaftPeer peer, RaftServer raftServer) {
       this.peer = peer;
@@ -423,7 +417,7 @@ abstract class DataStreamBaseTest extends BaseTest {
           RaftClientReplyProto.parseFrom(replyByteBuffer.slice()));
       Assert.assertTrue(replyByteBuffer.isSuccess());
       Assert.assertEquals(clientReply.getCallId(), expectedClientReply.getCallId());
-      Assert.assertTrue(clientReply.getClientId().equals(expectedClientReply.getClientId()));
+      Assert.assertEquals(clientReply.getClientId(), expectedClientReply.getClientId());
       Assert.assertEquals(clientReply.getLogIndex(), expectedClientReply.getLogIndex());
     }
   }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1129