### PR TITLE
RATIS-1169. Move the DataStream tests from TestDataStreamNetty to DataStreamClusterTests

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/CollectionUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/CollectionUtils.java
@@ -68,6 +68,19 @@ public interface CollectionUtils {
     return size == 0? null: list.get(ThreadLocalRandom.current().nextInt(size));
   }
 
+  /** @return a randomly picked element. */
+  static <T> T random(Collection<T> elements) {
+    if (elements == null || elements.isEmpty()) {
+      return null;
+    }
+
+    final Iterator<T> i = elements.iterator();
+    for(int n = ThreadLocalRandom.current().nextInt(elements.size()); n > 0; n--) {
+      i.next();
+    }
+    return i.next();
+  }
+
   static <INPUT, OUTPUT> Iterable<OUTPUT> as(
       Iterable<INPUT> iteration, Function<INPUT, OUTPUT> converter) {
     return () -> new Iterator<OUTPUT>() {

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamAsyncClusterTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamAsyncClusterTests.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.datastream;
+
+import org.apache.ratis.MiniRaftCluster;
+import org.apache.ratis.RaftTestUtil;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.impl.DataStreamClientImpl.DataStreamOutputImpl;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.util.CollectionUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+public abstract class DataStreamAsyncClusterTests<CLUSTER extends MiniRaftCluster>
+    extends DataStreamClusterTests<CLUSTER> {
+  final Executor executor = Executors.newFixedThreadPool(16);
+
+  @Test
+  public void testMultipleStreamsSingleServer() throws Exception {
+    runWithNewCluster(1, this::runTestDataStream);
+  }
+
+  @Test
+  public void testMultipleStreamsMultipleServers() throws Exception {
+    runWithNewCluster(3, this::runTestDataStream);
+  }
+
+  void runTestDataStream(CLUSTER cluster) throws Exception {
+    RaftTestUtil.waitForLeader(cluster);
+    final List<CompletableFuture<Void>> futures = new ArrayList<>();
+    futures.add(CompletableFuture.runAsync(() -> runTestDataStream(cluster, 5, 10, 1_000_000, 10), executor));
+    futures.add(CompletableFuture.runAsync(() -> runTestDataStream(cluster, 2, 20, 1_000, 10_000), executor));
+    futures.forEach(CompletableFuture::join);
+  }
+
+  void runTestDataStream(CLUSTER cluster, int numClients, int numStreams, int bufferSize, int bufferNum) {
+    final List<CompletableFuture<Void>> futures = new ArrayList<>();
+    for (int j = 0; j < numClients; j++) {
+      futures.add(CompletableFuture.runAsync(() -> runTestDataStream(cluster, numStreams, bufferSize, bufferNum), executor));
+    }
+    Assert.assertEquals(numClients, futures.size());
+    futures.forEach(CompletableFuture::join);
+  }
+
+  void runTestDataStream(CLUSTER cluster, int numStreams, int bufferSize, int bufferNum) {
+    final Iterable<RaftServer> servers = CollectionUtils.as(cluster.getServers(), s -> s);
+    final List<CompletableFuture<Void>> futures = new ArrayList<>();
+    try(RaftClient client = cluster.createClient()) {
+      for (int i = 0; i < numStreams; i++) {
+        final DataStreamOutputImpl out = (DataStreamOutputImpl) client.getDataStreamApi().stream();
+        futures.add(CompletableFuture.runAsync(() -> DataStreamTestUtils.writeAndCloseAndAssertReplies(
+            servers, out, bufferSize, bufferNum), executor));
+      }
+      Assert.assertEquals(numStreams, futures.size());
+      futures.forEach(CompletableFuture::join);
+    } catch (IOException e) {
+      throw new CompletionException(e);
+    }
+  }
+}

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamWithGrpcCluster.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamWithGrpcCluster.java
@@ -18,6 +18,6 @@
 package org.apache.ratis.datastream;
 
 public class TestNettyDataStreamWithGrpcCluster
-    extends DataStreamClusterTests<MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty>
+    extends DataStreamAsyncClusterTests<MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty>
     implements MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty.FactoryGet {
 }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamWithMock.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamWithMock.java
@@ -50,7 +50,7 @@ import java.util.stream.Collectors;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class TestDataStreamNetty extends DataStreamBaseTest {
+public class TestNettyDataStreamWithMock extends DataStreamBaseTest {
   static RaftPeer newRaftPeer(RaftServer server) {
     final InetSocketAddress rpc = NetUtils.createLocalServerAddress();
     final int dataStreamPort = NettyConfigKeys.DataStream.port(server.getProperties());
@@ -72,16 +72,6 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
     final RaftProperties p = new RaftProperties(properties);
     NettyConfigKeys.DataStream.setPort(p, NetUtils.createSocketAddr(peer.getDataStreamAddress()).getPort());
     return super.newRaftServer(peer, p);
-  }
-
-  @Test
-  public void testDataStreamSingleServer() throws Exception {
-    runTestDataStream(1);
-  }
-
-  @Test
-  public void testDataStreamMultipleServer() throws Exception {
-    runTestDataStream(3);
   }
 
   private void testMockCluster(int leaderIndex, int numServers, RaftException leaderException,
@@ -146,7 +136,7 @@ public class TestDataStreamNetty extends DataStreamBaseTest {
       Exception expectedException, Exception headerException) throws Exception {
     try {
       final List<RaftPeer> peers = raftServers.stream()
-          .map(TestDataStreamNetty::newRaftPeer)
+          .map(TestNettyDataStreamWithMock::newRaftPeer)
           .collect(Collectors.toList());
       setup(groupId, peers, raftServers);
       runTestMockCluster(clientId, bufferSize, bufferNum, expectedException, headerException);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1169