### PR TITLE
RATIS-1164. Remove deprecated RaftServerConstants.INVALID_LOG_INDEX.

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/ArithmeticStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/ArithmeticStateMachine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -23,8 +23,8 @@ import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.RaftServer;
-import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.statemachine.StateMachineStorage;
 import org.apache.ratis.statemachine.TransactionContext;
@@ -112,12 +112,12 @@ public class ArithmeticStateMachine extends BaseStateMachine {
   private long load(SingleFileSnapshotInfo snapshot, boolean reload) throws IOException {
     if (snapshot == null) {
       LOG.warn("The snapshot info is null.");
-      return RaftServerConstants.INVALID_LOG_INDEX;
+      return RaftLog.INVALID_LOG_INDEX;
     }
     final File snapshotFile = snapshot.getFile().getPath().toFile();
     if (!snapshotFile.exists()) {
       LOG.warn("The snapshot file {} does not exist for snapshot {}", snapshotFile, snapshot);
-      return RaftServerConstants.INVALID_LOG_INDEX;
+      return RaftLog.INVALID_LOG_INDEX;
     }
 
     final TermIndex last = SimpleStateMachineStorage.getTermIndexFromSnapshotFile(snapshotFile);

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
@@ -69,7 +69,6 @@ import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.logservice.server.ArchivalInfo.ArchivalStatus;
-import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.impl.RaftServerProxy;
 import org.apache.ratis.server.impl.ServerState;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -224,12 +223,12 @@ public class LogStateMachine extends BaseStateMachine {
   private long load(SingleFileSnapshotInfo snapshot, boolean reload) throws IOException {
     if (snapshot == null) {
       LOG.warn("The snapshot info is null.");
-      return RaftServerConstants.INVALID_LOG_INDEX;
+      return RaftLog.INVALID_LOG_INDEX;
     }
     final File snapshotFile = snapshot.getFile().getPath().toFile();
     if (!snapshotFile.exists()) {
       LOG.warn("The snapshot file {} does not exist for snapshot {}", snapshotFile, snapshot);
-      return RaftServerConstants.INVALID_LOG_INDEX;
+      return RaftLog.INVALID_LOG_INDEX;
     }
 
     final TermIndex last = SimpleStateMachineStorage.getTermIndexFromSnapshotFile(snapshotFile);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.ratis.server.impl;
 
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.util.Preconditions;
 
 import java.util.*;
@@ -43,7 +44,7 @@ public final class RaftConfiguration {
   public static final class Builder {
     private PeerConfiguration oldConf;
     private PeerConfiguration conf;
-    private long logEntryIndex = RaftServerConstants.INVALID_LOG_INDEX;
+    private long logEntryIndex = RaftLog.INVALID_LOG_INDEX;
 
     private boolean forceStable = false;
     private boolean forceTransitional = false;
@@ -92,11 +93,8 @@ public final class RaftConfiguration {
     }
 
     public Builder setLogEntryIndex(long logEntryIndex) {
-      Preconditions.assertTrue(
-          logEntryIndex != RaftServerConstants.INVALID_LOG_INDEX);
-      Preconditions.assertTrue(
-          this.logEntryIndex == RaftServerConstants.INVALID_LOG_INDEX,
-          "logEntryIndex is already set.");
+      Preconditions.assertTrue(logEntryIndex != RaftLog.INVALID_LOG_INDEX);
+      Preconditions.assertTrue(this.logEntryIndex == RaftLog.INVALID_LOG_INDEX, "logEntryIndex is already set.");
       this.logEntryIndex = logEntryIndex;
       return this;
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerConstants.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerConstants.java
@@ -17,18 +17,9 @@
  */
 package org.apache.ratis.server.impl;
 
-import org.apache.ratis.server.raftlog.RaftLog;
-
-public final class RaftServerConstants {
-  /** @deprecated use {@link RaftLog#INVALID_LOG_INDEX}. */
-  @Deprecated
-  public static final long INVALID_LOG_INDEX = RaftLog.INVALID_LOG_INDEX;
+public interface RaftServerConstants {
   public static final long DEFAULT_CALLID = 0;
   public static final long DEFAULT_TERM = 0;
-
-  private RaftServerConstants() {
-    //Never constructed
-  }
 
   public enum StartupOption {
     FORMAT("format"),

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerConstants.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerConstants.java
@@ -17,9 +17,13 @@
  */
 package org.apache.ratis.server.impl;
 
-public interface RaftServerConstants {
+public final class RaftServerConstants {
   public static final long DEFAULT_CALLID = 0;
   public static final long DEFAULT_TERM = 0;
+
+  private RaftServerConstants() {
+    //Never constructed
+  }
 
   public enum StartupOption {
     FORMAT("format"),

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogSequentialOps.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLogSequentialOps.java
@@ -110,7 +110,7 @@ interface RaftLogSequentialOps {
    * Note that the underlying I/O operation is submitted but may not be completed when this method returns.
    *
    * @return the index of the new log entry if it is appended;
-   *         otherwise, return {@link org.apache.ratis.server.impl.RaftServerConstants#INVALID_LOG_INDEX}.
+   *         otherwise, return {@link org.apache.ratis.server.raftlog.RaftLog#INVALID_LOG_INDEX}.
    */
   long appendMetadata(long term, long commitIndex);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -20,7 +20,6 @@ package org.apache.ratis.server.raftlog.segmented;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.impl.ServerProtoUtils;
 import org.apache.ratis.server.metrics.RaftLogMetrics;
 import org.apache.ratis.server.protocol.TermIndex;
@@ -497,8 +496,7 @@ public class SegmentedRaftLogCache {
 
   long getStartIndex() {
     if (closedSegments.isEmpty()) {
-      return openSegment != null ? openSegment.getStartIndex() :
-          RaftServerConstants.INVALID_LOG_INDEX;
+      return Optional.ofNullable(openSegment).map(LogSegment::getStartIndex).orElse(RaftLog.INVALID_LOG_INDEX);
     } else {
       return closedSegments.get(0).getStartIndex();
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogInputStream.java
@@ -17,8 +17,6 @@
  */
 package org.apache.ratis.server.raftlog.segmented;
 
-import static org.apache.ratis.server.impl.RaftServerConstants.INVALID_LOG_INDEX;
-
 import java.io.Closeable;
 import java.io.EOFException;
 import java.io.File;
@@ -32,6 +30,8 @@ import org.apache.ratis.util.OpenCloseState;
 import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.ratis.server.raftlog.RaftLog.INVALID_LOG_INDEX;
 
 public class SegmentedRaftLogInputStream implements Closeable {
   static final Logger LOG = LoggerFactory.getLogger(SegmentedRaftLogInputStream.class);
@@ -130,7 +130,7 @@ public class SegmentedRaftLogInputStream implements Closeable {
         if (entry != null) {
           long index = entry.getIndex();
           if (!isOpen() && index >= endIndex) {
-            /**
+            /*
              * The end index may be derived from the segment recovery
              * process. It is possible that we still have some uncleaned garbage
              * in the end. We should skip them.

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogReader.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogReader.java
@@ -19,8 +19,8 @@ package org.apache.ratis.server.raftlog.segmented;
 
 import org.apache.ratis.io.CorruptedFileException;
 import org.apache.ratis.protocol.exceptions.ChecksumException;
-import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.metrics.RaftLogMetrics;
+import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.thirdparty.com.google.protobuf.CodedInputStream;
 import org.apache.ratis.thirdparty.com.google.protobuf.CodedOutputStream;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
@@ -32,6 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+import java.util.Optional;
 import java.util.zip.Checksum;
 
 import com.codahale.metrics.Timer;
@@ -229,8 +230,7 @@ class SegmentedRaftLogReader implements Closeable {
    * @return the index of the log entry
    */
   long scanEntry() throws IOException {
-    LogEntryProto entry = decodeEntry();
-    return entry != null ? entry.getIndex() : RaftServerConstants.INVALID_LOG_INDEX;
+    return Optional.ofNullable(decodeEntry()).map(LogEntryProto::getIndex).orElse(RaftLog.INVALID_LOG_INDEX);
   }
 
   void verifyTerminator() throws IOException {

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageDirectory.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageDirectory.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ratis.server.storage;
 
-import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.util.AtomicFileOutputStream;
 import org.apache.ratis.util.FileUtils;
@@ -85,7 +84,7 @@ public class RaftStorageDirectory {
     }
 
     public boolean isOpen() {
-      return endIndex == RaftServerConstants.INVALID_LOG_INDEX;
+      return endIndex == RaftLog.INVALID_LOG_INDEX;
     }
 
     @Override

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
@@ -25,8 +25,8 @@ import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
-import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.statemachine.SnapshotInfo;
 import org.apache.ratis.statemachine.StateMachine;
@@ -152,7 +152,7 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
 
   @Override
   public long takeSnapshot() throws IOException {
-    return RaftServerConstants.INVALID_LOG_INDEX;
+    return RaftLog.INVALID_LOG_INDEX;
   }
 
   @Override

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
@@ -30,10 +30,10 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.impl.ServerProtoUtils;
 import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogInputStream;
 import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogOutputStream;
 import org.apache.ratis.server.storage.RaftStorage;
@@ -70,7 +70,7 @@ import java.util.concurrent.TimeUnit;
  * For snapshot it simply merges all the log segments together.
  */
 public class SimpleStateMachine4Testing extends BaseStateMachine {
-  private static volatile int SNAPSHOT_THRESHOLD = 100;
+  private static final int SNAPSHOT_THRESHOLD = 100;
   private static final Logger LOG = LoggerFactory.getLogger(SimpleStateMachine4Testing.class);
   private static final String RAFT_TEST_SIMPLE_STATE_MACHINE_TAKE_SNAPSHOT_KEY
       = "raft.test.simple.state.machine.take.snapshot";
@@ -162,7 +162,7 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
 
   private final Blocking blocking = new Blocking();
   private final Collecting collecting = new Collecting();
-  private long endIndexLastCkpt = RaftServerConstants.INVALID_LOG_INDEX;
+  private long endIndexLastCkpt = RaftLog.INVALID_LOG_INDEX;
   private volatile RoleInfoProto slownessInfo = null;
   private volatile RoleInfoProto leaderElectionTimeoutInfo = null;
 
@@ -254,7 +254,7 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   public long takeSnapshot() {
     final TermIndex termIndex = getLastAppliedTermIndex();
     if (termIndex.getTerm() <= 0 || termIndex.getIndex() <= 0) {
-      return RaftServerConstants.INVALID_LOG_INDEX;
+      return RaftLog.INVALID_LOG_INDEX;
     }
     final long endIndex = termIndex.getIndex();
 
@@ -305,7 +305,7 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
     if (snapshot == null || !snapshot.getFile().getPath().toFile().exists()) {
       LOG.info("The snapshot file {} does not exist",
           snapshot == null ? null : snapshot.getFile());
-      return RaftServerConstants.INVALID_LOG_INDEX;
+      return RaftLog.INVALID_LOG_INDEX;
     } else {
       LOG.info("Loading snapshot {}", snapshot);
       final long endIndex = snapshot.getIndex();

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestRaftLogReadWrite.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestRaftLogReadWrite.java
@@ -22,9 +22,9 @@ import org.apache.ratis.RaftTestUtil.SimpleOperation;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.protocol.exceptions.ChecksumException;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerConstants;
 import org.apache.ratis.server.impl.RaftServerConstants.StartupOption;
 import org.apache.ratis.server.impl.ServerProtoUtils;
+import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.thirdparty.com.google.protobuf.CodedOutputStream;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
@@ -53,7 +53,7 @@ public class TestRaftLogReadWrite extends BaseTest {
   private int bufferSize;
 
   @Before
-  public void setup() throws Exception {
+  public void setup() {
     storageDir = getTestDir();
     RaftProperties properties = new RaftProperties();
     RaftServerConfigKeys.setStorageDir(properties,  Collections.singletonList(storageDir));
@@ -116,8 +116,7 @@ public class TestRaftLogReadWrite extends BaseTest {
 
     Assert.assertEquals(size, openSegment.length());
 
-    LogEntryProto[] readEntries = readLog(openSegment, 0,
-        RaftServerConstants.INVALID_LOG_INDEX, true);
+    final LogEntryProto[] readEntries = readLog(openSegment, 0, RaftLog.INVALID_LOG_INDEX, true);
     Assert.assertArrayEquals(entries, readEntries);
   }
 
@@ -144,8 +143,7 @@ public class TestRaftLogReadWrite extends BaseTest {
       }
     }
 
-    LogEntryProto[] readEntries = readLog(openSegment, 0,
-        RaftServerConstants.INVALID_LOG_INDEX, true);
+    final LogEntryProto[] readEntries = readLog(openSegment, 0, RaftLog.INVALID_LOG_INDEX, true);
     Assert.assertArrayEquals(entries, readEntries);
 
     storage.close();
@@ -173,8 +171,7 @@ public class TestRaftLogReadWrite extends BaseTest {
         openSegment.length());
 
     // check if the reader can correctly read the log file
-    LogEntryProto[] readEntries = readLog(openSegment, 0,
-        RaftServerConstants.INVALID_LOG_INDEX, true);
+    final LogEntryProto[] readEntries = readLog(openSegment, 0, RaftLog.INVALID_LOG_INDEX, true);
     Assert.assertArrayEquals(entries, readEntries);
 
     out.close();
@@ -211,7 +208,7 @@ public class TestRaftLogReadWrite extends BaseTest {
 
     List<LogEntryProto> list = new ArrayList<>();
     try (SegmentedRaftLogInputStream in = new SegmentedRaftLogInputStream(openSegment, 0,
-        RaftServerConstants.INVALID_LOG_INDEX, true)) {
+        RaftLog.INVALID_LOG_INDEX, true)) {
       LogEntryProto entry;
       while ((entry = in.nextEntry()) != null) {
         list.add(entry);
@@ -259,7 +256,7 @@ public class TestRaftLogReadWrite extends BaseTest {
     }
 
     try {
-      readLog(openSegment, 0, RaftServerConstants.INVALID_LOG_INDEX, true);
+      readLog(openSegment, 0, RaftLog.INVALID_LOG_INDEX, true);
       Assert.fail("The read of corrupted log file should fail");
     } catch (ChecksumException e) {
       LOG.info("Caught ChecksumException as expected", e);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1164