### PR TITLE
RATIS-1213. Provide a default implementation for DataStreamApi.stream()

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
@@ -38,7 +38,9 @@ import java.nio.ByteBuffer;
  */
 public interface DataStreamApi {
   /** Create a stream to write data. */
-  DataStreamOutput stream();
+  default DataStreamOutput stream() {
+    return stream(null);
+  }
 
   /** Create a stream by providing a customized header message. */
   DataStreamOutput stream(ByteBuffer headerMessage);

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/DataStreamClientImpl.java
@@ -171,13 +171,6 @@ public class DataStreamClientImpl implements DataStreamClient {
   }
 
   @Override
-  public DataStreamOutputRpc stream() {
-    final RaftClientRequest request = new RaftClientRequest(clientId, dataStreamServer.getId(), groupId,
-        RaftClientImpl.nextCallId(), RaftClientRequest.dataStreamRequestType());
-    return new DataStreamOutputImpl(request);
-  }
-
-  @Override
   public DataStreamOutputRpc stream(RaftClientRequest request) {
     return new DataStreamOutputImpl(request);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can provide a default implementation for ``DataStreamOutput stream();` so it can reuse existing code.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1213

## How was this patch tested?

UT
