### PR TITLE
RATIS-1187. Avoid directly using RaftServerImpl in LeaderElectionMetrics

### DIFF
--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/server/TestGrpcServerMetrics.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/server/TestGrpcServerMetrics.java
@@ -25,7 +25,6 @@ import static org.apache.ratis.grpc.metrics.GrpcServerMetrics.RATIS_GRPC_METRICS
 import static org.apache.ratis.grpc.metrics.GrpcServerMetrics.RATIS_GRPC_METRICS_LOG_APPENDER_TIMEOUT;
 import static org.apache.ratis.grpc.metrics.GrpcServerMetrics.RATIS_GRPC_METRICS_REQUESTS_TOTAL;
 import static org.apache.ratis.grpc.metrics.GrpcServerMetrics.RATIS_GRPC_METRICS_REQUEST_RETRY_COUNT;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.SortedMap;
@@ -38,8 +37,6 @@ import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
-import org.apache.ratis.server.impl.RaftServerImpl;
-import org.apache.ratis.server.impl.ServerState;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -54,15 +51,10 @@ public class TestGrpcServerMetrics {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    RaftServerImpl raftServer = mock(RaftServerImpl.class);
-    ServerState serverStateMock = mock(ServerState.class);
-    when(raftServer.getState()).thenReturn(serverStateMock);
-    when(serverStateMock.getLastLeaderElapsedTimeMs()).thenReturn(1000L);
     raftGroupId = RaftGroupId.randomId();
     raftPeerId = RaftPeerId.valueOf("TestId");
     followerId = RaftPeerId.valueOf("FollowerId");
     RaftGroupMemberId raftGroupMemberId = RaftGroupMemberId.valueOf(raftPeerId, raftGroupId);
-    when(raftServer.getMemberId()).thenReturn(raftGroupMemberId);
     grpcServerMetrics = new GrpcServerMetrics(raftGroupMemberId.toString());
     ratisMetricRegistry = grpcServerMetrics.getRegistry();
   }

--- a/ratis-metrics/src/main/java/org/apache/ratis/metrics/RatisMetrics.java
+++ b/ratis-metrics/src/main/java/org/apache/ratis/metrics/RatisMetrics.java
@@ -30,7 +30,7 @@ public class RatisMetrics {
   @SuppressWarnings("VisibilityModifier")
   protected RatisMetricRegistry registry;
 
-  protected RatisMetricRegistry create(MetricRegistryInfo info) {
+  protected static RatisMetricRegistry create(MetricRegistryInfo info) {
     Optional<RatisMetricRegistry> metricRegistry = MetricRegistries.global().get(info);
     return metricRegistry.orElseGet(() -> {
       LOG.info("Creating Metrics Registry : {}", info.getName());

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -140,7 +140,8 @@ public class RaftServerImpl implements RaftServer.Division,
     this.dataStreamMap = new DataStreamMapImpl(id);
 
     this.jmxAdapter = new RaftServerJmxAdapter();
-    this.leaderElectionMetrics = LeaderElectionMetrics.getLeaderElectionMetrics(this);
+    this.leaderElectionMetrics = LeaderElectionMetrics.getLeaderElectionMetrics(
+        getMemberId(), state::getLastLeaderElapsedTimeMs);
     this.raftServerMetrics = RaftServerMetrics.computeIfAbsentRaftServerMetrics(
         getMemberId(), () -> commitInfoCache::get, () -> retryCache);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -266,9 +266,8 @@ public class ServerState implements Closeable {
         .isPresent();
   }
 
-  public long getLastLeaderElapsedTimeMs() {
-    final Timestamp t = lastNoLeaderTime;
-    return t == null ? 0 : t.elapsedTimeMs();
+  long getLastLeaderElapsedTimeMs() {
+    return Optional.ofNullable(lastNoLeaderTime).map(Timestamp::elapsedTimeMs).orElse(0L);
   }
 
   void becomeLeader() {

--- a/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/metrics/TestLeaderElectionMetrics.java
@@ -22,15 +22,11 @@ import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LAST_LEADER_
 import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECTION_TIMEOUT_COUNT_METRIC;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import org.apache.ratis.metrics.RatisMetricRegistry;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
-import org.apache.ratis.server.impl.RaftServerImpl;
-import org.apache.ratis.server.impl.ServerState;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -43,16 +39,11 @@ public class TestLeaderElectionMetrics {
   private static RatisMetricRegistry ratisMetricRegistry;
 
   @BeforeClass
-  public static void setUp() throws Exception {
-    RaftServerImpl raftServer = mock(RaftServerImpl.class);
-    ServerState serverStateMock = mock(ServerState.class);
-    when(raftServer.getState()).thenReturn(serverStateMock);
-    when(serverStateMock.getLastLeaderElapsedTimeMs()).thenReturn(1000L);
+  public static void setUp() {
     RaftGroupId raftGroupId = RaftGroupId.randomId();
     RaftPeerId raftPeerId = RaftPeerId.valueOf("TestId");
     RaftGroupMemberId raftGroupMemberId = RaftGroupMemberId.valueOf(raftPeerId, raftGroupId);
-    when(raftServer.getMemberId()).thenReturn(raftGroupMemberId);
-    leaderElectionMetrics = LeaderElectionMetrics.getLeaderElectionMetrics(raftServer);
+    leaderElectionMetrics = LeaderElectionMetrics.getLeaderElectionMetrics(raftGroupMemberId, () -> 1000L);
     ratisMetricRegistry = leaderElectionMetrics.getRegistry();
   }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1187