### PR TITLE
RATIS-1183. Add getId() and getPeer() to RaftServer/RaftServer.Division.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -241,7 +241,7 @@ class LeaderElection implements Runnable {
             return;
           case SHUTDOWN:
             LOG.info("{} received shutdown response when requesting votes.", this);
-            server.getProxy().close();
+            server.getRaftServer().close();
             return;
           case REJECTED:
           case DISCOVERED_A_NEW_TERM:

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderState.java
@@ -236,10 +236,11 @@ public class LeaderState {
   private final RaftServerMetrics raftServerMetrics;
   private final LogAppenderMetrics logAppenderMetrics;
 
-  LeaderState(RaftServerImpl server, RaftProperties properties) {
+  LeaderState(RaftServerImpl server) {
     this.name = server.getMemberId() + "-" + JavaUtils.getClassSimpleName(getClass());
     this.server = server;
 
+    final RaftProperties properties = server.getRaftServer().getProperties();
     stagingCatchupGap = RaftServerConfigKeys.stagingCatchupGap(properties);
     syncInterval = RaftServerConfigKeys.Rpc.sleepTime(properties);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LogAppender.java
@@ -155,7 +155,7 @@ public class LogAppender {
     this.leaderState = leaderState;
     this.raftLog = server.getState().getLog();
 
-    final RaftProperties properties = server.getProxy().getProperties();
+    final RaftProperties properties = server.getRaftServer().getProperties();
     this.snapshotChunkMaxSize = RaftServerConfigKeys.Log.Appender.snapshotChunkSizeMax(properties).getSizeInt();
     this.halfMinTimeoutMs = server.getMinTimeoutMs() / 2;
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -58,6 +58,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.*;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -155,6 +156,7 @@ public class RaftServerProxy implements RaftServer {
   }
 
   private final RaftPeerId id;
+  private final Supplier<RaftPeer> peerSupplier = JavaUtils.memoize(this::buildRaftPeer);
   private final RaftProperties properties;
   private final StateMachine.Registry stateMachineRegistry;
   private final LifeCycle lifeCycle;
@@ -235,6 +237,19 @@ public class RaftServerProxy implements RaftServer {
   @Override
   public RaftPeerId getId() {
     return id;
+  }
+
+  @Override
+  public RaftPeer getPeer() {
+    return peerSupplier.get();
+  }
+
+  private RaftPeer buildRaftPeer() {
+    return RaftPeer.newBuilder()
+        .setId(getId())
+        .setAddress(getServerRpc().getInetSocketAddress())
+        .setDataStreamAddress(getDataStreamServerRpc().getInetSocketAddress())
+        .build();
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
@@ -18,7 +18,6 @@
 
 package org.apache.ratis.server.impl;
 
-import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -90,8 +89,8 @@ class RoleInfo {
     return Objects.requireNonNull(leaderState.get(), "leaderState is null");
   }
 
-  LogEntryProto startLeaderState(RaftServerImpl server, RaftProperties properties) {
-    return updateAndGet(leaderState, new LeaderState(server, properties)).start();
+  LogEntryProto startLeaderState(RaftServerImpl server) {
+    return updateAndGet(leaderState, new LeaderState(server)).start();
   }
 
   void shutdownLeaderState(boolean allowNull) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -158,7 +158,7 @@ public class ServerState implements Closeable {
 
   private long initStatemachine(StateMachine sm, RaftGroupId gid)
       throws IOException {
-    sm.initialize(server.getProxy(), gid, storage);
+    sm.initialize(server.getRaftServer(), gid, storage);
     SnapshotInfo snapshot = sm.getLatestSnapshot();
 
     if (snapshot == null || snapshot.getTermIndex().getIndex() < 0) {

--- a/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
@@ -71,7 +71,7 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
     implements MiniRaftCluster.Factory.Get<CLUSTER> {
   {
     Log4jUtils.setLogLevel(RaftServer.Division.LOG, Level.DEBUG);
-    Log4jUtils.setLogLevel(RaftServerTestUtil.getStateMachineUpdaterLog(), Level.DEBUG);
+    RaftServerTestUtil.setStateMachineUpdaterLogLevel(Level.DEBUG);
 
     RaftServerConfigKeys.RetryCache.setExpiryTime(getProperties(), TimeDuration.valueOf(5, TimeUnit.SECONDS));
   }

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
@@ -77,7 +77,7 @@ public class SimpleStateMachine4Testing extends BaseStateMachine {
   private static final boolean RAFT_TEST_SIMPLE_STATE_MACHINE_TAKE_SNAPSHOT_DEFAULT = false;
   private boolean notifiedAsLeader;
 
-  public static SimpleStateMachine4Testing get(RaftServerImpl s) {
+  public static SimpleStateMachine4Testing get(RaftServer.Division s) {
     return (SimpleStateMachine4Testing)s.getStateMachine();
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamWithMock.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/TestNettyDataStreamWithMock.java
@@ -120,7 +120,8 @@ public class TestNettyDataStreamWithMock extends DataStreamBaseTest {
       if (getStateMachineException == null) {
         final ConcurrentMap<RaftGroupId, MyDivision> divisions = new ConcurrentHashMap<>();
         when(raftServer.getDivision(Mockito.any(RaftGroupId.class))).thenAnswer(
-            invocation -> divisions.computeIfAbsent((RaftGroupId)invocation.getArguments()[0], MyDivision::new));
+            invocation -> divisions.computeIfAbsent((RaftGroupId)invocation.getArguments()[0],
+                key -> new MyDivision(raftServer)));
       } else {
         when(raftServer.getDivision(Mockito.any(RaftGroupId.class))).thenThrow(getStateMachineException);
       }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestGrpcMessageMetrics.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestGrpcMessageMetrics.java
@@ -25,7 +25,8 @@ import org.apache.ratis.grpc.server.GrpcService;
 import org.apache.ratis.metrics.JVMMetrics;
 import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.protocol.RaftClientReply;
-import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.Assert;
@@ -62,9 +63,9 @@ public class TestGrpcMessageMetrics extends BaseTest
     JavaUtils.attempt(() -> assertMessageCount(cluster.getLeader()), 100, HUNDRED_MILLIS, cluster.getLeader().getId() + "-assertMessageCount", null);
   }
 
-  static void assertMessageCount(RaftServerImpl server) throws  Exception {
+  static void assertMessageCount(RaftServer.Division server) {
     String serverId = server.getId().toString();
-    GrpcService service = (GrpcService)(server.getProxy().getServerRpc());
+    GrpcService service = (GrpcService) RaftServerTestUtil.getServerRpc(server);
     RatisMetricRegistry registry = service.getServerInterceptor().getMetrics().getRegistry();
     String counter_prefix = serverId + "_" + "ratis.grpc.RaftServerProtocolService";
     Assert.assertTrue(registry.counter(counter_prefix + "_" + "requestVote" + "_OK_completed_total").getCount() > 0);

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRetryCacheWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRetryCacheWithGrpc.java
@@ -25,9 +25,8 @@ import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.exceptions.ResourceUnavailableException;
+import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerImpl;
-import org.apache.ratis.server.impl.RaftServerProxy;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
@@ -51,9 +50,9 @@ public class TestRetryCacheWithGrpc
     MiniRaftClusterWithGrpc cluster = getFactory().newCluster(NUM_SERVERS, properties);
     cluster.start();
 
-    RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster);
-    RaftServerProxy leaderProxy = leader.getProxy();
-    for (RaftServerImpl follower : cluster.getFollowers()) {
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+    final RaftServer leaderProxy = leader.getRaftServer();
+    for (RaftServer.Division follower : cluster.getFollowers()) {
       // block followers to trigger ResourceUnavailableException
       ((SimpleStateMachine4Testing) follower.getStateMachine()).blockWriteStateMachineData();
     }
@@ -74,7 +73,7 @@ public class TestRetryCacheWithGrpc
         return null;
       });
     }
-    for (RaftServerImpl follower : cluster.getFollowers()) {
+    for (RaftServer.Division follower : cluster.getFollowers()) {
       // unblock followers
       ((SimpleStateMachine4Testing)follower.getStateMachine()).unblockWriteStateMachineData();
     }

--- a/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
+++ b/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.statemachine;
 
+import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 import org.apache.log4j.Level;
 import org.apache.ratis.BaseTest;
@@ -48,7 +49,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -64,7 +64,7 @@ public class TestStateMachine extends BaseTest implements MiniRaftClusterWithSim
   public static final int NUM_SERVERS = 3;
 
   static class SMTransactionContext extends SimpleStateMachine4Testing {
-    public static SMTransactionContext get(RaftServerImpl s) {
+    public static SMTransactionContext get(RaftServer.Division s) {
       return (SMTransactionContext)s.getStateMachine();
     }
 
@@ -159,10 +159,10 @@ public class TestStateMachine extends BaseTest implements MiniRaftClusterWithSim
     }
 
     // check leader
-    RaftServerImpl raftServer = cluster.getLeader();
+    RaftServer.Division raftServer = cluster.getLeader();
     // assert every transaction has obtained context in leader
     final SMTransactionContext sm = SMTransactionContext.get(raftServer);
-    List<Long> ll = sm.applied.stream().collect(Collectors.toList());
+    final List<Long> ll = new ArrayList<>(sm.applied);
     Collections.sort(ll);
     assertEquals(ll.toString(), ll.size(), numTrx);
     for (int i=0; i < numTrx; i++) {


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1183