### PR TITLE
RATIS-1141. Class.getSimpleName() has a 4% overhead in the SegmentedRaftLogWriter thread.

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/RaftClientConfigKeys.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.client;
 
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
@@ -77,7 +78,7 @@ public interface RaftClientConfigKeys {
     }
 
     interface Experimental {
-      String PREFIX = Async.PREFIX + "." + Experimental.class.getSimpleName().toLowerCase();
+      String PREFIX = Async.PREFIX + "." + JavaUtils.getClassSimpleName(Experimental.class).toLowerCase();
 
       String SEND_DUMMY_REQUEST_KEY = PREFIX + ".send-dummy-request";
       boolean SEND_DUMMY_REQUEST_DEFAULT = true;

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftOutputStream.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftOutputStream.java
@@ -131,6 +131,6 @@ public class RaftOutputStream extends OutputStream {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "-" + getClient().getId() + ":byteFlushed=" + byteFlushed;
+    return JavaUtils.getClassSimpleName(getClass()) + "-" + getClient().getId() + ":byteFlushed=" + byteFlushed;
   }
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/retry/ClientRetryEvent.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/retry/ClientRetryEvent.java
@@ -21,6 +21,7 @@ import org.apache.ratis.client.impl.RaftClientImpl.PendingClientRequest;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 
 /** An {@link RetryPolicy.Event} specific to client request failure. */
@@ -73,6 +74,9 @@ public class ClientRetryEvent implements RetryPolicy.Event {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + ":attempt=" + attemptCount + ",request=" + request + ",cause=" + cause;
+    return JavaUtils.getClassSimpleName(getClass())
+        + ":attempt=" + attemptCount
+        + ",request=" + request
+        + ",cause=" + cause;
   }
 }

--- a/ratis-client/src/main/java/org/apache/ratis/client/retry/RequestTypeDependentRetryPolicy.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/retry/RequestTypeDependentRetryPolicy.java
@@ -20,6 +20,7 @@ package org.apache.ratis.client.retry;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.retry.RetryPolicy;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.TimeDuration;
 
@@ -74,7 +75,7 @@ public final class RequestTypeDependentRetryPolicy implements RetryPolicy {
     this.retryPolicyMap = Collections.unmodifiableMap(map);
     this.timeoutMap = timeoutMap;
     this.myString = () -> {
-      final StringBuilder b = new StringBuilder(getClass().getSimpleName()).append("{");
+      final StringBuilder b = new StringBuilder(JavaUtils.getClassSimpleName(getClass())).append("{");
       map.forEach((key, value) -> b.append(key).append("->").append(value).append(", "));
       b.setLength(b.length() - 2);
       return b.append("}").toString();

--- a/ratis-common/src/main/java/org/apache/ratis/datastream/DataStreamType.java
+++ b/ratis-common/src/main/java/org/apache/ratis/datastream/DataStreamType.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.datastream;
 
 import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.ReflectionUtils;
 
 /** The type of data stream implementations. */
@@ -41,10 +42,11 @@ public interface DataStreamType {
       // Try using it as a class name
       return ReflectionUtils.newInstance(ReflectionUtils.getClass(dataStreamType, DataStreamType.class));
     } catch(Throwable t) {
+      final String classname = JavaUtils.getClassSimpleName(DataStreamType.class);
       final IllegalArgumentException iae = new IllegalArgumentException(
-          "Invalid " + DataStreamType.class.getSimpleName() + ": \"" + dataStreamType + "\" "
-              + " cannot be used as a user-defined " + DataStreamType.class.getSimpleName()
-              + " and it is not a " + SupportedDataStreamType.class.getSimpleName() + ".");
+          "Invalid " + classname + ": \"" + dataStreamType + "\" "
+              + " cannot be used as a user-defined " + classname
+              + " and it is not a " + JavaUtils.getClassSimpleName(SupportedDataStreamType.class) + ".");
       iae.addSuppressed(t);
       iae.addSuppressed(fromSupportedRpcType);
       throw iae;

--- a/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamPacketImpl.java
+++ b/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamPacketImpl.java
@@ -19,6 +19,7 @@ package org.apache.ratis.datastream.impl;
 
 import org.apache.ratis.protocol.DataStreamPacket;
 import org.apache.ratis.proto.RaftProtos.DataStreamPacketHeaderProto.Type;
+import org.apache.ratis.util.JavaUtils;
 
 /**
  * This is an abstract implementation of {@link DataStreamPacket}.
@@ -53,7 +54,7 @@ public abstract class DataStreamPacketImpl implements DataStreamPacket {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "{"
+    return JavaUtils.getClassSimpleName(getClass()) + "{"
         + "streamId=" + getStreamId()
         + ", streamOffset=" + getStreamOffset()
         + ", dataLength=" + getDataLength()

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/GroupManagementRequest.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/GroupManagementRequest.java
@@ -17,6 +17,8 @@
  */
 package org.apache.ratis.protocol;
 
+import org.apache.ratis.util.JavaUtils;
+
 public final class GroupManagementRequest extends RaftClientRequest {
   public abstract static class Op {
     public abstract RaftGroupId getGroupId();
@@ -40,7 +42,7 @@ public final class GroupManagementRequest extends RaftClientRequest {
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + ":" + getGroup();
+      return JavaUtils.getClassSimpleName(getClass()) + ":" + getGroup();
     }
   }
 
@@ -71,7 +73,7 @@ public final class GroupManagementRequest extends RaftClientRequest {
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + ":" + getGroupId() + ", "
+      return JavaUtils.getClassSimpleName(getClass()) + ":" + getGroupId() + ", "
           + (deleteDirectory? "delete": (renameDirectory ? "rename" : "retain"))
           + "-dir";
     }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientMessage.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 package org.apache.ratis.protocol;
+
+import org.apache.ratis.util.JavaUtils;
 
 public abstract class RaftClientMessage implements RaftRpcMessage {
   private final ClientId clientId;
@@ -54,7 +56,7 @@ public abstract class RaftClientMessage implements RaftRpcMessage {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + ":" + clientId + "->" + serverId
+    return JavaUtils.getClassSimpleName(getClass()) + ":" + clientId + "->" + serverId
         + (groupId != null? "@" + groupId: "");
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/retry/MultipleLinearRandomRetry.java
+++ b/ratis-common/src/main/java/org/apache/ratis/retry/MultipleLinearRandomRetry.java
@@ -80,7 +80,7 @@ public final class MultipleLinearRandomRetry implements RetryPolicy {
       throw new IllegalArgumentException("pairs must be neither null nor empty.");
     }
     this.pairs = Collections.unmodifiableList(pairs);
-    this.myString = JavaUtils.memoize(() -> getClass().getSimpleName() + pairs);
+    this.myString = JavaUtils.memoize(() -> JavaUtils.getClassSimpleName(getClass()) + pairs);
   }
 
   @Override

--- a/ratis-common/src/main/java/org/apache/ratis/retry/RetryPolicies.java
+++ b/ratis-common/src/main/java/org/apache/ratis/retry/RetryPolicies.java
@@ -62,7 +62,7 @@ public interface RetryPolicies {
 
     @Override
     public String toString() {
-      return getClass().getSimpleName();
+      return JavaUtils.getClassSimpleName(getClass());
     }
   }
 
@@ -76,7 +76,7 @@ public interface RetryPolicies {
 
     @Override
     public String toString() {
-      return getClass().getSimpleName();
+      return JavaUtils.getClassSimpleName(getClass());
     }
   }
 
@@ -96,7 +96,7 @@ public interface RetryPolicies {
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + "(sleepTime = " + sleepTime + ")";
+      return JavaUtils.getClassSimpleName(getClass()) + "(sleepTime = " + sleepTime + ")";
     }
   }
 
@@ -113,7 +113,7 @@ public interface RetryPolicies {
       }
 
       this.maxAttempts = maxAttempts;
-      this.myString = JavaUtils.memoize(() -> getClass().getSimpleName()
+      this.myString = JavaUtils.memoize(() -> JavaUtils.getClassSimpleName(getClass())
           + "(maxAttempts=" + maxAttempts + ", sleepTime=" + sleepTime + ")");
     }
 

--- a/ratis-common/src/main/java/org/apache/ratis/rpc/RpcType.java
+++ b/ratis-common/src/main/java/org/apache/ratis/rpc/RpcType.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.rpc;
 
 import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.ReflectionUtils;
 
 /** The type of RPC implementations. */
@@ -42,10 +43,11 @@ public interface RpcType {
       return ReflectionUtils.newInstance(
           ReflectionUtils.getClass(rpcType, RpcType.class));
     } catch(Exception e) {
+      final String classname = JavaUtils.getClassSimpleName(RpcType.class);
       final IllegalArgumentException iae = new IllegalArgumentException(
-          "Invalid " + RpcType.class.getSimpleName() + ": \"" + rpcType + "\" "
-              + " cannot be used as a user-defined " + RpcType.class.getSimpleName()
-              + " and it is not a " + SupportedRpcType.class.getSimpleName() + ".");
+          "Invalid " + classname + ": \"" + rpcType + "\" "
+              + " cannot be used as a user-defined " + classname
+              + " and it is not a " + JavaUtils.getClassSimpleName(SupportedRpcType.class) + ".");
       iae.addSuppressed(e);
       iae.addSuppressed(fromSupportedRpcType);
       throw iae;

--- a/ratis-common/src/main/java/org/apache/ratis/util/JavaUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/JavaUtils.java
@@ -35,6 +35,8 @@ import java.util.TimerTask;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
@@ -49,6 +51,11 @@ public interface JavaUtils {
 
   DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
   CompletableFuture[] EMPTY_COMPLETABLE_FUTURE_ARRAY = {};
+
+  ConcurrentMap<Class<?>, String> CLASS_SIMPLE_NAMES = new ConcurrentHashMap<>();
+  static String getClassSimpleName(Class<?> clazz) {
+    return CLASS_SIMPLE_NAMES.computeIfAbsent(clazz, Class::getSimpleName);
+  }
 
   static String date() {
     return DATE_FORMAT.format(new Date());

--- a/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
@@ -39,7 +39,7 @@ public interface SlidingWindow {
   Logger LOG = LoggerFactory.getLogger(SlidingWindow.class);
 
   static String getName(Class<?> clazz, Object name) {
-    return SlidingWindow.class.getSimpleName() +  "$" + clazz.getSimpleName() + ":" + name;
+    return JavaUtils.getClassSimpleName(SlidingWindow.class) +  "$" + JavaUtils.getClassSimpleName(clazz) + ":" + name;
   }
 
   interface Request<REPLY> {

--- a/ratis-common/src/main/java/org/apache/ratis/util/TaskQueue.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/TaskQueue.java
@@ -120,7 +120,7 @@ public class TaskQueue {
   }
 
   @Override
-  public synchronized String toString() {
-    return name + "-" + getClass().getSimpleName();
+  public String toString() {
+    return name + "-" + JavaUtils.getClassSimpleName(getClass());
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/util/TimeDuration.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/TimeDuration.java
@@ -259,7 +259,7 @@ public final class TimeDuration implements Comparable<TimeDuration> {
   public long roundUpNanos(long nanos) {
     if (duration <= 0) {
       throw new ArithmeticException(
-          "Rounding up to a non-positive " + getClass().getSimpleName() + " (=" + this + ")");
+          "Rounding up to a non-positive " + JavaUtils.getClassSimpleName(getClass()) + " (=" + this + ")");
     }
 
     final long divisor = toLong(TimeUnit.NANOSECONDS);

--- a/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
+++ b/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
@@ -103,7 +103,7 @@ public abstract class BaseTest {
   }
 
   public File getClassTestDir() {
-    return new File(getRootTestDir(), getClass().getSimpleName());
+    return new File(getRootTestDir(), JavaUtils.getClassSimpleName(getClass()));
   }
 
   public File getTestDir() {
@@ -116,7 +116,7 @@ public abstract class BaseTest {
       Class<? extends Throwable> expectedThrowableClass, Logger log,
       Class<? extends Throwable>... expectedCauseClasses) {
     if (log != null) {
-      log.info("The test \"" + description + "\" throws " + t.getClass().getSimpleName(), t);
+      log.info("The test \"{}\" throws {}", description,  JavaUtils.getClassSimpleName(t.getClass()), t);
     }
     Assert.assertEquals(expectedThrowableClass, t.getClass());
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/Runner.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/Runner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,6 +21,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import org.apache.ratis.examples.arithmetic.cli.Arithmetic;
 import org.apache.ratis.examples.filestore.cli.FileStore;
+import org.apache.ratis.util.JavaUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -51,13 +52,13 @@ public final class Runner {
 
     JCommander.Builder builder = JCommander.newBuilder().addObject(runner);
     commands.forEach(command -> builder
-        .addCommand(command.getClass().getSimpleName().toLowerCase(), command));
+        .addCommand(JavaUtils.getClassSimpleName(command.getClass()).toLowerCase(), command));
     JCommander jc = builder.build();
     try {
       jc.parse(newArgs);
-      Optional<SubCommandBase> selectedCommand = commands.stream().filter(
-          command -> command.getClass().getSimpleName()
-              .equalsIgnoreCase(jc.getParsedCommand())).findFirst();
+      final Optional<SubCommandBase> selectedCommand = commands.stream()
+          .filter(command -> JavaUtils.getClassSimpleName(command.getClass()).equalsIgnoreCase(jc.getParsedCommand()))
+          .findFirst();
       if (selectedCommand.isPresent()) {
         selectedCommand.get().run();
       } else {
@@ -71,9 +72,9 @@ public final class Runner {
   }
 
   private static List<SubCommandBase> initializeCommands(String command) {
-    if (command.equalsIgnoreCase(FileStore.class.getSimpleName())) {
+    if (command.equalsIgnoreCase(JavaUtils.getClassSimpleName(FileStore.class))) {
       return FileStore.getSubCommands();
-    } else if (command.equalsIgnoreCase(Arithmetic.class.getSimpleName())) {
+    } else if (command.equalsIgnoreCase(JavaUtils.getClassSimpleName(Arithmetic.class))) {
       return Arithmetic.getSubCommands();
     }
     return null;

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
@@ -105,7 +105,8 @@ public class FileStore implements Closeable {
   }
 
   public RaftPeerId getId() {
-    return Objects.requireNonNull(idSupplier.get(), getClass().getSimpleName() + " is not initialized.");
+    return Objects.requireNonNull(idSupplier.get(),
+        () -> JavaUtils.getClassSimpleName(getClass()) + " is not initialized.");
   }
 
   public Path getRoot() {

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/ParameterizedBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/ParameterizedBaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -27,6 +27,7 @@ import org.apache.ratis.netty.MiniRaftClusterWithNetty;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
 import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.AfterClass;
 import org.junit.Test;
@@ -46,7 +47,7 @@ public abstract class ParameterizedBaseTest extends BaseTest {
 
   /** Subclasses should override this method to provide real data parameters. */
   @Parameterized.Parameters
-  public static Collection<Object[]> data() throws IOException {
+  public static Collection<Object[]> data() {
     return Collections.emptyList();
   }
 
@@ -76,14 +77,12 @@ public abstract class ParameterizedBaseTest extends BaseTest {
 
   private static void add(
       Collection<Object[]> clusters, MiniRaftCluster.Factory factory,
-      String[] ids, RaftProperties properties)
-      throws IOException {
+      String[] ids, RaftProperties properties) {
     clusters.add(new Object[]{factory.newCluster(ids, properties)});
   }
 
   public static Collection<Object[]> getMiniRaftClusters(
-      RaftProperties prop, int clusterSize, Class<?>... clusterClasses)
-      throws IOException {
+      RaftProperties prop, int clusterSize, Class<?>... clusterClasses) {
     final List<Class<?>> classes = Arrays.asList(clusterClasses);
     final boolean isAll = classes.isEmpty(); //empty means all
 
@@ -114,15 +113,14 @@ public abstract class ParameterizedBaseTest extends BaseTest {
 //      add(clusters, MiniRaftClusterWithHadoopRpc.FACTORY, ids.next(), prop);
     }
     for(int i = 0; i < clusters.size(); i++) {
-      LOG.info(i + ": " + clusters.get(i)[0].getClass().getSimpleName());
+      LOG.info(i + ": " + JavaUtils.getClassSimpleName(clusters.get(i)[0].getClass()));
     }
     LOG.info("#clusters = " + clusters.size());
     return clusters;
   }
 
   public static <S extends StateMachine> Collection<Object[]> getMiniRaftClusters(
-      Class<S> stateMachineClass, int clusterSize, Class<?>... clusterClasses)
-      throws IOException {
+      Class<S> stateMachineClass, int clusterSize, Class<?>... clusterClasses) {
     final RaftProperties prop = new RaftProperties();
 
     // avoid flaky behaviour in CI environment

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmetic.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmetic.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -45,7 +45,7 @@ public class TestArithmetic extends ParameterizedBaseTest {
   }
 
   @Parameterized.Parameters
-  public static Collection<Object[]> data() throws IOException {
+  public static Collection<Object[]> data() {
     return getMiniRaftClusters(ArithmeticStateMachine.class, 3);
   }
 

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/counter/TestCounter.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/counter/TestCounter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -35,7 +35,7 @@ import java.util.Collection;
 public class TestCounter extends ParameterizedBaseTest {
 
   @Parameterized.Parameters
-  public static Collection<Object[]> data() throws IOException {
+  public static Collection<Object[]> data() {
     return getMiniRaftClusters(CounterStateMachine.class, 3);
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
@@ -233,7 +233,7 @@ public class GrpcClientProtocolClient implements Closeable {
 
     @Override
     public String toString() {
-      return getName() + ":" + getClass().getSimpleName();
+      return getName() + ":" + JavaUtils.getClassSimpleName(getClass());
     }
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolService.java
@@ -105,11 +105,11 @@ public class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase
     private final Map<Integer, OrderedRequestStreamObserver> map = new ConcurrentHashMap<>();
 
     void putNew(OrderedRequestStreamObserver so) {
-      CollectionUtils.putNew(so.getId(), so, map, () -> getClass().getSimpleName());
+      CollectionUtils.putNew(so.getId(), so, map, () -> JavaUtils.getClassSimpleName(getClass()));
     }
 
     void removeExisting(OrderedRequestStreamObserver so) {
-      CollectionUtils.removeExisting(so.getId(), so, map, () -> getClass().getSimpleName());
+      CollectionUtils.removeExisting(so.getId(), so, map, () -> JavaUtils.getClassSimpleName(getClass()));
     }
 
     void closeAllExisting(RaftGroupId groupId) {
@@ -170,7 +170,7 @@ public class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase
 
   private abstract class RequestStreamObserver implements StreamObserver<RaftClientRequestProto> {
     private final int id = streamCount.getAndIncrement();
-    private final String name = getId() + "-" + getClass().getSimpleName() + id;
+    private final String name = getId() + "-" + JavaUtils.getClassSimpleName(getClass()) + id;
     private final StreamObserver<RaftClientReplyProto> responseObserver;
     private final AtomicBoolean isClosed = new AtomicBoolean();
 
@@ -350,7 +350,7 @@ public class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase
       if (!requestGroupId.equals(updated)) {
         final GroupMismatchException exception = new GroupMismatchException(getId()
             + ": The group (" + requestGroupId + ") of " + r.getClientId()
-            + " does not match the group (" + updated + ") of the " + getClass().getSimpleName());
+            + " does not match the group (" + updated + ") of the " + JavaUtils.getClassSimpleName(getClass()));
         responseError(exception, () -> "processClientRequest (Group mismatched) for " + r);
         return;
       }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientStreamer.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientStreamer.java
@@ -80,6 +80,7 @@ public class GrpcClientStreamer implements Closeable {
   private RaftPeerId leaderId;
   private volatile GrpcClientProtocolProxy leaderProxy;
   private final ClientId clientId;
+  private final String name;
 
   private volatile RunningState running = RunningState.RUNNING;
   private final ExceptionAndRetry exceptionAndRetry;
@@ -89,6 +90,7 @@ public class GrpcClientStreamer implements Closeable {
   GrpcClientStreamer(RaftProperties prop, RaftGroup group,
       RaftPeerId leaderId, ClientId clientId, GrpcTlsConfig tlsConfig) {
     this.clientId = clientId;
+    this.name = JavaUtils.getClassSimpleName(getClass()) + "-" + clientId;
     maxPendingNum = GrpcConfigKeys.OutputStream.outstandingAppendsMax(prop);
     maxMessageSize = GrpcConfigKeys.messageSizeMax(prop, LOG::debug);
     dataQueue = new ConcurrentLinkedDeque<>();
@@ -209,7 +211,7 @@ public class GrpcClientStreamer implements Closeable {
 
   @Override
   public String toString() {
-    return this.getClass().getSimpleName() + "-" + clientId;
+    return name;
   }
 
   private class Sender extends Daemon {
@@ -313,7 +315,7 @@ public class GrpcClientStreamer implements Closeable {
     }
 
     @Override // called by handleError and handleNotLeader
-    public void close() throws IOException {
+    public void close() {
       active = false;
     }
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcOutputStream.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcOutputStream.java
@@ -23,6 +23,7 @@ import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.ProtoUtils;
 
 import java.io.IOException;
@@ -35,6 +36,7 @@ public class GrpcOutputStream extends OutputStream {
   private int count;
   private final AtomicLong seqNum = new AtomicLong();
   private final ClientId clientId;
+  private final String name;
   private final GrpcClientStreamer streamer;
 
   private boolean closed = false;
@@ -45,6 +47,7 @@ public class GrpcOutputStream extends OutputStream {
     buf = new byte[bufferSize];
     count = 0;
     this.clientId = clientId;
+    this.name = JavaUtils.getClassSimpleName(getClass()) + "-" + clientId;
     streamer = new GrpcClientStreamer(prop, group, leaderId, clientId, tlsConfig);
   }
 
@@ -102,7 +105,7 @@ public class GrpcOutputStream extends OutputStream {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "-" + clientId;
+    return name;
   }
 
   private void checkClosed() throws IOException {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -254,7 +254,7 @@ public class GrpcLogAppender extends LogAppender {
    * StreamObserver for handling responses from the follower
    */
   private class AppendLogResponseHandler implements StreamObserver<AppendEntriesReplyProto> {
-    private final String name = getFollower().getName() + "-" + getClass().getSimpleName();
+    private final String name = getFollower().getName() + "-" + JavaUtils.getClassSimpleName(getClass());
 
     /**
      * After receiving a appendEntries reply, do the following:
@@ -350,7 +350,7 @@ public class GrpcLogAppender extends LogAppender {
   }
 
   private class InstallSnapshotResponseHandler implements StreamObserver<InstallSnapshotReplyProto> {
-    private final String name = getFollower().getName() + "-" + getClass().getSimpleName();
+    private final String name = getFollower().getName() + "-" + JavaUtils.getClassSimpleName(getClass());
     private final Queue<Integer> pending;
     private final AtomicBoolean done = new AtomicBoolean(false);
     private final boolean isNotificationOnly;
@@ -608,8 +608,10 @@ public class GrpcLogAppender extends LogAppender {
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + ":cid=" + callId + ",entriesCount=" + entriesCount + ",lastEntry=" +
-          lastEntry;
+      return JavaUtils.getClassSimpleName(getClass())
+          + ":cid=" + callId
+          + ",entriesCount=" + entriesCount
+          + ",lastEntry=" + lastEntry;
     }
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -52,7 +52,7 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
     PeerProxyMap<GrpcServerProtocolClient>> {
   static final Logger LOG = LoggerFactory.getLogger(GrpcService.class);
   public static final String GRPC_SEND_SERVER_REQUEST =
-      GrpcService.class.getSimpleName() + ".sendRequest";
+      JavaUtils.getClassSimpleName(GrpcService.class) + ".sendRequest";
 
   public static final class Builder extends RaftServerRpc.Builder<Builder, GrpcService> {
     private GrpcTlsConfig tlsConfig;
@@ -121,7 +121,7 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
 
     this.serverInterceptor = new MetricServerInterceptor(
         idSupplier,
-        getClass().getSimpleName() + "_" + Integer.toString(port)
+        JavaUtils.getClassSimpleName(getClass()) + "_" + port
     );
 
     NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forPort(port)
@@ -174,7 +174,8 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
     } catch (IOException e) {
       ExitUtils.terminate(1, "Failed to start Grpc server", e, LOG);
     }
-    LOG.info("{}: {} started, listening on {}", getId(), getClass().getSimpleName(), getInetSocketAddress());
+    LOG.info("{}: {} started, listening on {}",
+        getId(), JavaUtils.getClassSimpleName(getClass()), getInetSocketAddress());
   }
 
   @Override

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/HadoopRpcService.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/HadoopRpcService.java
@@ -45,6 +45,7 @@ import com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.com.google.protobuf.GeneratedMessageV3;
 import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.util.CodeInjectionForTesting;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.PeerProxyMap;
 import org.apache.ratis.util.function.CheckedFunction;
 import org.slf4j.Logger;
@@ -57,7 +58,7 @@ import java.net.InetSocketAddress;
 public final class HadoopRpcService extends RaftServerRpcWithProxy<Proxy<RaftServerProtocolPB>,
     PeerProxyMap<Proxy<RaftServerProtocolPB>>> {
   public static final Logger LOG = LoggerFactory.getLogger(HadoopRpcService.class);
-  static final String CLASS_NAME = HadoopRpcService.class.getSimpleName();
+  static final String CLASS_NAME = JavaUtils.getClassSimpleName(HadoopRpcService.class);
   public static final String SEND_SERVER_REQUEST = CLASS_NAME + ".sendServerRequest";
 
   public static final class Builder extends RaftServerRpc.Builder<Builder, HadoopRpcService> {
@@ -108,8 +109,7 @@ public final class HadoopRpcService extends RaftServerRpcWithProxy<Proxy<RaftSer
 
     addRaftClientProtocol(server, conf);
 
-    LOG.info(getClass().getSimpleName() + " created RPC.Server at "
-        + ipcServerAddress);
+    LOG.info(JavaUtils.getClassSimpleName(getClass()) + " created RPC.Server at " + ipcServerAddress);
   }
 
   @Override

--- a/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/MiniRaftClusterWithHadoopRpc.java
+++ b/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/MiniRaftClusterWithHadoopRpc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -30,6 +30,7 @@ import org.apache.ratis.server.impl.DelayLocalExecutionInjection;
 import org.apache.ratis.server.impl.RaftServerProxy;
 import org.apache.ratis.server.impl.ServerImplUtils;
 import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.util.JavaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,6 +100,6 @@ public class MiniRaftClusterWithHadoopRpc extends MiniRaftCluster.RpcBase {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + ": sendServerRequest=" + sendServerRequest;
+    return JavaUtils.getClassSimpleName(getClass()) + ": sendServerRequest=" + sendServerRequest;
   }
 }

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -82,6 +82,7 @@ import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
 import org.apache.ratis.statemachine.impl.SingleFileSnapshotInfo;
 import org.apache.ratis.thirdparty.com.google.protobuf.TextFormat;
 import org.apache.ratis.util.AutoCloseableLock;
+import org.apache.ratis.util.JavaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -489,7 +490,7 @@ public class LogStateMachine extends BaseStateMachine {
       try {
         client.close();
       } catch (Exception ignored) {
-        LOG.warn(ignored.getClass().getSimpleName() + " is ignored", ignored);
+        LOG.warn("{} is ignored", JavaUtils.getClassSimpleName(ignored.getClass()), ignored);
       }
     }
   }

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -33,6 +33,7 @@ import org.apache.ratis.logservice.util.TestUtils;
 import org.apache.ratis.metrics.JVMMetrics;
 import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.impl.RaftServerProxy;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -427,7 +428,7 @@ public class TestMetaServer {
                     try {
                         logStream.close();
                     } catch (Exception ignored) {
-                        LOG.warn(ignored.getClass().getSimpleName() + " is ignored", ignored);
+                        LOG.warn("{} is ignored", JavaUtils.getClassSimpleName(ignored.getClass()), ignored);
                     }
                 }
             }

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyClient.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyClient.java
@@ -26,6 +26,7 @@ import org.apache.ratis.thirdparty.io.netty.channel.socket.SocketChannel;
 import org.apache.ratis.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LogLevel;
 import org.apache.ratis.thirdparty.io.netty.handler.logging.LoggingHandler;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.NetUtils;
 
@@ -33,7 +34,7 @@ import java.io.Closeable;
 import java.net.InetSocketAddress;
 
 public class NettyClient implements Closeable {
-  private final LifeCycle lifeCycle = new LifeCycle(getClass().getSimpleName());
+  private final LifeCycle lifeCycle = new LifeCycle(JavaUtils.getClassSimpleName(getClass()));
 
   private Channel channel;
 

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/client/NettyClientStreamRpc.java
@@ -50,13 +50,13 @@ import java.util.function.Supplier;
 public class NettyClientStreamRpc implements DataStreamClientRpc {
   public static final Logger LOG = LoggerFactory.getLogger(NettyClientStreamRpc.class);
 
-  private final RaftPeer server;
+  private final String name;
   private final EventLoopGroup workerGroup = new NioEventLoopGroup();
   private final Supplier<Channel> channel;
   private final ConcurrentMap<Long, Queue<CompletableFuture<DataStreamReply>>> replies = new ConcurrentHashMap<>();
 
   public NettyClientStreamRpc(RaftPeer server, RaftProperties properties){
-    this.server = server;
+    this.name = JavaUtils.getClassSimpleName(getClass()) + "->" + server;
 
     final ChannelFuture f = new Bootstrap()
         .group(workerGroup)
@@ -144,6 +144,6 @@ public class NettyClientStreamRpc implements DataStreamClientRpc {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "->" + server;
+    return name;
   }
 }

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -44,6 +44,7 @@ import org.apache.ratis.proto.netty.NettyProtos.RaftNettyExceptionReplyProto;
 import org.apache.ratis.proto.netty.NettyProtos.RaftNettyServerReplyProto;
 import org.apache.ratis.proto.netty.NettyProtos.RaftNettyServerRequestProto;
 import org.apache.ratis.util.CodeInjectionForTesting;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.ProtoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +59,7 @@ import java.util.Objects;
  */
 public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy, NettyRpcProxy.PeerMap> {
   public static final Logger LOG = LoggerFactory.getLogger(NettyRpcService.class);
-  static final String CLASS_NAME = NettyRpcService.class.getSimpleName();
+  static final String CLASS_NAME = JavaUtils.getClassSimpleName(NettyRpcService.class);
   public static final String SEND_SERVER_REQUEST = CLASS_NAME + ".sendServerRequest";
 
   public static final class Builder extends RaftServerRpc.Builder<Builder, NettyRpcService> {
@@ -102,7 +103,7 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
     final ChannelInitializer<SocketChannel> initializer
         = new ChannelInitializer<SocketChannel>() {
       @Override
-      protected void initChannel(SocketChannel ch) throws Exception {
+      protected void initChannel(SocketChannel ch) {
         final ChannelPipeline p = ch.pipeline();
 
         p.addLast(new ProtobufVarint32FrameDecoder());
@@ -137,7 +138,7 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
     try {
       channelFuture.syncUninterruptibly();
     } catch(Exception t) {
-      throw new IOException(getId() + ": Failed to start " + getClass().getSimpleName(), t);
+      throw new IOException(getId() + ": Failed to start " + JavaUtils.getClassSimpleName(getClass()), t);
     }
   }
 

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -214,7 +214,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + ":" + request;
+      return JavaUtils.getClassSimpleName(getClass()) + ":" + request;
     }
   }
 
@@ -278,7 +278,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
 
   public NettyServerStreamRpc(RaftServer server) {
     this.server = server;
-    this.name = server.getId() + "-" + getClass().getSimpleName();
+    this.name = server.getId() + "-" + JavaUtils.getClassSimpleName(getClass());
 
     final RaftProperties properties = server.getProperties();
     final int port = NettyConfigKeys.DataStream.port(properties);

--- a/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.server;
 
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 import org.slf4j.Logger;
@@ -493,7 +494,7 @@ public interface RaftServerConfigKeys {
   }
 
   interface Notification {
-    String PREFIX = RaftServerConfigKeys.PREFIX + "." + Notification.class.getSimpleName().toLowerCase();
+    String PREFIX = RaftServerConfigKeys.PREFIX + "." + JavaUtils.getClassSimpleName(Notification.class).toLowerCase();
 
     /** Timeout value to notify the state machine when there is no leader. */
     String NO_LEADER_TIMEOUT_KEY = PREFIX + ".no-leader.timeout";
@@ -508,7 +509,8 @@ public interface RaftServerConfigKeys {
   }
 
   interface LeaderElection {
-    String PREFIX = RaftServerConfigKeys.PREFIX + "." + LeaderElection.class.getSimpleName().toLowerCase();
+    String PREFIX = RaftServerConfigKeys.PREFIX
+        + "." + JavaUtils.getClassSimpleName(LeaderElection.class).toLowerCase();
 
     String LEADER_STEP_DOWN_WAIT_TIME_KEY = PREFIX + ".leader.step-down.wait-time";
     TimeDuration LEADER_STEP_DOWN_WAIT_TIME_DEFAULT = TimeDuration.valueOf(10, TimeUnit.SECONDS);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/CommitInfoCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/CommitInfoCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,6 +20,7 @@ package org.apache.ratis.server.impl;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.ProtoUtils;
 
 import java.util.Objects;
@@ -47,6 +48,6 @@ class CommitInfoCache {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + ":" + map.values();
+    return JavaUtils.getClassSimpleName(getClass()) + ":" + map.values();
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ConfigurationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.impl;
 
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.StringUtils;
 
@@ -82,7 +83,9 @@ public class ConfigurationManager {
 
   @Override
   public synchronized String toString() {
-    return getClass().getSimpleName() + ", init=" + initialConf + ", confs=" + StringUtils.map2String(configurations);
+    return JavaUtils.getClassSimpleName(getClass())
+        + ", init=" + initialConf
+        + ", confs=" + StringUtils.map2String(configurations);
   }
 
   // TODO: remove Configuration entries after they are committed

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/FollowerState.java
@@ -63,7 +63,7 @@ class FollowerState extends Daemon {
   private final AtomicInteger outstandingOp = new AtomicInteger();
 
   FollowerState(RaftServerImpl server, Object reason) {
-    this.name = server.getMemberId() + "-" + getClass().getSimpleName();
+    this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.server = server;
     this.reason = reason;
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -24,6 +24,7 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.ratis.util.Daemon;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.LogUtils;
 import org.apache.ratis.util.Preconditions;
@@ -118,7 +119,7 @@ class LeaderElection implements Runnable {
   private final RaftServerImpl server;
 
   LeaderElection(RaftServerImpl server) {
-    this.name = server.getMemberId() + "-" + getClass().getSimpleName() + COUNT.incrementAndGet();
+    this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass()) + COUNT.incrementAndGet();
     this.lifeCycle = new LifeCycle(this);
     this.daemon = new Daemon(this);
     this.server = server;
@@ -167,11 +168,11 @@ class LeaderElection implements Runnable {
       final LifeCycle.State state = lifeCycle.getCurrentState();
       if (state.isClosingOrClosed()) {
         LOG.info("{}: {} is safely ignored since this is already {}",
-            this, e.getClass().getSimpleName(), state, e);
+            this, JavaUtils.getClassSimpleName(e.getClass()), state, e);
       } else {
         if (!server.isAlive()) {
           LOG.info("{}: {} is safely ignored since the server is not alive: {}",
-              this, e.getClass().getSimpleName(), server, e);
+              this, JavaUtils.getClassSimpleName(e.getClass()), server, e);
         } else {
           LOG.error("{}: Failed, state={}", this, state, e);
         }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
@@ -62,7 +62,7 @@ import java.util.stream.Stream;
  */
 public class LeaderState {
   private static final Logger LOG = RaftServerImpl.LOG;
-  public static final String APPEND_PLACEHOLDER = LeaderState.class.getSimpleName() + ".placeholder";
+  public static final String APPEND_PLACEHOLDER = JavaUtils.getClassSimpleName(LeaderState.class) + ".placeholder";
 
   private enum BootStrapProgress {
     NOPROGRESS, PROGRESSING, CAUGHTUP
@@ -71,9 +71,11 @@ public class LeaderState {
   enum StepDownReason {
     HIGHER_TERM, HIGHER_PRIORITY, LOST_MAJORITY_HEARTBEATS, STATE_MACHINE_EXCEPTION;
 
+    private final String longName = JavaUtils.getClassSimpleName(getClass()) + ":" + name();
+
     @Override
     public String toString() {
-      return getClass().getSimpleName() + ":" + name();
+      return longName;
     }
   }
 
@@ -119,7 +121,7 @@ public class LeaderState {
   }
 
   private class EventQueue {
-    private final String name = server.getMemberId() + "-" + getClass().getSimpleName();
+    private final String name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
     private final BlockingQueue<StateUpdateEvent> queue = new ArrayBlockingQueue<>(4096);
 
     void submit(StateUpdateEvent event) {
@@ -235,7 +237,7 @@ public class LeaderState {
   private final LogAppenderMetrics logAppenderMetrics;
 
   LeaderState(RaftServerImpl server, RaftProperties properties) {
-    this.name = server.getMemberId() + "-" + getClass().getSimpleName();
+    this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.server = server;
 
     stagingCatchupGap = RaftServerConfigKeys.stagingCatchupGap(properties);
@@ -463,7 +465,7 @@ public class LeaderState {
 
   void restartSender(LogAppender sender) {
     final FollowerInfo follower = sender.getFollower();
-    LOG.info("{}: Restarting {} for {}", this, sender.getClass().getSimpleName(), follower.getName());
+    LOG.info("{}: Restarting {} for {}", this, JavaUtils.getClassSimpleName(sender.getClass()), follower.getName());
     sender.stopAppender();
     senders.removeAll(Collections.singleton(sender));
     addAndStartSenders(Collections.singleton(follower.getPeer()));
@@ -919,7 +921,7 @@ public class LeaderState {
   }
 
   private class ConfigurationStagingState {
-    private final String name = server.getMemberId() + "-" + getClass().getSimpleName();
+    private final String name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
     private final Map<RaftPeerId, RaftPeer> newPeers;
     private final PeerConfiguration newConf;
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
@@ -55,7 +55,7 @@ public class LogAppender {
   public static final Logger LOG = LoggerFactory.getLogger(LogAppender.class);
 
   class AppenderDaemon {
-    private final String name = LogAppender.this + "-" + getClass().getSimpleName();
+    private final String name = LogAppender.this + "-" + JavaUtils.getClassSimpleName(getClass());
     private final LifeCycle lifeCycle = new LifeCycle(name);
     private final Daemon daemon = new Daemon(this::run);
 
@@ -150,7 +150,7 @@ public class LogAppender {
 
   public LogAppender(RaftServerImpl server, LeaderState leaderState, FollowerInfo f) {
     this.follower = f;
-    this.name = follower.getName() + "-" + getClass().getSimpleName();
+    this.name = follower.getName() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.server = server;
     this.leaderState = leaderState;
     this.raftLog = server.getState().getLog();

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/MessageStreamRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/MessageStreamRequests.java
@@ -113,7 +113,7 @@ class MessageStreamRequests {
   private final StreamMap streams = new StreamMap();
 
   MessageStreamRequests(Object name) {
-    this.name = name + "-" + getClass().getSimpleName();
+    this.name = name + "-" + JavaUtils.getClassSimpleName(getClass());
   }
 
   CompletableFuture<?> streamAsync(RaftClientRequest request) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequest.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequest.java
@@ -21,6 +21,7 @@ import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.statemachine.TransactionContext;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 
 import java.util.Collection;
@@ -84,7 +85,6 @@ public class PendingRequest implements Comparable<PendingRequest> {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + "(index=" + index
-        + ", request=" + request;
+    return JavaUtils.getClassSimpleName(getClass()) + ":index=" + index + ", request=" + request;
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequests.java
@@ -29,6 +29,7 @@ import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.SetConfigurationRequest;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.statemachine.TransactionContext;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.ResourceSemaphore;
 import org.apache.ratis.util.SizeInBytes;
@@ -179,7 +180,7 @@ class PendingRequests {
   private final RequestMap pendingRequests;
 
   PendingRequests(RaftGroupMemberId id, RaftProperties properties, RaftServerMetrics raftServerMetrics) {
-    this.name = id + "-" + getClass().getSimpleName();
+    this.name = id + "-" + JavaUtils.getClassSimpleName(getClass());
     this.pendingRequests = new RequestMap(id,
         RaftServerConfigKeys.Write.elementLimit(properties),
         RaftServerConfigKeys.Write.byteLimit(properties),

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -80,7 +80,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
     RaftClientProtocol, RaftClientAsynchronousProtocol {
   public static final Logger LOG = LoggerFactory.getLogger(RaftServerImpl.class);
 
-  private static final String CLASS_NAME = RaftServerImpl.class.getSimpleName();
+  private static final String CLASS_NAME = JavaUtils.getClassSimpleName(RaftServerImpl.class);
   static final String REQUEST_VOTE = CLASS_NAME + ".requestVote";
   static final String APPEND_ENTRIES = CLASS_NAME + ".appendEntries";
   static final String INSTALL_SNAPSHOT = CLASS_NAME + ".installSnapshot";

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -167,9 +167,8 @@ public class RaftServerProxy implements RaftServer {
 
   private final DataStreamServerRpc dataStreamServerRpc;
 
-  private ExecutorService implExecutor;
-
   private final ImplMap impls = new ImplMap();
+  private final ExecutorService implExecutor = Executors.newSingleThreadExecutor();
 
   RaftServerProxy(RaftPeerId id, StateMachine.Registry stateMachineRegistry,
       RaftProperties properties, Parameters parameters) {
@@ -182,12 +181,9 @@ public class RaftServerProxy implements RaftServer {
     this.serverRpc = factory.newRaftServerRpc(this);
 
     this.id = id != null? id: RaftPeerId.valueOf(getIdStringFrom(serverRpc));
+    this.lifeCycle = new LifeCycle(this.id + "-" + JavaUtils.getClassSimpleName(getClass()));
 
     this.dataStreamServerRpc = new DataStreamServerImpl(this, parameters).getServerRpc();
-
-    this.lifeCycle = new LifeCycle(this.id + "-" + getClass().getSimpleName());
-
-    this.implExecutor = Executors.newSingleThreadExecutor();
   }
 
   /** Check the storage dir and add groups*/

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerRpcWithProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerRpcWithProxy.java
@@ -39,7 +39,8 @@ public abstract class RaftServerRpcWithProxy<PROXY extends Closeable, PROXIES ex
 
   public RaftServerRpcWithProxy(Supplier<RaftPeerId> idSupplier, Function<RaftPeerId, PROXIES> proxyCreater) {
     this.idSupplier = idSupplier;
-    this.lifeCycleSupplier = JavaUtils.memoize(() -> new LifeCycle(getId() + "-" + getClass().getSimpleName()));
+    this.lifeCycleSupplier = JavaUtils.memoize(
+        () -> new LifeCycle(getId() + "-" + JavaUtils.getClassSimpleName(getClass())));
     this.proxiesSupplier = JavaUtils.memoize(() -> proxyCreater.apply(getId()));
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
@@ -101,7 +101,7 @@ class RoleInfo {
         throw new NullPointerException("leaderState == null");
       }
     } else {
-      LOG.info("{}: shutdown {}", id, leader.getClass().getSimpleName());
+      LOG.info("{}: shutdown {}", id, leader);
       leader.stop();
     }
     // TODO: make sure that StateMachineUpdater has applied all transactions that have context
@@ -118,7 +118,7 @@ class RoleInfo {
   void shutdownFollowerState() {
     final FollowerState follower = followerState.getAndSet(null);
     if (follower != null) {
-      LOG.info("{}: shutdown {}", id, follower.getClass().getSimpleName());
+      LOG.info("{}: shutdown {}", id, follower);
       follower.stopRunning();
       follower.interrupt();
     }
@@ -131,7 +131,7 @@ class RoleInfo {
   void shutdownLeaderElection() {
     final LeaderElection election = leaderElection.getAndSet(null);
     if (election != null) {
-      LOG.info("{}: shutdown {}", id, election.getClass().getSimpleName());
+      LOG.info("{}: shutdown {}", id, election);
       election.shutdown();
       // no need to interrupt the election thread
     }
@@ -140,7 +140,7 @@ class RoleInfo {
   private <T> T updateAndGet(AtomicReference<T> ref, T current) {
     final T updated = ref.updateAndGet(previous -> previous != null? previous: current);
     Preconditions.assertTrue(updated == current, "previous != null");
-    LOG.info("{}: start {}", id, current.getClass().getSimpleName());
+    LOG.info("{}: start {}", id, current);
     return updated;
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
@@ -83,7 +83,7 @@ class StateMachineUpdater implements Runnable {
 
   StateMachineUpdater(StateMachine stateMachine, RaftServerImpl server,
       ServerState serverState, long lastAppliedIndex, RaftProperties properties) {
-    this.name = serverState.getMemberId() + "-" + getClass().getSimpleName();
+    this.name = serverState.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.infoIndexChange = s -> LOG.info("{}: {}", name, s);
     this.debugIndexChange = s -> LOG.debug("{}: {}", name, s);
 
@@ -128,7 +128,8 @@ class StateMachineUpdater implements Runnable {
       stateMachine.close();
       stateMachineMetrics.unregister();
     } catch(Throwable t) {
-      LOG.warn(name + ": Failed to close " + stateMachine.getClass().getSimpleName() + " " + stateMachine, t);
+      LOG.warn(name + ": Failed to close " + JavaUtils.getClassSimpleName(stateMachine.getClass())
+          + " " + stateMachine, t);
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/WatchRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/WatchRequests.java
@@ -171,7 +171,7 @@ class WatchRequests {
   private final TimeoutScheduler scheduler = TimeoutScheduler.getInstance();
 
   WatchRequests(Object name, RaftProperties properties) {
-    this.name = name + "-" + getClass().getSimpleName();
+    this.name = name + "-" + JavaUtils.getClassSimpleName(getClass());
 
     final TimeDuration watchTimeout = RaftServerConfigKeys.Watch.timeout(properties);
     this.watchTimeoutNanos = watchTimeout.to(TimeUnit.NANOSECONDS);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -57,7 +57,7 @@ import java.util.function.Consumer;
  */
 public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
   public static final Logger LOG = LoggerFactory.getLogger(RaftLog.class);
-  public static final String LOG_SYNC = RaftLog.class.getSimpleName() + ".logSync";
+  public static final String LOG_SYNC = JavaUtils.getClassSimpleName(RaftLog.class) + ".logSync";
 
   private final Consumer<Object> infoIndexChange = s -> LOG.info("{}: {}", getName(), s);
   private final Consumer<Object> traceIndexChange = s -> LOG.trace("{}: {}", getName(), s);
@@ -88,7 +88,7 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
   private volatile LogEntryProto lastMetadataEntry = null;
 
   protected RaftLog(RaftGroupMemberId memberId, long commitIndex, RaftProperties properties) {
-    this.name = memberId + "-" + getClass().getSimpleName();
+    this.name = memberId + "-" + JavaUtils.getClassSimpleName(getClass());
     this.memberId = memberId;
     this.commitIndex = new RaftLogIndex("commitIndex", commitIndex);
     this.snapshotIndex = new RaftLogIndex("snapshotIndex", commitIndex);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -121,7 +121,7 @@ public class SegmentedRaftLog extends RaftLog {
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + ":" + getEndIndex();
+      return JavaUtils.getClassSimpleName(getClass()) + ":" + getEndIndex();
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -344,13 +344,9 @@ public class SegmentedRaftLogCache {
   private final int maxCachedSegments;
   private final CacheInvalidationPolicy evictionPolicy = new CacheInvalidationPolicyDefault();
 
-  SegmentedRaftLogCache(Object name, RaftStorage storage, RaftProperties properties) {
-    this(name, storage, properties, null);
-  }
-
   SegmentedRaftLogCache(Object name, RaftStorage storage, RaftProperties properties,
                                 RaftLogMetrics raftLogMetrics) {
-    this.name = name + "-" + getClass().getSimpleName();
+    this.name = name + "-" + JavaUtils.getClassSimpleName(getClass());
     this.closedSegments = new LogSegmentList(name);
     this.storage = storage;
     this.raftLogMetrics = raftLogMetrics;

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogOutputStream.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogOutputStream.java
@@ -20,6 +20,7 @@ package org.apache.ratis.server.raftlog.segmented;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.CodedOutputStream;
 import org.apache.ratis.util.IOUtils;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.apache.ratis.util.PureJavaCrc32C;
 import org.apache.ratis.util.function.CheckedConsumer;
@@ -140,6 +141,6 @@ public class SegmentedRaftLogOutputStream implements Closeable {
 
   @Override
   public String toString() {
-    return this.getClass().getSimpleName() + "(" + file + ")";
+    return JavaUtils.getClassSimpleName(getClass()) + "(" + file + ")";
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -176,7 +176,7 @@ class SegmentedRaftLogWorker implements Runnable {
   SegmentedRaftLogWorker(RaftGroupMemberId memberId, StateMachine stateMachine, Runnable submitUpdateCommitEvent,
                          RaftServerImpl server, RaftStorage storage, RaftProperties properties,
                          RaftLogMetrics metricRegistry) {
-    this.name = memberId + "-" + getClass().getSimpleName();
+    this.name = memberId + "-" + JavaUtils.getClassSimpleName(getClass());
     LOG.info("new {} for {}", name, storage);
 
     this.submitUpdateCommitEvent = submitUpdateCommitEvent;
@@ -298,8 +298,8 @@ class SegmentedRaftLogWorker implements Runnable {
             if (logIOException != null) {
               throw logIOException;
             } else {
-              Timer.Context executionTimeContext =
-                  raftLogMetrics.getRaftLogTaskExecutionTimer(task.getClass().getSimpleName().toLowerCase()).time();
+              final Timer.Context executionTimeContext = raftLogMetrics.getRaftLogTaskExecutionTimer(
+                  JavaUtils.getClassSimpleName(task.getClass()).toLowerCase()).time();
               task.execute();
               executionTimeContext.stop();
             }

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorage.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorage.java
@@ -23,6 +23,7 @@ import org.apache.ratis.server.impl.RaftConfiguration;
 import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.impl.ServerProtoUtils;
 import org.apache.ratis.server.storage.RaftStorageDirectory.StorageState;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,6 +152,6 @@ public class RaftStorage implements Closeable {
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + ":" + getStorageDir();
+    return JavaUtils.getClassSimpleName(getClass()) + ":" + getStorageDir();
   }
 }

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
@@ -32,6 +32,7 @@ import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.statemachine.StateMachineStorage;
 import org.apache.ratis.statemachine.TransactionContext;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.Preconditions;
 
@@ -49,7 +50,7 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
     StateMachine.EventApi, StateMachine.LeaderEventApi, StateMachine.FollowerEventApi {
   private final CompletableFuture<RaftServer> server = new CompletableFuture<>();
   private volatile RaftGroupId groupId;
-  private final LifeCycle lifeCycle = new LifeCycle(getClass().getSimpleName());
+  private final LifeCycle lifeCycle = new LifeCycle(JavaUtils.getClassSimpleName(getClass()));
 
   private final AtomicReference<TermIndex> lastAppliedTermIndex = new AtomicReference<>();
 
@@ -219,7 +220,7 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + ":"
+    return JavaUtils.getClassSimpleName(getClass()) + ":"
         + (!server.isDone()? "uninitialized": getId() + ":" + groupId);
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/LogAppenderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LogAppenderTests.java
@@ -37,6 +37,7 @@ import org.apache.ratis.server.impl.ServerState;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.Log4jUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.junit.Assert;
@@ -202,7 +203,7 @@ public abstract class LogAppenderTests<CLUSTER extends MiniRaftCluster>
         try {
           clients.get(i).close();
         } catch (Exception ignored) {
-          LOG.warn(ignored.getClass().getSimpleName() + " is ignored", ignored);
+          LOG.warn("{} is ignored", JavaUtils.getClassSimpleName(ignored.getClass()), ignored);
         }
       }
     }

--- a/ratis-server/src/test/java/org/apache/ratis/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/MiniRaftCluster.java
@@ -83,7 +83,7 @@ import static org.apache.ratis.server.impl.RaftServerConstants.DEFAULT_CALLID;
 public abstract class MiniRaftCluster implements Closeable {
   public static final Logger LOG = LoggerFactory.getLogger(MiniRaftCluster.class);
 
-  public static final String CLASS_NAME = MiniRaftCluster.class.getSimpleName();
+  public static final String CLASS_NAME = JavaUtils.getClassSimpleName(MiniRaftCluster.class);
   public static final String STATEMACHINE_CLASS_KEY = CLASS_NAME + ".statemachine.class";
   private static final StateMachine.Registry STATEMACHINE_REGISTRY_DEFAULT = gid -> new BaseStateMachine();
   private static final TimeDuration RETRY_INTERVAL_DEFAULT =
@@ -220,7 +220,7 @@ public abstract class MiniRaftCluster implements Closeable {
 
   private final Supplier<File> rootTestDir = JavaUtils.memoize(
       () -> new File(BaseTest.getRootTestDir(),
-          getClass().getSimpleName() + Integer.toHexString(ThreadLocalRandom.current().nextInt())));
+          JavaUtils.getClassSimpleName(getClass()) + Integer.toHexString(ThreadLocalRandom.current().nextInt())));
 
   public File getStorageDir(RaftPeerId id) {
     return new File(rootTestDir.get(), id.toString());
@@ -250,7 +250,7 @@ public abstract class MiniRaftCluster implements Closeable {
 
   protected MiniRaftCluster(String[] ids, RaftProperties properties, Parameters parameters) {
     this.group = initRaftGroup(Arrays.asList(ids));
-    LOG.info("new {} with {}", getClass().getSimpleName(), group);
+    LOG.info("new {} with {}", JavaUtils.getClassSimpleName(getClass()), group);
     this.properties = new RaftProperties(properties);
     this.parameters = parameters;
 
@@ -286,7 +286,7 @@ public abstract class MiniRaftCluster implements Closeable {
   public void start() throws IOException {
     LOG.info(".............................................................. ");
     LOG.info("... ");
-    LOG.info("...     Starting " + getClass().getSimpleName());
+    LOG.info("...     Starting " + JavaUtils.getClassSimpleName(getClass()));
     LOG.info("... ");
     LOG.info(".............................................................. ");
 
@@ -711,7 +711,7 @@ public abstract class MiniRaftCluster implements Closeable {
   public void shutdown() {
     LOG.info("************************************************************** ");
     LOG.info("*** ");
-    LOG.info("***     Stopping " + getClass().getSimpleName());
+    LOG.info("***     Stopping " + JavaUtils.getClassSimpleName(getClass()));
     LOG.info("*** ");
     LOG.info("************************************************************** ");
     LOG.info(printServers());
@@ -732,7 +732,7 @@ public abstract class MiniRaftCluster implements Closeable {
 
     Optional.ofNullable(timer.get()).ifPresent(Timer::cancel);
     ExitUtils.assertNotTerminated();
-    LOG.info(getClass().getSimpleName() + " shutdown completed");
+    LOG.info("{} shutdown completed", JavaUtils.getClassSimpleName(getClass()));
   }
 
   /**

--- a/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
@@ -328,7 +328,7 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
 
     @Override
     public String toString() {
-      return getClass().getSimpleName() + index
+      return JavaUtils.getClassSimpleName(getClass()) + index
           + "(step=" + step + "/" + messages.length
           + ", isRunning=" + isRunning
           + ", isAlive=" + isAlive()

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/BlockRequestHandlingInjection.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/BlockRequestHandlingInjection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,7 +19,7 @@ package org.apache.ratis.server.impl;
 
 import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.util.CodeInjectionForTesting;
-import org.apache.ratis.util.StringUtils;
+import org.apache.ratis.util.JavaUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -91,7 +91,7 @@ public class BlockRequestHandlingInjection implements CodeInjectionForTesting.Co
 
   @Override
   public String toString() {
-    return getClass().getSimpleName()
+    return JavaUtils.getClassSimpleName(getClass())
         + ": requestors=" + requestors.keySet()
         + ", repliers=" + repliers.keySet();
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/DelayLocalExecutionInjection.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/DelayLocalExecutionInjection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,6 +19,7 @@ package org.apache.ratis.server.impl;
 
 import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.util.CodeInjectionForTesting;
+import org.apache.ratis.util.JavaUtils;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -74,6 +75,6 @@ public class DelayLocalExecutionInjection implements CodeInjectionForTesting.Cod
 
   @Override
   public String toString() {
-    return getClass().getSimpleName() + ": delays=" + delays;
+    return JavaUtils.getClassSimpleName(getClass()) + ": delays=" + delays;
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -239,7 +239,7 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     if (chosen < 0) {
       chosen = ThreadLocalRandom.current().nextInt(idIndex.length);
     }
-    final String type = cluster.getClass().getSimpleName()
+    final String type = JavaUtils.getClassSimpleName(cluster.getClass())
         + Arrays.toString(idIndex) + "chosen=" + chosen;
     LOG.info("\n\nrunMultiGroupTest with " + type + ": " + cluster.printServers());
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -226,7 +226,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
 
             latch.countDown();
           } catch (Exception ignored) {
-            LOG.warn(ignored.getClass().getSimpleName() + " is ignored", ignored);
+            LOG.warn("{} is ignored", JavaUtils.getClassSimpleName(ignored.getClass()), ignored);
           }
         });
         clientThread.start();
@@ -685,7 +685,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
             }
           }
         } catch (Exception ignored) {
-          LOG.warn(ignored.getClass().getSimpleName() + " is ignored", ignored);
+          LOG.warn("{} is ignored", JavaUtils.getClassSimpleName(ignored.getClass()), ignored);
         }
       }).start();
 

--- a/ratis-test/src/test/java/org/apache/ratis/server/TestRaftServerConfigKeys.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/TestRaftServerConfigKeys.java
@@ -43,7 +43,7 @@ public class TestRaftServerConfigKeys {
 
   private static final Supplier<File> rootTestDir = JavaUtils.memoize(
       () -> new File(BaseTest.getRootTestDir(),
-          TestRaftServerConfigKeys.class.getSimpleName() +
+          JavaUtils.getClassSimpleName(TestRaftServerConfigKeys.class) +
               Integer.toHexString(ThreadLocalRandom.current().nextInt())));
 
   @AfterClass

--- a/ratis-test/src/test/java/org/apache/ratis/server/impl/TestServerState.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/impl/TestServerState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.ratis.server.impl;
 
 import org.apache.ratis.BaseTest;
@@ -42,7 +41,7 @@ public class TestServerState {
 
   private static final Supplier<File> rootTestDir = JavaUtils.memoize(
       () -> new File(BaseTest.getRootTestDir(),
-          TestServerState.class.getSimpleName() +
+          JavaUtils.getClassSimpleName(TestServerState.class) +
               Integer.toHexString(ThreadLocalRandom.current().nextInt())));
 
   @AfterClass

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestCacheEviction.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestCacheEviction.java
@@ -37,6 +37,7 @@ import org.apache.ratis.server.raftlog.segmented.TestSegmentedRaftLog.SegmentRan
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.junit.Assert;
 import org.junit.Test;
@@ -53,7 +54,7 @@ public class TestCacheEviction extends BaseTest {
 
   static LogSegmentList prepareSegments(int numSegments, boolean[] cached, long start, long size) {
     Assert.assertEquals(numSegments, cached.length);
-    final LogSegmentList segments = new LogSegmentList(TestCacheEviction.class.getSimpleName());
+    final LogSegmentList segments = new LogSegmentList(JavaUtils.getClassSimpleName(TestCacheEviction.class));
     for (int i = 0; i < numSegments; i++) {
       LogSegment s = LogSegment.newCloseSegment(null, start, start + size - 1, null);
       if (cached[i]) {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1141