### PR TITLE
RATIS-1149. Leader should step down and initiate a stateMachine action in case of jvm pauses.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/JvmPauseMonitor.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/JvmPauseMonitor.java
@@ -1,0 +1,181 @@
+package org.apache.ratis.server;
+
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.impl.RaftServerProxy;
+import org.apache.ratis.thirdparty.com.google.common.base.Joiner;
+import org.apache.ratis.thirdparty.com.google.common.base.Stopwatch;
+import org.apache.ratis.thirdparty.com.google.common.collect.Lists;
+import org.apache.ratis.thirdparty.com.google.common.collect.Maps;
+import org.apache.ratis.thirdparty.com.google.common.collect.Sets;
+import org.apache.ratis.util.Daemon;
+import org.apache.ratis.util.JavaUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.management.GarbageCollectorMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+
+public class JvmPauseMonitor {
+  public static final Logger LOG =
+    LoggerFactory.getLogger(JvmPauseMonitor.class);
+  /**
+   * The target sleep time
+   */
+  private static final long SLEEP_INTERVAL_MS = 500;
+  private long totalGcExtraSleepTime = 0;
+
+  private Thread monitorThread;
+  private volatile boolean shouldRun = true;
+  private final RaftServerProxy proxy;
+
+  public boolean isStarted() {
+    return monitorThread != null;
+  }
+
+  public long getTotalGcExtraSleepTime() {
+    return totalGcExtraSleepTime;
+  }
+
+  private String formatMessage(long extraSleepTime,
+                               Map<String, GcTimes> gcTimesAfterSleep,
+                               Map<String, GcTimes> gcTimesBeforeSleep) {
+
+    Set<String> gcBeanNames = Sets.intersection(gcTimesAfterSleep.keySet(),
+      gcTimesBeforeSleep.keySet());
+    List<String> gcDiffs = Lists.newArrayList();
+    for (String name : gcBeanNames) {
+      GcTimes diff = gcTimesAfterSleep.get(name)
+                       .subtract(gcTimesBeforeSleep.get(name));
+      if (diff.gcCount != 0) {
+        gcDiffs.add("GC pool '" + name + "' had collection(s): " + diff
+                                                                     .toString());
+      }
+    }
+
+    String ret = "Detected pause in JVM or host machine (eg GC): "
+                   + "pause of approximately " + extraSleepTime + "ms\n";
+    if (gcDiffs.isEmpty()) {
+      ret += "No GCs detected";
+    } else {
+      ret += Joiner.on("\n").join(gcDiffs);
+    }
+    return ret;
+  }
+
+  public JvmPauseMonitor(RaftServerProxy proxy) {
+    this.proxy = proxy;
+  }
+
+  private Map<String, GcTimes> getGcTimes() {
+    Map<String, GcTimes> map = Maps.newHashMap();
+    List<GarbageCollectorMXBean> gcBeans =
+      ManagementFactory.getGarbageCollectorMXBeans();
+    for (GarbageCollectorMXBean gcBean : gcBeans) {
+      map.put(gcBean.getName(), new GcTimes(gcBean));
+    }
+    return map;
+  }
+
+  private static class GcTimes {
+    private GcTimes(GarbageCollectorMXBean gcBean) {
+      gcCount = gcBean.getCollectionCount();
+      gcTimeMillis = gcBean.getCollectionTime();
+    }
+
+    private GcTimes(long count, long time) {
+      this.gcCount = count;
+      this.gcTimeMillis = time;
+    }
+
+    private GcTimes subtract(GcTimes other) {
+      return new GcTimes(this.gcCount - other.gcCount,
+        this.gcTimeMillis - other.gcTimeMillis);
+    }
+
+    @Override
+    public String toString() {
+      return "count=" + gcCount + " time=" + gcTimeMillis + "ms";
+    }
+
+    private long gcCount;
+    private long gcTimeMillis;
+  }
+
+  class Monitor implements Runnable {
+    private final String name = JvmPauseMonitor.this + "-" + JavaUtils
+                                                               .getClassSimpleName(getClass());
+
+    public void run() {
+      while (shouldRun) {
+        Stopwatch sw = Stopwatch.createUnstarted();
+        Map<String, GcTimes> gcTimesBeforeSleep = getGcTimes();
+        LOG.info("Starting Ratis JVM pause monitor");
+        while (shouldRun) {
+          sw.reset().start();
+          try {
+            Thread.sleep(SLEEP_INTERVAL_MS);
+          } catch (InterruptedException ie) {
+            return;
+          }
+          long extraSleepTime =
+            sw.elapsed(TimeUnit.MILLISECONDS) - SLEEP_INTERVAL_MS;
+          Map<String, GcTimes> gcTimesAfterSleep = getGcTimes();
+
+          if (extraSleepTime > 0) {
+            LOG.warn(formatMessage(extraSleepTime, gcTimesAfterSleep,
+              gcTimesBeforeSleep));
+          }
+          totalGcExtraSleepTime += extraSleepTime;
+          gcTimesBeforeSleep = gcTimesAfterSleep;
+          int leaderStepDownWaitTime =
+            RaftServerConfigKeys.LeaderElection.leaderStepDownWaitTime(
+              proxy.getProperties()).toIntExact(TimeUnit.MILLISECONDS);
+          int rpcSlownessTimeoutMs = RaftServerConfigKeys.Rpc.slownessTimeout(
+            proxy.getProperties()).toIntExact(TimeUnit.MILLISECONDS);
+          try {
+            if (totalGcExtraSleepTime > leaderStepDownWaitTime) {
+              proxy.getImpls().forEach(RaftServerImpl::stepDownOnJvmPause);
+            }
+            if (totalGcExtraSleepTime > rpcSlownessTimeoutMs) {
+              // close down all pipelines if the total gc period exceeds
+              // rpc slowness timeout
+              proxy.close();
+            }
+          } catch (IOException ioe) {
+            LOG.info("Encountered exception in JvmPauseMonitor {}", ioe);
+          }
+        }
+      }
+    }
+
+    @Override
+    public String toString() {
+      return name;
+    }
+  }
+
+
+  public void start() {
+    monitorThread = new Daemon(new Monitor());
+    monitorThread.start();
+  }
+
+  public void stop() {
+    shouldRun = false;
+    if (monitorThread != null) {
+      monitorThread.interrupt();
+      try {
+        monitorThread.join();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/JvmPauseMonitor.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/JvmPauseMonitor.java
@@ -89,7 +89,7 @@ public class JvmPauseMonitor {
     return map;
   }
 
-  private static class GcTimes {
+  private static final class GcTimes {
     private GcTimes(GarbageCollectorMXBean gcBean) {
       gcCount = gcBean.getCollectionCount();
       gcTimeMillis = gcBean.getCollectionTime();

--- a/ratis-server/src/main/java/org/apache/ratis/server/JvmPauseMonitor.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/JvmPauseMonitor.java
@@ -124,10 +124,10 @@ public class JvmPauseMonitor {
                                                                                                        .MILLISECONDS);
       int rpcSlownessTimeoutMs = RaftServerConfigKeys.Rpc.slownessTimeout(proxy.getProperties()).toIntExact(
         TimeUnit.MILLISECONDS);
+      Stopwatch sw = Stopwatch.createUnstarted();
+      Map<String, GcTimes> gcTimesBeforeSleep = getGcTimes();
+      LOG.info("Starting Ratis JVM pause monitor");
       while (shouldRun) {
-        Stopwatch sw = Stopwatch.createUnstarted();
-        Map<String, GcTimes> gcTimesBeforeSleep = getGcTimes();
-        LOG.info("Starting Ratis JVM pause monitor");
         sw.reset().start();
         try {
           Thread.sleep(SLEEP_INTERVAL_MS);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
@@ -69,7 +69,7 @@ public class LeaderState {
   }
 
   enum StepDownReason {
-    HIGHER_TERM, HIGHER_PRIORITY, LOST_MAJORITY_HEARTBEATS, STATE_MACHINE_EXCEPTION;
+    HIGHER_TERM, HIGHER_PRIORITY, LOST_MAJORITY_HEARTBEATS, STATE_MACHINE_EXCEPTION, JVM_PAUSE;
 
     private final String longName = JavaUtils.getClassSimpleName(getClass()) + ":" + name();
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -635,8 +635,7 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
 
   public void stepDownOnJvmPause() {
     if (isLeader()) {
-      final LeaderState leaderState = role.getLeaderStateNonNull();
-      leaderState.submitStepDownEvent(LeaderState.StepDownReason.JVM_PAUSE);
+      role.getLeaderState().ifPresent(leader -> leader.submitStepDownEvent(LeaderState.StepDownReason.JVM_PAUSE));
     }
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -633,6 +633,13 @@ public class RaftServerImpl implements RaftServerProtocol, RaftServerAsynchronou
     return pending.getFuture();
   }
 
+  public void stepDownOnJvmPause() {
+    if (isLeader()) {
+      final LeaderState leaderState = role.getLeaderStateNonNull();
+      leaderState.submitStepDownEvent(LeaderState.StepDownReason.JVM_PAUSE);
+    }
+  }
+
   @Override
   public CompletableFuture<RaftClientReply> submitClientRequestAsync(
       RaftClientRequest request) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Idea of JvmpauseMonitor taken from hadoop with two additional conditions added:

1) If the total jvm pause time exceeds maxRpcTimeout in Ratis, ratis leader will stepdown
2) If the total pause time exceeds rpcSlownesstimeout, kill all the ratis pipeline on the node

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1149

## How was this patch tested?
Tested Manually by adding below code manually :
`@@ -97,7 +98,12 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
     final RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster);
     final RaftPeerId leaderId = leader.getId();
 
-    final RaftProperties p = getProperties();
+    List<String> list = Lists.newArrayList();
+    int i = 0;
+    while (true) {
+      list.add(String.valueOf(i++));
+    }
+   /* final RaftProperties p = getProperties();
`

> 2020-11-17 11:54:12,471 [org.apache.ratis.server.JvmPauseMonitor@96ffc3c-Monitor] WARN  server.JvmPauseMonitor (JvmPauseMonitor.java:run(141)) - Detected pause in JVM or host machine (eg GC): pause of approximately 1ms
> GC pool 'PS Scavenge' had collection(s): count=1 time=16ms
> 2020-11-17 11:54:13,217 [org.apache.ratis.server.JvmPauseMonitor@96ffc3c-Monitor] WARN  server.JvmPauseMonitor (JvmPauseMonitor.java:run(141)) - Detected pause in JVM or host machine (eg GC): pause of approximately 245ms
> GC pool 'PS MarkSweep' had collection(s): count=1 time=622ms
> GC pool 'PS Scavenge' had collection(s): count=3 time=82ms
> 2020-11-17 11:54:13,218 [org.apache.ratis.server.JvmPauseMonitor@96ffc3c-Monitor] INFO  impl.RaftServerProxy (RaftServerProxy.java:lambda$close$4(338)) - s0: close
> 2020-11-17 11:54:13,218 [org.apache.ratis.server.JvmPauseMonitor@96ffc3c-Monitor] INFO  impl.RaftServerImpl (RaftServerImpl.java:lambda$shutdown$3(328)) - s0@group-E57B5B3B2345: shutdown
> 2020-11-17 11:54:13,219 [org.apache.ratis.server.JvmPauseMonitor@96ffc3c-Monitor] INFO  util.JmxRegister (JmxRegister.java:unregister(73)) - Successfully un-registered JMX Bean with object name Ratis:service=RaftServer,group=group-E57B5B3B2345,id=s0
> 2020-11-17 11:54:13,219 [org.apache.ratis.server.JvmPauseMonitor@96ffc3c-Monitor] INFO  impl.RoleInfo (RoleInfo.java:shutdownLeaderState(104)) - s0: shutdown s0@group-E57B5B3B2345-LeaderState
