### PR TITLE
RATIS-1145. In NettyServerStreamRpc, the local/remote writes should only wait for the previous write.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -410,7 +410,7 @@ public interface RaftServerConfigKeys {
     String PREFIX = RaftServerConfigKeys.PREFIX + ".data-stream";
 
     String ASYNC_THREAD_POOL_SIZE_KEY = PREFIX + ".async.thread.pool.size";
-    int ASYNC_THREAD_POOL_SIZE_DEFAULT = 4;
+    int ASYNC_THREAD_POOL_SIZE_DEFAULT = 16;
 
     static int asyncThreadPoolSize(RaftProperties properties) {
       return getInt(properties::getInt, ASYNC_THREAD_POOL_SIZE_KEY, ASYNC_THREAD_POOL_SIZE_DEFAULT, getDefaultLog(),

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestDataStreamNetty.java
@@ -70,14 +70,12 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
 
   @Test
   public void testDataStreamSingleServer() throws Exception {
-    runTestDataStream(1, 5, 10, 1_000_000, 10);
-    runTestDataStream(1, 2, 20, 1_000, 10_000);
+    runTestDataStream(1);
   }
 
   @Test
   public void testDataStreamMultipleServer() throws Exception {
-    runTestDataStream(3, 5, 10, 1_000_000, 10);
-    runTestDataStream(3, 2, 20, 1_000, 10_000);
+    runTestDataStream(3);
   }
 
   private void testCloseStream(int leaderIndex, int numServers) throws Exception {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1145