### PR TITLE
RATIS-1140. Do not create DataStreamOutput for non-primary server

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -57,6 +57,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -253,7 +254,8 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
           RaftClientRequestProto.parseFrom(buf.nioBuffer()));
       final StateMachine stateMachine = server.getStateMachine(request.getRaftGroupId());
       return new StreamInfo(request, stateMachine.data().stream(request),
-          proxies.getDataStreamOutput(request));
+          server.getId().equals(request.getServerId())?
+          proxies.getDataStreamOutput(request) : Collections.EMPTY_LIST);
     } catch (Throwable e) {
       throw new CompletionException(e);
     }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -335,15 +335,16 @@ abstract class DataStreamBaseTest extends BaseTest {
     // start stream servers on raft peers.
     for (int i = 0; i < peers.size(); i++) {
       final Server server = new Server(peers.get(i), raftServers.get(i));
-      if (i == 0) {
-        // only the first server routes requests to peers.
-        List<RaftPeer> otherPeers = new ArrayList<>(peers);
-        otherPeers.remove(peers.get(i));
-        server.addRaftPeers(otherPeers);
-      }
+      server.addRaftPeers(removePeerFromList(peers.get(i), peers));
       server.start();
       servers.add(server);
     }
+  }
+
+  private Collection<RaftPeer> removePeerFromList(RaftPeer peer, List<RaftPeer> peers) {
+    List<RaftPeer> otherPeers = new ArrayList<>(peers);
+    otherPeers.remove(peer);
+    return otherPeers;
   }
 
   RaftClient newRaftClientForDataStream() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

I found this issue when setting up MiniRaftCluster for data stream. In a normal case, every Raft peer can act as a primary server and clients will decide which Raft to use.

However, when all Raft peers can act as a primary. in previous implementation, there will be a deadlock case that a server will receive a request, and then route to other peers, and other peers will do the same.

Thus we should distinguish primary server by adding primary server id into the Raft proto, and do not forward requests to peers when the server is not the primary.

## What is the link to the Apache JIRA


https://issues.apache.org/jira/browse/RATIS-1140

## How was this patch tested?

UT
