### PR TITLE
RATIS-1134. Remove DataStreamApi.stream(RaftGroupId).

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
@@ -37,9 +37,6 @@ import org.apache.ratis.protocol.RaftGroupId;
  * but {@link MessageStreamApi} streams messages only to the leader.
  */
 public interface DataStreamApi {
-  /** Create a stream to write data to the default group. */
+  /** Create a stream to write data. */
   DataStreamOutput stream();
-
-  /** Create a stream to write data to the given group. */
-  DataStreamOutput stream(RaftGroupId groupId);
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
@@ -17,8 +17,6 @@
  */
 package org.apache.ratis.client.api;
 
-import org.apache.ratis.protocol.RaftGroupId;
-
 /**
  * Stream data asynchronously to all the servers in the {@link org.apache.ratis.protocol.RaftGroup}.
  * Clients may stream data to the nearest server and then the server will forward the data to the other servers.

--- a/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamPacketByteBuffer.java
+++ b/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamPacketByteBuffer.java
@@ -24,13 +24,13 @@ import java.nio.ByteBuffer;
  * Implements {@link org.apache.ratis.protocol.DataStreamPacket} with {@link ByteBuffer}.
  */
 public abstract class DataStreamPacketByteBuffer extends DataStreamPacketImpl {
-  private static final ByteBuffer EMPTY = ByteBuffer.allocateDirect(0).asReadOnlyBuffer();
+  public static final ByteBuffer EMPTY_BYTE_BUFFER = ByteBuffer.allocateDirect(0).asReadOnlyBuffer();
 
   private final ByteBuffer buffer;
 
   public DataStreamPacketByteBuffer(long streamId, long streamOffset, ByteBuffer buffer, Type type) {
     super(streamId, streamOffset, type);
-    this.buffer = buffer != null? buffer.asReadOnlyBuffer(): EMPTY;
+    this.buffer = buffer != null? buffer.asReadOnlyBuffer(): EMPTY_BYTE_BUFFER;
   }
 
   @Override

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -397,8 +397,8 @@ abstract class DataStreamBaseTest extends BaseTest {
         final RaftClient client = newRaftClientForDataStream();
         clients.add(client);
         for (int i = 0; i < numStreams; i++) {
-          futures.add(CompletableFuture.runAsync(
-              () -> runTestDataStream((DataStreamOutputImpl) client.getDataStreamApi().stream(raftGroup.getGroupId()), bufferSize, bufferNum)));
+          futures.add(CompletableFuture.runAsync(() -> runTestDataStream(
+              (DataStreamOutputImpl) client.getDataStreamApi().stream(), bufferSize, bufferNum)));
         }
       }
       Assert.assertEquals(numClients*numStreams, futures.size());
@@ -413,7 +413,7 @@ abstract class DataStreamBaseTest extends BaseTest {
   private void runTestCloseStream(int bufferSize, int bufferNum, RaftClientReply expectedClientReply)
       throws IOException {
     try (final RaftClient client = newRaftClientForDataStream()) {
-      DataStreamOutputImpl out = (DataStreamOutputImpl) client.getDataStreamApi().stream(raftGroup.getGroupId());
+      final DataStreamOutputImpl out = (DataStreamOutputImpl) client.getDataStreamApi().stream();
       runTestDataStream(out, bufferSize, bufferNum);
       DataStreamReplyByteBuffer replyByteBuffer = (DataStreamReplyByteBuffer) out.closeAsync().join();
 

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamDisabled.java
@@ -20,7 +20,6 @@ package org.apache.ratis.datastream;
 import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.client.DisabledDataStreamClientFactory;
 import org.apache.ratis.client.RaftClient;
-import org.apache.ratis.client.impl.DataStreamClientImpl;
 import org.apache.ratis.conf.RaftProperties;
 import org.junit.Before;
 import org.junit.Rule;

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
@@ -58,13 +58,13 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
 
   @Test
   public void testDataStreamSingleServer() throws Exception {
-    runTestDataStream(1, 2, 20, 1_000_000, 10);
+    runTestDataStream(1, 5, 10, 1_000_000, 10);
     runTestDataStream(1, 2, 20, 1_000, 10_000);
   }
 
   @Test
   public void testDataStreamMultipleServer() throws Exception {
-    runTestDataStream(3, 2, 20, 1_000_000, 100);
+    runTestDataStream(3, 5, 10, 1_000_000, 10);
     runTestDataStream(3, 2, 20, 1_000, 10_000);
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1134