### PR TITLE
RATIS-1144. Default disable datastream when start a MiniRaftCluster

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/RaftConfigKeys.java
+++ b/ratis-common/src/main/java/org/apache/ratis/RaftConfigKeys.java
@@ -51,7 +51,7 @@ public interface RaftConfigKeys {
     String PREFIX = RaftConfigKeys.PREFIX + ".datastream";
 
     String TYPE_KEY = PREFIX + ".type";
-    String TYPE_DEFAULT = SupportedDataStreamType.NETTY.name();
+    String TYPE_DEFAULT = SupportedDataStreamType.DISABLED.name();
 
     static SupportedDataStreamType type(RaftProperties properties, Consumer<String> logger) {
       final String t = get(properties::get, TYPE_KEY, TYPE_DEFAULT, logger);

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
@@ -96,6 +96,7 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
       RaftPeerId peerId = RaftPeerId.valueOf("s" + i);
       RaftProperties properties = new RaftProperties();
       NettyConfigKeys.DataStream.setPort(properties, NetUtils.createLocalServerAddress().getPort());
+      RaftConfigKeys.DataStream.setType(properties, SupportedDataStreamType.NETTY);
 
       if (i == leaderIndex) {
         raftClientReply = expectedClientReply;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Default disable datastream when start a MiniRaftCluster, so that the other test no need to start data stream server, to make the CI run faster.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1144

## How was this patch tested?

no need to add new ut.
