### PR TITLE
RATIS-1180. Expose RaftServer status with Status Info

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -593,6 +593,30 @@ public class RaftServerImpl implements RaftServer.Division,
     return true;
   }
 
+  /**
+   * Return status of the RaftServer.
+   * @return LeaderStatus
+   */
+  public ServerStatus getServerStatus() {
+    if (!isLeader()) {
+      return ServerStatus.NOT_LEADER;
+    }
+
+    final LeaderState leaderState = role.getLeaderState().orElse(null);
+    if (leaderState == null || !leaderState.isReady()) {
+      return ServerStatus.LEADER_AND_NOTREADY;
+    }
+
+    return ServerStatus.LEADER_AND_READY;
+  }
+
+
+  public enum ServerStatus {
+    NOT_LEADER,
+    LEADER_AND_NOTREADY,
+    LEADER_AND_READY;
+  }
+
   NotLeaderException generateNotLeaderException() {
     if (lifeCycle.getCurrentState() != RUNNING) {
       return new NotLeaderException(getMemberId(), null, null);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now we have isLeader() but it says false when it is leader and not ready. There is no way to figure out if it is leader and not ready from this API, we need to call isLeader and isLeaderReady for that.

This Jira exposes the ServerStatus with the following info.
NOT_LEADER, LEADER_AND_READY, and LEADER_AND_NOT_READY.

The purpose of Jira is to avoid multiple calls like isLeader and isLeaderReady, trying to achieve the same with a single API.

Expose ServerStatus API with the following info.
NOT_LEADER, LEADER_AND_READY, and LEADER_AND_NOT_READY.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1180

## How was this patch tested?


