### PR TITLE
Ratis 1188. Change MiniRaftCluster.getLeader() to return RaftServer.Division.

### DIFF
--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmeticLogDump.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmeticLogDump.java
@@ -28,7 +28,7 @@ import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
 import org.apache.ratis.server.storage.RaftStorageDirectory;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
@@ -76,9 +76,9 @@ public class TestArithmeticLogDump extends BaseTest {
 
   @Test
   public void testLogDump() throws Exception {
-    RaftServerImpl leaderServer = RaftTestUtil.waitForLeader(cluster);
+    final RaftServer.Division leaderServer = RaftTestUtil.waitForLeader(cluster);
     List<RaftStorageDirectory.LogPathAndIndex> files =
-        leaderServer.getState().getStorage().getStorageDir().getLogSegmentFiles();
+        RaftServerTestUtil.getRaftStorage(leaderServer).getStorageDir().getLogSegmentFiles();
     Assert.assertEquals(1, files.size());
     cluster.shutdown();
 

--- a/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
+++ b/ratis-logservice/src/test/java/org/apache/ratis/logservice/server/TestMetaServer.java
@@ -31,8 +31,6 @@ import org.apache.ratis.logservice.proto.MetaServiceProtos;
 import org.apache.ratis.logservice.util.LogServiceCluster;
 import org.apache.ratis.logservice.util.TestUtils;
 import org.apache.ratis.metrics.JVMMetrics;
-import org.apache.ratis.server.impl.RaftServerImpl;
-import org.apache.ratis.server.impl.RaftServerProxy;
 import org.apache.ratis.util.JavaUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.AfterClass;
@@ -183,14 +181,12 @@ public class TestMetaServer {
             assert (listLogs.stream().filter(log -> log.getLogName().getName().startsWith("testReadWrite")).count() == 1);
             List<LogServer> workers = cluster.getWorkers();
             for (LogServer worker : workers) {
-                RaftServerImpl server = ((RaftServerProxy) worker.getServer())
-                        .getImpl(listLogs.get(0).getRaftGroup().getGroupId());
+                worker.getServer().getDivision(listLogs.get(0).getRaftGroup().getGroupId());
                 // TODO: perform all additional checks on state machine level
             }
             writer.write(testMessage);
             for (LogServer worker : workers) {
-                RaftServerImpl server = ((RaftServerProxy) worker.getServer())
-                        .getImpl(listLogs.get(0).getRaftGroup().getGroupId());
+                worker.getServer().getDivision(listLogs.get(0).getRaftGroup().getGroupId());
             }
 //        assert(stream.getSize() > 0); //TODO: Doesn't work
             LogReader reader = stream.createReader();

--- a/ratis-server/src/test/java/org/apache/ratis/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/MiniRaftCluster.java
@@ -537,7 +537,7 @@ public abstract class MiniRaftCluster implements Closeable {
    * @return the unique leader with the highest term. Or, return null if there is no leader.
    * @throws IllegalStateException if there are multiple leaders with the same highest term.
    */
-  public RaftServerImpl getLeader() {
+  public RaftServer.Division getLeader() {
     return getLeader(getLeaders(null), null, leaders -> {
       throw newIllegalStateExceptionForMultipleLeaders(null, leaders);
     });

--- a/ratis-server/src/test/java/org/apache/ratis/RaftAsyncTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftAsyncTests.java
@@ -38,7 +38,7 @@ import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.impl.DelayLocalExecutionInjection;
-import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.raftlog.RaftLog;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
@@ -418,8 +418,8 @@ public abstract class RaftAsyncTests<CLUSTER extends MiniRaftCluster> extends Ba
     LOG.info("Running testCheckLeadershipFailure");
 
     waitForLeader(cluster);
-    RaftServerImpl prevLeader = cluster.getLeader();
-    long termOfPrevLeader = prevLeader.getState().getCurrentTerm();
+    final RaftServer.Division prevLeader = cluster.getLeader();
+    final long termOfPrevLeader = RaftServerTestUtil.getCurrentTerm(prevLeader);
     LOG.info("Previous Leader is elected on term {}", termOfPrevLeader);
 
     try (final RaftClient client = cluster.createClient()) {
@@ -447,8 +447,8 @@ public abstract class RaftAsyncTests<CLUSTER extends MiniRaftCluster> extends Ba
     }
 
     waitForLeader(cluster);
-    RaftServerImpl currLeader = cluster.getLeader();
-    long termOfCurrLeader = currLeader.getState().getCurrentTerm();
+    final RaftServer.Division currLeader = cluster.getLeader();
+    final long termOfCurrLeader = RaftServerTestUtil.getCurrentTerm(currLeader);
     LOG.info("Current Leader is elected on term {}", termOfCurrLeader);
 
     // leader on termOfPrevLeader should step-down.
@@ -463,8 +463,8 @@ public abstract class RaftAsyncTests<CLUSTER extends MiniRaftCluster> extends Ba
   }
 
   private void runTestNoRetryWaitOnNotLeaderException(MiniRaftCluster cluster) throws Exception {
-    final RaftServerImpl leader = waitForLeader(cluster);
-    final List<RaftServerImpl> followers = cluster.getFollowers();
+    final RaftServer.Division leader = waitForLeader(cluster);
+    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
     Assert.assertNotNull(followers);
     Assert.assertEquals(2, followers.size());
     Assert.assertNotSame(leader, followers.get(0));

--- a/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
@@ -32,7 +32,6 @@ import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
@@ -218,13 +217,13 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
     final int numMessages = p.numMessages;
 
     // blockStartTransaction of the leader so that no transaction can be committed MAJORITY
-    final RaftServerImpl leader = cluster.getLeader();
+    final RaftServer.Division leader = cluster.getLeader();
     LOG.info("block leader {}", leader.getId());
     SimpleStateMachine4Testing.get(leader).blockStartTransaction();
 
     // blockFlushStateMachineData a follower so that no transaction can be ALL_COMMITTED
-    final List<RaftServerImpl> followers = cluster.getFollowers();
-    final RaftServerImpl blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
+    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final RaftServer.Division blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
     LOG.info("block follower {}", blockedFollower.getId());
     SimpleStateMachine4Testing.get(blockedFollower).blockFlushStateMachineData();
 
@@ -340,8 +339,8 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
     final int numMessages = p.numMessages;
 
     // blockFlushStateMachineData a follower so that no transaction can be ALL_COMMITTED
-    final List<RaftServerImpl> followers = cluster.getFollowers();
-    final RaftServerImpl blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
+    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final RaftServer.Division blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
     LOG.info("block follower {}", blockedFollower.getId());
     SimpleStateMachine4Testing.get(blockedFollower).blockFlushStateMachineData();
 
@@ -392,13 +391,13 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
     final TimeDuration watchTimeoutDenomination = RaftServerConfigKeys.Watch.timeoutDenomination(properties);
 
     // blockStartTransaction of the leader so that no transaction can be committed MAJORITY
-    final RaftServerImpl leader = cluster.getLeader();
+    final RaftServer.Division leader = cluster.getLeader();
     LOG.info("block leader {}", leader.getId());
     SimpleStateMachine4Testing.get(leader).blockStartTransaction();
 
     // blockFlushStateMachineData a follower so that no transaction can be ALL_COMMITTED
-    final List<RaftServerImpl> followers = cluster.getFollowers();
-    final RaftServerImpl blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
+    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final RaftServer.Division blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
     LOG.info("block follower {}", blockedFollower.getId());
     SimpleStateMachine4Testing.get(blockedFollower).blockFlushStateMachineData();
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -120,7 +120,7 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     }
 
     JavaUtils.attempt(() -> {
-      RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
+      final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
       Assert.assertTrue(leader.getId() == peers.get(suggestedLeaderIndex).getId());
     }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
 
@@ -134,7 +134,7 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     cluster.setBlockRequestsFrom(suggestedLeader, true);
 
     JavaUtils.attempt(() -> {
-      RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
+      final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
       Assert.assertTrue(leader.getId() != peers.get(suggestedLeaderIndex).getId());
     }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
 
@@ -154,13 +154,13 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     // suggested leader with highest priority rejoin cluster, then current leader will yield
     // leadership to suggested leader when suggested leader catch up the log.
     JavaUtils.attempt(() -> {
-      RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
+      final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
       Assert.assertTrue(leader.getId() == peers.get(suggestedLeaderIndex).getId());
     }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
 
     cluster.killServer(peers.get(suggestedLeaderIndex).getId());
     JavaUtils.attempt(() -> {
-      RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
+      final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
       Assert.assertTrue(leader.getId() != peers.get(suggestedLeaderIndex).getId());
     }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
 
@@ -347,7 +347,7 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     final RaftPeerId peerId = peer.getId();
     final RaftGroup group = RaftGroup.valueOf(cluster.getGroupId(), peer);
     try (final RaftClient client = cluster.createClient()) {
-      Assert.assertEquals(group, cluster.getRaftServerImpl(peerId).getGroup());
+      Assert.assertEquals(group, cluster.getDivision(peerId).getGroup());
       try {
         client.getGroupManagementApi(peer.getId()).add(group);
       } catch (IOException ex) {
@@ -355,7 +355,7 @@ public abstract class GroupManagementBaseTest extends BaseTest {
         // the exception is instance of AlreadyExistsException
         Assert.assertTrue(ex.toString().contains(AlreadyExistsException.class.getCanonicalName()));
       }
-      Assert.assertEquals(group, cluster.getRaftServerImpl(peerId).getGroup());
+      Assert.assertEquals(group, cluster.getDivision(peerId).getGroup());
       cluster.shutdown();
     }
   }
@@ -372,8 +372,7 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     final RaftGroup group1 = RaftGroup.valueOf(cluster1.getGroupId(), peer1);
     final RaftGroup group2 = RaftGroup.valueOf(cluster2.getGroupId(), peer1);
     try (final RaftClient client = cluster1.createClient()) {
-      Assert.assertEquals(group1,
-          cluster1.getRaftServerImpl(peerId1).getGroup());
+      Assert.assertEquals(group1, cluster1.getDivision(peerId1).getGroup());
       try {
 
         // Group2 is added to one of the peers in Group1
@@ -421,7 +420,7 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     final RaftGroup group2 = RaftGroup.valueOf(cluster2.getGroupId(), peer1);
     try (final RaftClient client = cluster1.createClient()) {
       Assert.assertEquals(group1,
-          cluster1.getRaftServerImpl(peerId1).getGroup());
+          cluster1.getDivision(peerId1).getGroup());
       try {
 
         // Group2 is added again to one of the peers in Group1

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftStateMachineExceptionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftStateMachineExceptionTests.java
@@ -106,7 +106,7 @@ public abstract class RaftStateMachineExceptionTests<CLUSTER extends MiniRaftClu
     RaftPeerId leaderId = RaftTestUtil.waitForLeader(cluster).getId();
 
     cluster.getLeaderAndSendFirstMessage(true);
-    long oldLastApplied = cluster.getLeader().getState().getLastAppliedIndex();
+    final long oldLastApplied = RaftServerTestUtil.getLastAppliedIndex(cluster.getLeader());
 
     try (final RaftClient client = cluster.createClient(leaderId)) {
       final RaftClientRpc rpc = client.getClientRpc();

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/SimpleStateMachine4Testing.java
@@ -30,7 +30,6 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.impl.ServerProtoUtils;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.RaftLog;

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftWithGrpc.java
@@ -83,14 +83,14 @@ public class TestRaftWithGrpc
           replyFuture = client.async().send(new RaftTestUtil.SimpleMessage("abc"));
       TimeDuration.valueOf(5 , TimeUnit.SECONDS).sleep();
       // replyFuture should not be completed until append request is unblocked.
-      Assert.assertTrue(!replyFuture.isDone());
+      Assert.assertFalse(replyFuture.isDone());
       // unblock append request.
       cluster.getServerAliveStream()
           .filter(impl -> !impl.isLeader())
           .map(SimpleStateMachine4Testing::get)
           .forEach(SimpleStateMachine4Testing::unblockWriteStateMachineData);
 
-      final RaftLog leaderLog = cluster.getLeader().getState().getLog();
+      final RaftLog leaderLog = RaftServerTestUtil.getRaftLog(cluster.getLeader());
       // The entries have been appended in the followers
       // although the append entry timed out at the leader
       cluster.getServerAliveStream().filter(impl -> !impl.isLeader()).forEach(raftServer ->

--- a/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
+++ b/ratis-test/src/test/java/org/apache/ratis/statemachine/TestStateMachine.java
@@ -33,9 +33,6 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerImpl;
-import org.apache.ratis.server.impl.RaftServerProxy;
-import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
 import org.apache.ratis.util.Log4jUtils;
 import org.junit.*;
@@ -152,7 +149,7 @@ public class TestStateMachine extends BaseTest implements MiniRaftClusterWithSim
     // TODO: there eshould be a better way to ensure all data is replicated and applied
     Thread.sleep(cluster.getTimeoutMax().toLong(TimeUnit.MILLISECONDS) + 100);
 
-    for (RaftServerImpl raftServer : cluster.iterateServerImpls()) {
+    for (RaftServer.Division raftServer : cluster.iterateDivisions()) {
       final SMTransactionContext sm = SMTransactionContext.get(raftServer);
       sm.rethrowIfException();
       assertEquals(numTrx, sm.numApplied.get());
@@ -193,10 +190,9 @@ public class TestStateMachine extends BaseTest implements MiniRaftClusterWithSim
         }
       }
 
-      final RaftServerProxy proxy = cluster.getServer(id);
+      final RaftServer server = cluster.getServer(id);
       for(Map.Entry<RaftGroupId, StateMachine> e: registry.entrySet()) {
-        final RaftServerImpl impl = RaftServerTestUtil.getRaftServerImpl(proxy, e.getKey());
-        Assert.assertSame(e.getValue(), impl.getStateMachine());
+        Assert.assertSame(e.getValue(), server.getDivision(e.getKey()).getStateMachine());
       }
     }
   }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1188