### PR TITLE
RATIS-1215. Allow put duplicate key into LogSegment#entryCache

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -421,8 +421,12 @@ public class LogSegment implements Comparable<Long> {
 
   void putEntryCache(TermIndex key, LogEntryProto value, Op op) {
     final LogEntryProto previous = entryCache.put(key, value);
-    Preconditions.assertNull(previous, "entryCache shouldn't contains duplicated entry");
-    totalCacheSize.getAndAdd(getEntrySize(value, op));
+    long previousSize = 0;
+    if (previous != null) {
+      // Different threads maybe load LogSegment file into cache at the same time, so duplicate maybe happen
+      previousSize = getEntrySize(value, Op.REMOVE_CACHE);
+    }
+    totalCacheSize.getAndAdd(getEntrySize(value, op) - previousSize);
   }
 
   void removeEntryCache(TermIndex key, Op op) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, duplicated key maybe put into entryCache by different threads loading segment file at the same time. So we should allow it.

For example.

First thread's stack:
```
org.apache.ratis.server.raftlog.segmented.LogSegment$LogEntryLoader|LogSegment.java|245|load
org.apache.ratis.server.raftlog.segmented.LogSegment|LogSegment.java|363|loadCache
org.apache.ratis.server.raftlog.segmented.SegmentedRaftLog|SegmentedRaftLog.java|275|get
org.apache.ratis.server.impl.StateMachineUpdater|StateMachineUpdater.java|223|applyLog
org.apache.ratis.server.impl.StateMachineUpdater|StateMachineUpdater.java|176|run
```

Second thread's stack:
```
org.apache.ratis.server.raftlog.segmented.LogSegment$LogEntryLoader|LogSegment.java|245|load
org.apache.ratis.server.raftlog.segmented.LogSegment|LogSegment.java|363|loadCache
org.apache.ratis.server.raftlog.segmented.SegmentedRaftLog|SegmentedRaftLog.java|275|get
org.apache.ratis.server.impl.LeaderStateImpl|LeaderStateImpl.java|736|updateCommit
org.apache.ratis.server.impl.LeaderStateImpl|LeaderStateImpl.java|689|lambda$updateCommit$12
java.util.Optional|Optional.java|159|ifPresent
org.apache.ratis.server.impl.LeaderStateImpl|LeaderStateImpl.java|689|updateCommit
org.apache.ratis.server.impl.LeaderStateImpl$StateUpdateEvent|LeaderStateImpl.java|109|execute
org.apache.ratis.server.impl.LeaderStateImpl$EventProcessor|LeaderStateImpl.java|572|run

```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1215

## How was this patch tested?

No need to add new ut.
