### PR TITLE
RATIS-1177. NPE when RaftServerJmxAdapter queries getLeaderId.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1622,7 +1622,12 @@ public class RaftServerImpl implements RaftServer.Division,
 
     @Override
     public String getLeaderId() {
-      return getState().getLeaderId().toString();
+      RaftPeerId leaderId = getState().getLeaderId();
+      if (leaderId != null) {
+        return leaderId.toString();
+      } else {
+        return null;
+      }
     }
 
     @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a follower is in candidate state but unable to get votes and also unable to get new leader info, the JMXBeanServer query to getLeaderId can throw a NPE. 


## What is the link to the Apache JIRA

This happens because RaftServerJmxAdapter#getLeaderId() does not check whether leaderId is null before calling toString() on it.
