### PR TITLE
RATIS-1132. Primary and peer should use the same streamId

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/DataStreamClient.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/DataStreamClient.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ratis.client;
 
-import org.apache.ratis.client.api.DataStreamApi;
 import org.apache.ratis.client.impl.DataStreamClientImpl;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
@@ -30,9 +29,9 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 
 /**
- * A user interface extending {@link DataStreamApi}.
+ * A user interface extending {@link DataStreamRpcApi}.
  */
-public interface DataStreamClient extends DataStreamApi, Closeable {
+public interface DataStreamClient extends DataStreamRpcApi, Closeable {
   Logger LOG = LoggerFactory.getLogger(DataStreamClient.class);
 
   /** Return the rpc client instance **/

--- a/ratis-client/src/main/java/org/apache/ratis/client/DataStreamRpcApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/DataStreamRpcApi.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ratis.client;
+
+import org.apache.ratis.client.api.DataStreamApi;
+import org.apache.ratis.client.api.DataStreamOutput;
+import org.apache.ratis.protocol.RaftGroupId;
+
+/** An RPC interface which extends the user interface {@link DataStreamApi}. */
+public interface DataStreamRpcApi extends DataStreamApi {
+  /** Create a stream for primary server to send data to peer server. */
+  DataStreamOutput stream(RaftGroupId groupId, long streamId);
+}

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
@@ -42,7 +42,4 @@ public interface DataStreamApi {
 
   /** Create a stream to write data to the given group. */
   DataStreamOutput stream(RaftGroupId groupId);
-
-  /** Create a stream to write data to the given group. */
-  DataStreamOutput stream(RaftGroupId groupId, long streamId);
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
@@ -42,4 +42,7 @@ public interface DataStreamApi {
 
   /** Create a stream to write data to the given group. */
   DataStreamOutput stream(RaftGroupId groupId);
+
+  /** Create a stream to write data to the given group. */
+  DataStreamOutput stream(RaftGroupId groupId, long streamId);
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -70,7 +70,10 @@ public class DataStreamClientImpl implements DataStreamClient {
     private long streamOffset = 0;
 
     public DataStreamOutputImpl(RaftGroupId groupId) {
-      final long streamId = RaftClientImpl.nextCallId();
+      this(groupId, RaftClientImpl.nextCallId());
+    }
+
+    public DataStreamOutputImpl(RaftGroupId groupId, long streamId) {
       this.header = new RaftClientRequest(clientId, raftServer.getId(), groupId, streamId,
           RaftClientRequest.writeRequestType());
       this.headerFuture = orderedStreamAsync.sendRequest(streamId, -1,
@@ -131,6 +134,11 @@ public class DataStreamClientImpl implements DataStreamClient {
   @Override
   public DataStreamOutputRpc stream(RaftGroupId gid) {
     return new DataStreamOutputImpl(gid);
+  }
+
+  @Override
+  public DataStreamOutputRpc stream(RaftGroupId gid, long streamId) {
+    return new DataStreamOutputImpl(gid, streamId);
   }
 
   @Override

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -80,7 +80,7 @@ public class DataStreamClientImpl implements DataStreamClient {
           ClientProtoUtils.toRaftClientRequestProto(header).toByteString().asReadOnlyByteBuffer(), Type.STREAM_HEADER);
     }
 
-    long getStreamId() {
+    public long getStreamId() {
       return header.getCallId();
     }
 

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -80,7 +80,7 @@ public class DataStreamClientImpl implements DataStreamClient {
           ClientProtoUtils.toRaftClientRequestProto(header).toByteString().asReadOnlyByteBuffer(), Type.STREAM_HEADER);
     }
 
-    public long getStreamId() {
+    long getStreamId() {
       return header.getCallId();
     }
 

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -38,7 +38,6 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.statemachine.StateMachine.DataStream;
-import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.thirdparty.io.netty.bootstrap.ServerBootstrap;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBuf;
 import org.apache.ratis.thirdparty.io.netty.channel.*;
@@ -141,7 +140,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
       return stream;
     }
 
-    public List<DataStreamOutputRpc> getDataStreamOutputs() {
+    List<DataStreamOutputRpc> getDataStreamOutputs() {
       return outs;
     }
 
@@ -157,15 +156,6 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
     public String toString() {
       return getClass().getSimpleName() + ":" + request;
     }
-  }
-
-  @VisibleForTesting
-  public List<DataStreamOutputRpc> getDataStreamOutputRpcs() {
-    List<DataStreamOutputRpc> outputRpcs = new ArrayList<>();
-    for (StreamInfo info : streams.map.values()) {
-      outputRpcs.addAll(info.getDataStreamOutputs());
-    }
-    return outputRpcs;
   }
 
   static class StreamMap {

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -38,6 +38,7 @@ import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.statemachine.StateMachine.DataStream;
+import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.thirdparty.io.netty.bootstrap.ServerBootstrap;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBuf;
 import org.apache.ratis.thirdparty.io.netty.channel.*;
@@ -140,7 +141,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
       return stream;
     }
 
-    List<DataStreamOutputRpc> getDataStreamOutputs() {
+    public List<DataStreamOutputRpc> getDataStreamOutputs() {
       return outs;
     }
 
@@ -156,6 +157,15 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
     public String toString() {
       return getClass().getSimpleName() + ":" + request;
     }
+  }
+
+  @VisibleForTesting
+  public List<DataStreamOutputRpc> getDataStreamOutputRpcs() {
+    List<DataStreamOutputRpc> outputRpcs = new ArrayList<>();
+    for (StreamInfo info : streams.map.values()) {
+      outputRpcs.addAll(info.getDataStreamOutputs());
+    }
+    return outputRpcs;
   }
 
   static class StreamMap {

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
@@ -78,7 +78,7 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
     RaftClientReply expectedClientReply = new RaftClientReply(clientId, suggestedLeader.getId(),
         groupId, callId, true, null, null, longIndex, null);
 
-    for (int i = 0; i < 3; i ++) {
+    for (int i = 0; i < numServers; i ++) {
       RaftServer raftServer = mock(RaftServer.class);
       RaftClientReply raftClientReply;
       RaftPeerId peerId = RaftPeerId.valueOf("s" + i);
@@ -122,5 +122,10 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
   public void testCloseStreamOneServer() throws Exception {
     // primary is 0, leader is 0
     testCloseStream(0, 1);
+  }
+
+  @Test
+  public void testSameStreamId() throws Exception {
+    runTestSameStreamId(3, 1_000_000, 10);
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
@@ -123,9 +123,4 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
     // primary is 0, leader is 0
     testCloseStream(0, 1);
   }
-
-  @Test
-  public void testSameStreamId() throws Exception {
-    runTestSameStreamId(3, 1_000_000, 10);
-  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When peer create data stream, it call RaftClientImpl.nextCallId(), so the primary's streamId maybe different from peer's.
It maybe difficult to debug when error happen.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1132

## How was this patch tested?

new ut
