### PR TITLE
RATIS-1146. Does not build with newer JDK

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -19,9 +19,19 @@ jobs:
   build:
     name: compile
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+      fail-fast: false
     steps:
-      - uses: actions/checkout@master
-      - run: ./dev-support/checks/build.sh
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Run a full build
+        run: ./dev-support/checks/build.sh
   rat:
     name: rat
     runs-on: ubuntu-18.04

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,9 +19,19 @@ jobs:
   build:
     name: compile
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java: [ 8, 11 ]
+      fail-fast: false
     steps:
-      - uses: actions/checkout@master
-      - run: ./dev-support/checks/build.sh
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Run a full build
+        run: ./dev-support/checks/build.sh
   rat:
     name: rat
     runs-on: ubuntu-18.04

--- a/dev-support/checks/build.sh
+++ b/dev-support/checks/build.sh
@@ -17,5 +17,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m"
-mvn -B -Dmaven.javadoc.skip=true -DskipTests clean install
+mvn -V -B -Dmaven.javadoc.skip=true -DskipTests clean install
 exit $?

--- a/pom.xml
+++ b/pom.xml
@@ -484,6 +484,12 @@
 	      <artifactId>jline</artifactId>
 	      <version>3.9.0</version>
 	    </dependency>
+
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/ratis-proto/pom.xml
+++ b/ratis-proto/pom.xml
@@ -187,5 +187,9 @@
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-thirdparty-misc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Add `javax.annotation-api` dependency, required for compilation with Java 9+.
2. Improve _compile_ CI check to build Ratis with both Java 8 and Java 11.

https://issues.apache.org/jira/browse/RATIS-1146

## How was this patch tested?

Compile checks:
https://github.com/adoroszlai/incubator-ratis/runs/1385567749#step:4:10
https://github.com/adoroszlai/incubator-ratis/runs/1385567774#step:4:1729

Compiled Ratis locally with the same Java versions, and Java 14, too:

```
$ mvn -DskipTests -V clean package
...
Java version: 14.0.1
...
[INFO] BUILD SUCCESS
```