### PR TITLE
RATIS-1001. Make RaftServerImpl#getRoleInfoProto() public

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -487,7 +487,7 @@ public class RaftServerImpl implements RaftServer.Division,
         getGroup(), getRoleInfoProto(), state.getStorage().getStorageDir().hasMetaFile());
   }
 
-  RoleInfoProto getRoleInfoProto() {
+  public RoleInfoProto getRoleInfoProto() {
     RaftPeerRole currentRole = role.getCurrentRole();
     RoleInfoProto.Builder roleInfo = RoleInfoProto.newBuilder()
         .setSelf(getPeer().getRaftPeerProto())


### PR DESCRIPTION
## What changes were proposed in this pull request?

make RaftServerImpl#getRoleInfoProto() public, providing app layer an atomic way to get term and role when RaftServer is a leader.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1001

## How was this patch tested?

CI
