### PR TITLE
RATIS-1194. SegmentedRaftLog syncWithSnapshot should not create a new open segment.

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLog.java
@@ -501,7 +501,7 @@ public class SegmentedRaftLog extends RaftLog {
       }
       if (openSegment.getEndIndex() <= lastSnapshotIndex) {
         fileLogWorker.closeLogSegment(openSegment);
-        cache.rollOpenSegment(true);
+        cache.rollOpenSegment(false);
       }
     }
     return purgeImpl(lastSnapshotIndex);


### PR DESCRIPTION
## What changes were proposed in this pull request?
In SegmentedRaftLog#syncWithSnapshot, if the snapshot index is the last open segment index, then the open segment is finalized and closed (which releases the SegmentedRaftLogOutputStream). In the next step, while rolling the open segment in the cache, a new open segment is created. However, the output stream has already been closed. This causes the peer to terminate when a transaction comes in after the syncWithSnapshot call.

Instead of creating a new open segment here, we should let any new transaction coming in to the system create a new open segment through the StartOpenSegment call which re-initializes the output stream.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1194

## How was this patch tested?
Manually tested.