### PR TITLE
RATIS-1142. Remove STREAM_CLOSE_FORWARD

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/DataStreamOutputRpc.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/DataStreamOutputRpc.java
@@ -27,9 +27,6 @@ public interface DataStreamOutputRpc extends DataStreamOutput {
   /** Get the future of the header request. */
   CompletableFuture<DataStreamReply> getHeaderFuture();
 
-  /** Peer close asynchronously. */
-  CompletableFuture<DataStreamReply> closeForwardAsync();
-
   /** Create a transaction asynchronously once the stream data is replicated to all servers */
   CompletableFuture<DataStreamReply> startTransactionAsync();
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -88,11 +88,6 @@ public class DataStreamClientImpl implements DataStreamClient {
     }
 
     @Override
-    public CompletableFuture<DataStreamReply> closeForwardAsync() {
-      return send(Type.STREAM_CLOSE_FORWARD);
-    }
-
-    @Override
     public CompletableFuture<DataStreamReply> startTransactionAsync() {
       return send(Type.START_TRANSACTION);
     }

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -287,8 +287,7 @@ message DataStreamPacketHeaderProto {
     STREAM_HEADER = 0;
     STREAM_DATA = 1;
     STREAM_CLOSE = 2;
-    STREAM_CLOSE_FORWARD = 3;
-    START_TRANSACTION = 4;
+    START_TRANSACTION = 3;
   }
 
   uint64 streamId = 1;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove STREAM_CLOSE_FORWARD, because we use `boolean isPrimary(RaftPeerId primaryId) `to distinguish primary and peer.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1142

## How was this patch tested?

No need new ut.
