### PR TITLE
RATIS-1135. Initialize DataStreamServer after RaftServerProxy id is set

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -180,9 +180,11 @@ public class RaftServerProxy implements RaftServer {
     this.factory = ServerFactory.cast(rpcType.newFactory(parameters));
 
     this.serverRpc = factory.newRaftServerRpc(this);
-    this.dataStreamServerRpc = new DataStreamServerImpl(this, parameters).getServerRpc();
 
     this.id = id != null? id: RaftPeerId.valueOf(getIdStringFrom(serverRpc));
+
+    this.dataStreamServerRpc = new DataStreamServerImpl(this, parameters).getServerRpc();
+
     this.lifeCycle = new LifeCycle(this.id + "-" + getClass().getSimpleName());
 
     this.implExecutor = Executors.newSingleThreadExecutor();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The server id could be `null` at https://github.com/apache/incubator-ratis/blob/189ee94471afdef8bd6c8b1fb419309230bfaa24/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java#L185

So move the DataStreamServer creation after it.

Otherwise the `server.getId()` could be `null` at https://github.com/apache/incubator-ratis/blob/189ee94471afdef8bd6c8b1fb419309230bfaa24/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java#L221


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1135

## How was this patch tested?

UT
