### PR TITLE
RATIS-1133. Primary and peer should use the same RaftClientReques

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/DataStreamRpcApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/DataStreamRpcApi.java
@@ -20,10 +20,10 @@ package org.apache.ratis.client;
 
 import org.apache.ratis.client.api.DataStreamApi;
 import org.apache.ratis.client.api.DataStreamOutput;
-import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftClientRequest;
 
 /** An RPC interface which extends the user interface {@link DataStreamApi}. */
 public interface DataStreamRpcApi extends DataStreamApi {
   /** Create a stream for primary server to send data to peer server. */
-  DataStreamOutput stream(RaftGroupId groupId, long streamId);
+  DataStreamOutput stream(RaftClientRequest request);
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -70,13 +70,13 @@ public class DataStreamClientImpl implements DataStreamClient {
     private long streamOffset = 0;
 
     public DataStreamOutputImpl(RaftGroupId groupId) {
-      this(groupId, RaftClientImpl.nextCallId());
+      this(new RaftClientRequest(clientId, raftServer.getId(), groupId, RaftClientImpl.nextCallId(),
+          RaftClientRequest.writeRequestType()));
     }
 
-    public DataStreamOutputImpl(RaftGroupId groupId, long streamId) {
-      this.header = new RaftClientRequest(clientId, raftServer.getId(), groupId, streamId,
-          RaftClientRequest.writeRequestType());
-      this.headerFuture = orderedStreamAsync.sendRequest(streamId, -1,
+    public DataStreamOutputImpl(RaftClientRequest request) {
+      this.header = request;
+      this.headerFuture = orderedStreamAsync.sendRequest(request.getCallId(), -1,
           ClientProtoUtils.toRaftClientRequestProto(header).toByteString().asReadOnlyByteBuffer(), Type.STREAM_HEADER);
     }
 
@@ -137,8 +137,8 @@ public class DataStreamClientImpl implements DataStreamClient {
   }
 
   @Override
-  public DataStreamOutputRpc stream(RaftGroupId gid, long streamId) {
-    return new DataStreamOutputImpl(gid, streamId);
+  public DataStreamOutputRpc stream(RaftClientRequest request) {
+    return new DataStreamOutputImpl(request);
   }
 
   @Override

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -63,18 +63,13 @@ public class DataStreamClientImpl implements DataStreamClient {
     this.orderedStreamAsync = new OrderedStreamAsync(clientId, dataStreamClientRpc, properties);
   }
 
-  public class DataStreamOutputImpl implements DataStreamOutputRpc {
+  public final class DataStreamOutputImpl implements DataStreamOutputRpc {
     private final RaftClientRequest header;
     private final CompletableFuture<DataStreamReply> headerFuture;
 
     private long streamOffset = 0;
 
-    public DataStreamOutputImpl(RaftGroupId groupId) {
-      this(new RaftClientRequest(clientId, raftServer.getId(), groupId, RaftClientImpl.nextCallId(),
-          RaftClientRequest.writeRequestType()));
-    }
-
-    public DataStreamOutputImpl(RaftClientRequest request) {
+    private DataStreamOutputImpl(RaftClientRequest request) {
       this.header = request;
       this.headerFuture = orderedStreamAsync.sendRequest(request.getCallId(), -1,
           ClientProtoUtils.toRaftClientRequestProto(header).toByteString().asReadOnlyByteBuffer(), Type.STREAM_HEADER);
@@ -133,7 +128,9 @@ public class DataStreamClientImpl implements DataStreamClient {
 
   @Override
   public DataStreamOutputRpc stream(RaftGroupId gid) {
-    return new DataStreamOutputImpl(gid);
+    RaftClientRequest request = new RaftClientRequest(
+        clientId, raftServer.getId(), groupId, RaftClientImpl.nextCallId(), RaftClientRequest.writeRequestType());
+    return new DataStreamOutputImpl(request);
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -475,11 +475,7 @@ abstract class DataStreamBaseTest extends BaseTest {
     Assert.assertEquals(dataSize, stream.getByteWritten());
     Assert.assertEquals(writeRequest.getCallId(), header.getCallId());
     Assert.assertEquals(writeRequest.getClientId(), header.getClientId());
-
-    final Server primary = getPrimaryServer();
-    if (server == primary) {
-      Assert.assertEquals(writeRequest.getServerId(), header.getServerId());
-    }
+    Assert.assertEquals(writeRequest.getServerId(), header.getServerId());
   }
 
   static ByteBuffer initBuffer(int offset, int size) {

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -474,6 +474,7 @@ abstract class DataStreamBaseTest extends BaseTest {
     Assert.assertEquals(raftGroup.getGroupId(), header.getRaftGroupId());
     Assert.assertEquals(dataSize, stream.getByteWritten());
     Assert.assertEquals(writeRequest.getCallId(), header.getCallId());
+    Assert.assertEquals(writeRequest.getClientId(), header.getClientId());
 
     final Server primary = getPrimaryServer();
     if (server == primary) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When primary create DataStreamOutputImpl for peer, it will create a new [RaftClientRequest](https://github.com/apache/incubator-ratis/blob/master/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java#L77) and send it to peer. I think primary should send RaftClientRequest got from client to peer.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1133

## How was this patch tested?

new assert
