### PR TITLE
RATIS-1160. DataStreamClientImpl.closeAsync() should be idempotent.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientMessage.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientMessage.java
@@ -23,12 +23,13 @@ public abstract class RaftClientMessage implements RaftRpcMessage {
   private final ClientId clientId;
   private final RaftPeerId serverId;
   private final RaftGroupId groupId;
+  private final long callId;
 
-  public RaftClientMessage(ClientId clientId, RaftPeerId serverId,
-      RaftGroupId groupId) {
+  RaftClientMessage(ClientId clientId, RaftPeerId serverId, RaftGroupId groupId, long callId) {
     this.clientId = clientId;
     this.serverId = serverId;
     this.groupId = groupId;
+    this.callId = callId;
   }
 
   @Override
@@ -54,9 +55,13 @@ public abstract class RaftClientMessage implements RaftRpcMessage {
     return groupId;
   }
 
+  public long getCallId() {
+    return callId;
+  }
+
   @Override
   public String toString() {
     return JavaUtils.getClassSimpleName(getClass()) + ":" + clientId + "->" + serverId
-        + (groupId != null? "@" + groupId: "");
+        + (groupId != null? "@" + groupId: "") + ", cid=" + getCallId();
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientReply.java
@@ -38,7 +38,6 @@ import java.util.Collections;
  */
 public class RaftClientReply extends RaftClientMessage {
   private final boolean success;
-  private final long callId;
 
   /**
    * We mainly track two types of exceptions here:
@@ -71,9 +70,8 @@ public class RaftClientReply extends RaftClientMessage {
       ClientId clientId, RaftPeerId serverId, RaftGroupId groupId,
       long callId, boolean success, Message message, RaftException exception,
       long logIndex, Collection<CommitInfoProto> commitInfos) {
-    super(clientId, serverId, groupId);
+    super(clientId, serverId, groupId, callId);
     this.success = success;
-    this.callId = callId;
     this.message = message;
     this.exception = exception;
     this.logIndex = logIndex;
@@ -125,17 +123,13 @@ public class RaftClientReply extends RaftClientMessage {
     return false;
   }
 
-  public long getCallId() {
-    return callId;
-  }
-
   public long getLogIndex() {
     return logIndex;
   }
 
   @Override
   public String toString() {
-    return super.toString() + ", cid=" + getCallId() + ", "
+    return super.toString() + ", "
         + (isSuccess()? "SUCCESS":  "FAILED " + exception)
         + ", logIndex=" + getLogIndex() + ", commits" + ProtoUtils.toString(commitInfos);
   }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientRequest.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientRequest.java
@@ -191,7 +191,6 @@ public class RaftClientRequest extends RaftClientMessage {
         r.getCallId(), message, RaftClientRequest.writeRequestType(), r.getSlidingWindowEntry());
   }
 
-  private final long callId;
   private final Message message;
   private final Type type;
 
@@ -204,8 +203,7 @@ public class RaftClientRequest extends RaftClientMessage {
   public RaftClientRequest(
       ClientId clientId, RaftPeerId serverId, RaftGroupId groupId,
       long callId, Message message, Type type, SlidingWindowEntry slidingWindowEntry) {
-    super(clientId, serverId, groupId);
-    this.callId = callId;
+    super(clientId, serverId, groupId, callId);
     this.message = message;
     this.type = type;
     this.slidingWindowEntry = slidingWindowEntry != null? slidingWindowEntry: SlidingWindowEntry.getDefaultInstance();
@@ -214,10 +212,6 @@ public class RaftClientRequest extends RaftClientMessage {
   @Override
   public final boolean isRequest() {
     return true;
-  }
-
-  public long getCallId() {
-    return callId;
   }
 
   public SlidingWindowEntry getSlidingWindowEntry() {
@@ -238,7 +232,7 @@ public class RaftClientRequest extends RaftClientMessage {
 
   @Override
   public String toString() {
-    return super.toString() + ", cid=" + callId + ", seq=" + ProtoUtils.toString(slidingWindowEntry) + ", "
+    return super.toString() + ", seq=" + ProtoUtils.toString(slidingWindowEntry) + ", "
         + type + ", " + getMessage();
   }
 }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1160