### PR TITLE
RATIS-1203. Fix flaky tests caused by TestRetryCacheMetrics#retryCache

### DIFF
--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRetryCacheMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRetryCacheMetrics.java
@@ -57,7 +57,7 @@ public class TestRetryCacheMetrics {
     
     @After
     public void tearDown() {
-    	retryCache.close();
+        retryCache.close();
         checkEntryCount(0);
     }
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRetryCacheMetrics.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRetryCacheMetrics.java
@@ -29,6 +29,7 @@ import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.metrics.RaftServerMetrics;
 import org.apache.ratis.util.TimeDuration;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -53,6 +54,12 @@ public class TestRetryCacheMetrics {
           raftGroupMemberId, () -> null, () -> retryCache);
       ratisMetricRegistry = raftServerMetrics.getRegistry();
     }
+    
+    @After
+    public void tearDown() {
+    	retryCache.close();
+        checkEntryCount(0);
+    }
 
     @Test
     public void testRetryCacheEntryCount() {
@@ -64,9 +71,6 @@ public class TestRetryCacheMetrics {
 
       retryCache.refreshEntry(entry);
       checkEntryCount(1);
-
-      retryCache.close();
-      checkEntryCount(0);
     }
 
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?
Proposed code changes to fix flaky test in class `TestRetryCacheMetrics.java`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1203#
(This JIRA ticket contains more detailed info. for this PR)

## How was this patch tested?
- The flaky test is found by running [iDFlakies](https://github.com/idflakies/iDFlakies) (tools for detecting/classifying flaky tests). After fixing the issue, there are no flaky tests.
- This patch is also tested with maven command: `mvn test`
