### PR TITLE
RATIS-1198. Fix OOM when use FileStore to write 1GB file

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -375,7 +375,6 @@ public class DataStreamManagement {
           } else if (request.getType() == Type.STREAM_CLOSE) {
             if (info.isPrimary()) {
               // after all server close stream, primary server start transaction
-              // TODO(runzhiwang): send start transaction to leader directly
               startTransaction(info, request, ctx);
             } else {
               sendReply(remoteWrites, request, bytesWritten, ctx);

--- a/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -221,6 +221,16 @@ public interface RaftServerConfigKeys {
       setInt(properties::setInt, SEGMENT_CACHE_NUM_MAX_KEY, maxCachedSegmentNum);
     }
 
+    String SEGMENT_CACHE_SIZE_MAX_KEY = PREFIX + ".segment.cache.size.max";
+    SizeInBytes SEGMENT_CACHE_SIZE_MAX_DEFAULT = SizeInBytes.valueOf("200MB");
+    static SizeInBytes segmentCacheSizeMax(RaftProperties properties) {
+      return getSizeInBytes(properties::getSizeInBytes, SEGMENT_CACHE_SIZE_MAX_KEY,
+          SEGMENT_CACHE_SIZE_MAX_DEFAULT, getDefaultLog());
+    }
+    static void setSegmentCacheSizeMax(RaftProperties properties, SizeInBytes maxCachedSegmentSize) {
+      setSizeInBytes(properties::set, SEGMENT_CACHE_SIZE_MAX_KEY, maxCachedSegmentSize);
+    }
+
     String PREALLOCATED_SIZE_KEY = PREFIX + ".preallocated.size";
     SizeInBytes PREALLOCATED_SIZE_DEFAULT = SizeInBytes.valueOf("4MB");
     static SizeInBytes preallocatedSize(RaftProperties properties) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -420,7 +420,8 @@ public class LogSegment implements Comparable<Long> {
   }
 
   void putEntryCache(TermIndex key, LogEntryProto value, Op op) {
-    entryCache.put(key, value);
+    final LogEntryProto previous = entryCache.put(key, value);
+    Preconditions.assertNull(previous, "entryCache shouldn't contains duplicated entry");
     totalCacheSize.getAndAdd(getEntrySize(value, op));
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogCache.java
@@ -521,11 +521,11 @@ public class SegmentedRaftLogCache {
             closedSegments.get(closedSegments.size() - 1).getLastTermIndex());
   }
 
-  void appendEntry(LogEntryProto entry) {
+  void appendEntry(LogEntryProto entry, LogSegment.Op op) {
     // SegmentedRaftLog does the segment creation/rolling work. Here we just
     // simply append the entry into the open segment.
     Preconditions.assertTrue(openSegment != null);
-    openSegment.appendToOpenSegment(entry);
+    openSegment.appendToOpenSegment(entry, op);
   }
 
   /**

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestLogSegment.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestLogSegment.java
@@ -142,7 +142,7 @@ public class TestLogSegment extends BaseTest {
       if (entry == null) {
         entry = segment.loadCache(record);
       }
-      offset += getEntrySize(entry);
+      offset += getEntrySize(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
     }
   }
 
@@ -201,8 +201,8 @@ public class TestLogSegment extends BaseTest {
     while (size < max) {
       SimpleOperation op = new SimpleOperation("m" + i);
       LogEntryProto entry = ServerProtoUtils.toLogEntryProto(op.getLogEntryContent(), term, i++ + start);
-      size += getEntrySize(entry);
-      segment.appendToOpenSegment(entry);
+      size += getEntrySize(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
+      segment.appendToOpenSegment(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
     }
 
     Assert.assertTrue(segment.getTotalSize() >= max);
@@ -234,18 +234,18 @@ public class TestLogSegment extends BaseTest {
     final StateMachineLogEntryProto m = op.getLogEntryContent();
     try {
       LogEntryProto entry = ServerProtoUtils.toLogEntryProto(m, 0, 1001);
-      segment.appendToOpenSegment(entry);
+      segment.appendToOpenSegment(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
       Assert.fail("should fail since the entry's index needs to be 1000");
     } catch (IllegalStateException e) {
       // the exception is expected.
     }
 
     LogEntryProto entry = ServerProtoUtils.toLogEntryProto(m, 0, 1000);
-    segment.appendToOpenSegment(entry);
+    segment.appendToOpenSegment(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
 
     try {
       entry = ServerProtoUtils.toLogEntryProto(m, 0, 1002);
-      segment.appendToOpenSegment(entry);
+      segment.appendToOpenSegment(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
       Assert.fail("should fail since the entry's index needs to be 1001");
     } catch (IllegalStateException e) {
       // the exception is expected.
@@ -260,7 +260,7 @@ public class TestLogSegment extends BaseTest {
     for (int i = 0; i < 100; i++) {
       LogEntryProto entry = ServerProtoUtils.toLogEntryProto(
           new SimpleOperation("m" + i).getLogEntryContent(), term, i + start);
-      segment.appendToOpenSegment(entry);
+      segment.appendToOpenSegment(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
     }
 
     // truncate an open segment (remove 1080~1099)
@@ -313,7 +313,7 @@ public class TestLogSegment extends BaseTest {
         1024, 1024, ByteBuffer.allocateDirect(bufferSize))) {
       SimpleOperation op = new SimpleOperation(new String(content));
       LogEntryProto entry = ServerProtoUtils.toLogEntryProto(op.getLogEntryContent(), 0, 0);
-      size = LogSegment.getEntrySize(entry);
+      size = LogSegment.getEntrySize(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
       out.write(entry);
     }
     Assert.assertEquals(file.length(),
@@ -340,7 +340,7 @@ public class TestLogSegment extends BaseTest {
     Arrays.fill(content, (byte) 1);
     SimpleOperation op = new SimpleOperation(new String(content));
     LogEntryProto entry = ServerProtoUtils.toLogEntryProto(op.getLogEntryContent(), 0, 0);
-    final long entrySize = LogSegment.getEntrySize(entry);
+    final long entrySize = LogSegment.getEntrySize(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
 
     long totalSize = SegmentedRaftLogFormat.getHeaderLength();
     long preallocated = 16 * 1024;

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestLogSegment.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestLogSegment.java
@@ -128,7 +128,7 @@ public class TestLogSegment extends BaseTest {
     Assert.assertEquals(start, segment.getStartIndex());
     Assert.assertEquals(end, segment.getEndIndex());
     Assert.assertEquals(isOpen, segment.isOpen());
-    Assert.assertEquals(totalSize, segment.getTotalSize());
+    Assert.assertEquals(totalSize, segment.getTotalFileSize());
 
     long offset = SegmentedRaftLogFormat.getHeaderLength();
     for (long i = start; i <= end; i++) {
@@ -183,7 +183,7 @@ public class TestLogSegment extends BaseTest {
     LogSegment closedSegment = LogSegment.loadSegment(storage, closedSegmentFile,
         1000, 1099, false, loadInitial, null, null);
     checkLogSegment(closedSegment, 1000, 1099, false,
-        closedSegment.getTotalSize(), 1);
+        closedSegment.getTotalFileSize(), 1);
     Assert.assertEquals(loadInitial ? 0 : 1, closedSegment.getLoadingTimes());
   }
 
@@ -205,7 +205,7 @@ public class TestLogSegment extends BaseTest {
       segment.appendToOpenSegment(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
     }
 
-    Assert.assertTrue(segment.getTotalSize() >= max);
+    Assert.assertTrue(segment.getTotalFileSize() >= max);
     checkLogSegment(segment, start, i - 1 + start, true, size, term);
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -80,7 +80,7 @@ public class TestSegmentedRaftLog extends BaseTest {
   }
 
   public static long getOpenSegmentSize(RaftLog raftLog) {
-    return ((SegmentedRaftLog)raftLog).getRaftLogCache().getOpenSegment().getTotalSize();
+    return ((SegmentedRaftLog)raftLog).getRaftLogCache().getOpenSegment().getTotalFileSize();
   }
 
   private static final RaftPeerId peerId = RaftPeerId.valueOf("s0");

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLogCache.java
@@ -61,7 +61,7 @@ public class TestSegmentedRaftLogCache {
     for (long i = start; i <= end; i++) {
       SimpleOperation m = new SimpleOperation("m" + i);
       LogEntryProto entry = ServerProtoUtils.toLogEntryProto(m.getLogEntryContent(), 0, i);
-      s.appendToOpenSegment(entry);
+      s.appendToOpenSegment(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
     }
     if (!isOpen) {
       s.close();
@@ -152,7 +152,7 @@ public class TestSegmentedRaftLogCache {
     final SimpleOperation m = new SimpleOperation("m");
     try {
       LogEntryProto entry = ServerProtoUtils.toLogEntryProto(m.getLogEntryContent(), 0, 0);
-      cache.appendEntry(entry);
+      cache.appendEntry(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
       Assert.fail("the open segment is null");
     } catch (IllegalStateException ignored) {
     }
@@ -161,7 +161,7 @@ public class TestSegmentedRaftLogCache {
     cache.addSegment(openSegment);
     for (long index = 101; index < 200; index++) {
       LogEntryProto entry = ServerProtoUtils.toLogEntryProto(m.getLogEntryContent(), 0, index);
-      cache.appendEntry(entry);
+      cache.appendEntry(entry, LogSegment.Op.WRITE_CACHE_WITHOUT_STATE_MACHINE_CACHE);
     }
 
     Assert.assertNotNull(cache.getOpenSegment());


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**

Use FileStore write 1GB file, OOM happens.

**How to reproduce ?**
1.  change timeout 100 seconds to 600 seconds.
```
  public int getGlobalTimeoutSeconds() {
    return 100;
  }
```

2. change 1M to 50M, and run `testFileStore`, OOM happens

`testMultipleFiles("file", 20, SizeInBytes.valueOf("1M"), newClient);`

**What's the reason ?**

1. In FileStore, `CACHING_ENABLED_DEFAULT`, i.e. `stateMachineCachingEnabled` is false,  so cache will append the complete LogEntryProto into cache, without remove StateMachineData.
```
      if (stateMachineCachingEnabled) {
        // The stateMachineData will be cached inside the StateMachine itself.
        cache.appendEntry(ServerProtoUtils.removeStateMachineData(entry));
      } else {
        cache.appendEntry(entry);
      }
```

2. But when getEntrySize, it does not calculate the size of StateMachineData
```
  static long getEntrySize(LogEntryProto entry) {
    final int serialized = ServerProtoUtils.removeStateMachineData(entry).getSerializedSize();
    return serialized + CodedOutputStream.computeUInt32SizeNoTag(serialized) + 4L;
  }
```

3. So `isSegmentFull` is false, and can not evict cache, then LogSegment#entryCache keep too many LogEntryProto, which contains the StateMachineData, so OOM happens.

```
if (isSegmentFull(currentOpenSegment, entry)) {
        cache.rollOpenSegment(true);
        fileLogWorker.rollLogSegment(currentOpenSegment);
        checkAndEvictCache();
}
```

**How to fix ?**
If `stateMachineCachingEnabled` is false,  we calculate entry size without removeStateMachineData.
```
  static long getEntrySize(LogEntryProto entry, boolean stateMachineCachingEnabled) {
    final int serialized = stateMachineCachingEnabled ?
        ServerProtoUtils.removeStateMachineData(entry).getSerializedSize() :
        entry.getSerializedSize();
    return serialized + CodedOutputStream.computeUInt32SizeNoTag(serialized) + 4L;
  }
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1198

## How was this patch tested?

test it manually

1.  change timeout 100 seconds to 600 seconds.
  public int getGlobalTimeoutSeconds() {
    return 100;
  }

2. change 1M to 50M,  and run `testFileStore`

testMultipleFiles("file", 20, SizeInBytes.valueOf("1M"), newClient);