### PR TITLE
RATIS-1159. Wait ChannelFuture be completed before getting the local address

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyServerStreamRpc.java
@@ -201,6 +201,7 @@ public class NettyServerStreamRpc implements DataStreamServerRpc {
 
   @Override
   public InetSocketAddress getInetSocketAddress() {
+    channelFuture.awaitUninterruptibly();
     return (InetSocketAddress) channelFuture.channel().localAddress();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Need to wait the ChannelFuture be completed. Otherwise the local address (`channelFuture.channel().localAddress()`) could be `null`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1159

## How was this patch tested?

UT (run 100 times locally without seeing the timeout issue again)
