### PR TITLE
RATIS-1189. Change other MiniRaftCluster methods to return RaftServerDivision

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/RaftAsyncExceptionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftAsyncExceptionTests.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.stream.StreamSupport;
 
 public abstract class RaftAsyncExceptionTests<CLUSTER extends MiniRaftCluster>
     extends BaseTest
@@ -104,15 +105,15 @@ public abstract class RaftAsyncExceptionTests<CLUSTER extends MiniRaftCluster>
 
       RaftClientConfigKeys.Rpc.setRequestTimeout(properties.get(), ONE_SECOND);
       // Block StartTransaction
-      cluster.getServers().stream()
-          .map(cluster::getRaftServerImpl)
+      StreamSupport.stream(cluster.getServers().spliterator(), false)
+          .map(cluster::getDivision)
           .map(SimpleStateMachine4Testing::get)
           .forEach(SimpleStateMachine4Testing::blockStartTransaction);
       final CompletableFuture<RaftClientReply> replyFuture = client.async().send(new SimpleMessage("m1"));
       FIVE_SECONDS.sleep();
       // Unblock StartTransaction
-      cluster.getServers().stream()
-          .map(cluster::getRaftServerImpl)
+      StreamSupport.stream(cluster.getServers().spliterator(), false)
+          .map(cluster::getDivision)
           .map(SimpleStateMachine4Testing::get)
           .forEach(SimpleStateMachine4Testing::unblockStartTransaction);
       // The request should succeed after start transaction is unblocked

--- a/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RaftBasicTests.java
@@ -184,7 +184,7 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
     final RaftPeerId leaderId = leader.getId();
     final long term = RaftServerTestUtil.getCurrentTerm(leader);
 
-    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final List<RaftServer.Division> followers = cluster.getFollowers();
     final List<RaftServer.Division> followersToSendLog = followers.subList(0, followers.size() / 2);
     for (int i = followers.size() / 2; i < NUM_SERVERS - 1; i++) {
       cluster.killServer(followers.get(i).getId());
@@ -228,7 +228,7 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
   void runTestOldLeaderNotCommit(CLUSTER cluster) throws Exception {
     final RaftPeerId leaderId = waitForLeader(cluster).getId();
 
-    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final List<RaftServer.Division> followers = cluster.getFollowers();
     final RaftServer.Division followerToCommit = followers.get(0);
     try {
       for (int i = 1; i < NUM_SERVERS - 1; i++) {
@@ -484,7 +484,7 @@ public abstract class RaftBasicTests<CLUSTER extends MiniRaftCluster>
   }
 
   private static void checkFollowerCommitLagsLeader(MiniRaftCluster cluster) {
-    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final List<RaftServer.Division> followers = cluster.getFollowers();
     final RaftGroupMemberId leader = cluster.getLeader().getMemberId();
 
     Gauge leaderCommitGauge = RaftServerMetrics.getPeerCommitIndexGauge(leader, leader.getPeerId());

--- a/ratis-server/src/test/java/org/apache/ratis/RequestLimitAsyncBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/RequestLimitAsyncBaseTest.java
@@ -28,7 +28,6 @@ import org.apache.ratis.protocol.exceptions.ResourceUnavailableException;
 import org.apache.ratis.retry.RetryPolicies;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.util.Log4jUtils;
@@ -67,7 +66,7 @@ public abstract class RequestLimitAsyncBaseTest<CLUSTER extends MiniRaftCluster>
   }
 
   void runTestWriteElementLimit(CLUSTER cluster) throws Exception {
-    final RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster);
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
 
     try (RaftClient c1 = cluster.createClient(leader.getId())) {
       { // send first message to make sure the cluster is working

--- a/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/WatchRequestTests.java
@@ -222,7 +222,7 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
     SimpleStateMachine4Testing.get(leader).blockStartTransaction();
 
     // blockFlushStateMachineData a follower so that no transaction can be ALL_COMMITTED
-    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final List<RaftServer.Division> followers = cluster.getFollowers();
     final RaftServer.Division blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
     LOG.info("block follower {}", blockedFollower.getId());
     SimpleStateMachine4Testing.get(blockedFollower).blockFlushStateMachineData();
@@ -339,7 +339,7 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
     final int numMessages = p.numMessages;
 
     // blockFlushStateMachineData a follower so that no transaction can be ALL_COMMITTED
-    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final List<RaftServer.Division> followers = cluster.getFollowers();
     final RaftServer.Division blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
     LOG.info("block follower {}", blockedFollower.getId());
     SimpleStateMachine4Testing.get(blockedFollower).blockFlushStateMachineData();
@@ -396,7 +396,7 @@ public abstract class WatchRequestTests<CLUSTER extends MiniRaftCluster>
     SimpleStateMachine4Testing.get(leader).blockStartTransaction();
 
     // blockFlushStateMachineData a follower so that no transaction can be ALL_COMMITTED
-    final List<RaftServer.Division> followers = cluster.getFollowerDivisions();
+    final List<RaftServer.Division> followers = cluster.getFollowers();
     final RaftServer.Division blockedFollower = followers.get(ThreadLocalRandom.current().nextInt(followers.size()));
     LOG.info("block follower {}", blockedFollower.getId());
     SimpleStateMachine4Testing.get(blockedFollower).blockFlushStateMachineData();

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -291,8 +291,8 @@ public abstract class GroupManagementBaseTest extends BaseTest {
         final RaftGroup g = groups[i];
         LOG.info(i + ") close " + cluster.printServers(g.getGroupId()));
         for(RaftPeer p : g.getPeers()) {
-          final File root = cluster.getServer(p.getId()).getImpl(g.getGroupId())
-              .getState().getStorage().getStorageDir().getRoot();
+          final RaftServer.Division d = cluster.getDivision(p.getId(), g.getGroupId());
+          final File root = RaftServerTestUtil.getRaftStorage(d).getStorageDir().getRoot();
           Assert.assertTrue(root.exists());
           Assert.assertTrue(root.isDirectory());
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -155,7 +155,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     cluster.initServers();
 
     // start all except one servers
-    final Iterator<RaftServerProxy> i = cluster.getServers().iterator();
+    final Iterator<RaftServer> i = cluster.getServers().iterator();
     for(int j = 1; j < numServer; j++) {
       i.next().start();
     }
@@ -166,7 +166,7 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
     sleepTime.sleep();
 
     // start the last server
-    final RaftServerProxy lastServer = i.next();
+    final RaftServerProxy lastServer = (RaftServerProxy) i.next();
     lastServer.start();
     final RaftPeerId lastServerLeaderId = JavaUtils.attemptRepeatedly(
         () -> Optional.ofNullable(lastServer.getImpls().iterator().next().getState().getLeaderId())

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -321,7 +321,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
 
   void runTestBootstrapReconf(int numNewPeer, boolean startNewPeer, CLUSTER cluster) throws Exception {
       LOG.info("Originally {} peer(s), add {} more, startNewPeer={}",
-          cluster.getServers().size(), numNewPeer, startNewPeer);
+          cluster.getNumServers(), numNewPeer, startNewPeer);
       RaftTestUtil.waitForLeader(cluster);
       final RaftPeerId leaderId = cluster.getLeader().getId();
       try (final RaftClient client = cluster.createClient(leaderId)) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRatisServerMetricsBase.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRatisServerMetricsBase.java
@@ -55,14 +55,14 @@ public abstract class TestRatisServerMetricsBase<CLUSTER extends MiniRaftCluster
 
   void runTestClientFailedRequest(CLUSTER cluster)
       throws InterruptedException, IOException, ExecutionException {
-    RaftServerImpl leaderImpl = RaftTestUtil.waitForLeader(cluster);
+    final RaftServer.Division leaderImpl = RaftTestUtil.waitForLeader(cluster);
     ClientId clientId = ClientId.randomId();
     // StaleRead with Long.MAX_VALUE minIndex will fail.
     RaftClientRequest r = new RaftClientRequest(clientId, leaderImpl.getId(), cluster.getGroupId(),
         0, Message.EMPTY, RaftClientRequest.staleReadRequestType(Long.MAX_VALUE), null);
-    CompletableFuture<RaftClientReply> f = leaderImpl.submitClientRequestAsync(r);
+    final CompletableFuture<RaftClientReply> f = leaderImpl.getRaftServer().submitClientRequestAsync(r);
     Assert.assertTrue(!f.get().isSuccess());
-    assertEquals(1L,
-        leaderImpl.getRaftServerMetrics().getRegistry().counter(RATIS_SERVER_FAILED_CLIENT_STALE_READ_COUNT).getCount());
+    assertEquals(1L, RaftServerTestUtil.getRaftServerMetrics(leaderImpl).getRegistry()
+        .counter(RATIS_SERVER_FAILED_CLIENT_STALE_READ_COUNT).getCount());
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/MiniRaftClusterWithSimulatedRpc.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/MiniRaftClusterWithSimulatedRpc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.StreamSupport;
 
 import static org.apache.ratis.conf.ConfUtils.requireMin;
 
@@ -106,7 +107,8 @@ public class MiniRaftClusterWithSimulatedRpc extends MiniRaftCluster {
     serverRequestReply.getQueue(leaderId).blockSendRequestTo.set(block);
 
     // set delay takeRequest for the other queues
-    getServers().stream().filter(s -> !s.getId().toString().equals(leaderId))
+    StreamSupport.stream(getServers().spliterator(), false)
+        .filter(s -> !s.getId().toString().equals(leaderId))
         .map(s -> serverRequestReply.getQueue(s.getId().toString()))
         .forEach(q -> q.delayTakeRequestTo.set(delayMs));
 

--- a/ratis-test/src/test/java/org/apache/ratis/TestRaftServerNoLeaderTimeout.java
+++ b/ratis-test/src/test/java/org/apache/ratis/TestRaftServerNoLeaderTimeout.java
@@ -22,7 +22,6 @@ import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
@@ -78,8 +77,8 @@ public class TestRaftServerNoLeaderTimeout extends BaseTest {
     RaftTestUtil.waitForLeader(cluster);
     final TimeDuration noLeaderTimeout = RaftServerConfigKeys.Notification.noLeaderTimeout(cluster.getProperties());
 
-    RaftServerImpl healthyFollower = cluster.getFollowers().get(1);
-    RaftServerImpl failedFollower = cluster.getFollowers().get(0);
+    final RaftServer.Division healthyFollower = cluster.getFollowers().get(1);
+    final RaftServer.Division failedFollower = cluster.getFollowers().get(0);
     // fail the leader and one of the followers to that quorum is not present
     // for next leader election to succeed.
     cluster.killServer(failedFollower.getId());

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamAsyncClusterTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamAsyncClusterTests.java
@@ -28,8 +28,6 @@ import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerImpl;
-import org.apache.ratis.server.impl.RaftServerProxy;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.TimeDuration;
 import org.junit.Assert;
@@ -84,8 +82,8 @@ public abstract class DataStreamAsyncClusterTests<CLUSTER extends MiniRaftCluste
       client.async().watch(maxIndex, ReplicationLevel.ALL).join();
     }
     // assert all streams are linked
-    for (RaftServerProxy proxy : cluster.getServers()) {
-      final RaftServerImpl impl = proxy.getImpl(cluster.getGroupId());
+    for (RaftServer proxy : cluster.getServers()) {
+      final RaftServer.Division impl = proxy.getDivision(cluster.getGroupId());
       final MultiDataStreamStateMachine stateMachine = (MultiDataStreamStateMachine) impl.getStateMachine();
       for (SingleDataStream s : stateMachine.getStreams()) {
         Assert.assertFalse(s.getDataChannel().isOpen());

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamClusterTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamClusterTests.java
@@ -28,8 +28,7 @@ import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
-import org.apache.ratis.server.impl.RaftServerImpl;
-import org.apache.ratis.server.impl.RaftServerProxy;
+import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.util.Timestamp;
 import org.apache.ratis.util.function.CheckedConsumer;
 import org.junit.Assert;
@@ -148,8 +147,8 @@ public abstract class DataStreamClusterTests<CLUSTER extends MiniRaftCluster> ex
   }
 
   void assertLogEntry(CLUSTER cluster, RaftClientRequest request) throws Exception {
-    for (RaftServerProxy proxy : cluster.getServers()) {
-      final RaftServerImpl impl = proxy.getImpl(cluster.getGroupId());
+    for (RaftServer proxy : cluster.getServers()) {
+      final RaftServer.Division impl = proxy.getDivision(cluster.getGroupId());
       final MultiDataStreamStateMachine stateMachine = (MultiDataStreamStateMachine) impl.getStateMachine();
       final SingleDataStream s = stateMachine.getSingleDataStream(request);
       Assert.assertFalse(s.getDataChannel().isOpen());

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
@@ -34,7 +34,7 @@ import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.server.RaftServer;
-import org.apache.ratis.server.impl.RaftServerImpl;
+import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.impl.ServerProtoUtils;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.raftlog.RaftLog;
@@ -370,12 +370,13 @@ public interface DataStreamTestUtils {
     Assert.assertEquals(request.getClientId().toByteString(), s.getClientId());
   }
 
-  static void assertLogEntry(RaftServerImpl impl, SingleDataStream stream) throws Exception {
+  static void assertLogEntry(RaftServer.Division division, SingleDataStream stream) throws Exception {
     final RaftClientRequest request = stream.getWriteRequest();
     final LogEntryProto entryFromStream = stream.getLogEntry();
     assertLogEntry(entryFromStream, request);
 
-    final LogEntryProto entryFromLog = searchLogEntry(ClientInvocationId.valueOf(request), impl.getState().getLog());
+    final LogEntryProto entryFromLog = searchLogEntry(ClientInvocationId.valueOf(request),
+        RaftServerTestUtil.getRaftLog(division));
     Assert.assertSame(entryFromStream, entryFromLog);
   }
 }

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestGrpcOutputStream.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestGrpcOutputStream.java
@@ -23,10 +23,8 @@ import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.client.GrpcClientStreamer;
 import org.apache.ratis.grpc.client.GrpcOutputStream;
 import org.apache.ratis.protocol.ClientId;
-import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.util.Log4jUtils;
 import org.apache.ratis.util.SizeInBytes;
-import org.junit.Ignore;
 
 import java.io.OutputStream;
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRaftServerWithGrpc.java
@@ -48,9 +48,9 @@ import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.TimeoutIOException;
 import org.apache.ratis.retry.RetryPolicies;
+import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.RaftServerRpc;
-import org.apache.ratis.server.impl.RaftServerImpl;
 import org.apache.ratis.server.metrics.RaftServerMetrics;
 import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.impl.ServerImplUtils;
@@ -94,11 +94,11 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
   }
 
   void runTestServerRestartOnException(MiniRaftClusterWithGrpc cluster) throws Exception {
-    final RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster);
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
     final RaftPeerId leaderId = leader.getId();
 
     final RaftProperties p = getProperties();
-    GrpcConfigKeys.Server.setPort(p, leader.getServerRpc().getInetSocketAddress().getPort());
+    GrpcConfigKeys.Server.setPort(p, RaftServerTestUtil.getServerRpc(leader).getInetSocketAddress().getPort());
 
     // Create a raft server proxy with server rpc bound to a different address
     // compared to leader. This helps in locking the raft storage directory to
@@ -145,7 +145,7 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
   }
 
   void runTestLeaderRestart(MiniRaftClusterWithGrpc cluster) throws Exception {
-    final RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster);
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
 
     try (final RaftClient client = cluster.createClient()) {
       // send a request to make sure leader is ready
@@ -269,8 +269,8 @@ public class TestRaftServerWithGrpc extends BaseTest implements MiniRaftClusterW
 
   void testRaftClientRequestMetrics(MiniRaftClusterWithGrpc cluster) throws IOException,
       ExecutionException, InterruptedException {
-    final RaftServerImpl leader = RaftTestUtil.waitForLeader(cluster);
-    RaftServerMetrics raftServerMetrics = leader.getRaftServerMetrics();
+    final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster);
+    RaftServerMetrics raftServerMetrics = RaftServerTestUtil.getRaftServerMetrics(leader);
 
     try (final RaftClient client = cluster.createClient()) {
       final CompletableFuture<RaftClientReply> f1 = client.async().send(new SimpleMessage("testing"));

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/TestRaftLogMetrics.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/TestRaftLogMetrics.java
@@ -112,7 +112,7 @@ public class TestRaftLogMetrics extends BaseTest
     assertRaftLogWritePathMetrics(cluster.getLeader());
 
     // For followers, flush can be lagged behind.  Attempt multiple times.
-    for(RaftServer.Division f : cluster.getFollowerDivisions()) {
+    for(RaftServer.Division f : cluster.getFollowers()) {
       JavaUtils.attempt(() -> assertFlushCount(f), 10, HUNDRED_MILLIS, f.getId() + "-assertFlushCount", null);
       // We have already waited enough for follower metrics to populate.
       assertRaftLogWritePathMetrics(f);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1189