### PR TITLE
RATIS-1217. Fix filestore failed readStateMachineData when use AsyncApi

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
@@ -137,7 +137,7 @@ public class FileStore implements Closeable {
     return full;
   }
 
-  CompletableFuture<ReadReplyProto> read(String relative, long offset, long length) {
+  CompletableFuture<ReadReplyProto> read(String relative, long offset, long length, boolean readCommitted) {
     final Supplier<String> name = () -> "read(" + relative
         + ", " + offset + ", " + length + ") @" + getId();
     final CheckedSupplier<ReadReplyProto, IOException> task = LogUtils.newCheckedSupplier(LOG, () -> {
@@ -146,7 +146,7 @@ public class FileStore implements Closeable {
           .setResolvedPath(FileStoreCommon.toByteString(info.getRelativePath()))
           .setOffset(offset);
 
-      final ByteString bytes = info.read(this::resolve, offset, length);
+      final ByteString bytes = info.read(this::resolve, offset, length, readCommitted);
       return reply.setData(bytes).build();
     }, name);
     return submit(task, reader);

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreClient.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreClient.java
@@ -175,7 +175,7 @@ public class FileStoreClient implements Closeable {
     final WriteRequestHeaderProto.Builder header = WriteRequestHeaderProto.newBuilder()
         .setPath(ProtoUtils.toByteString(path))
         .setOffset(offset)
-        .setLength(data.position())
+        .setLength(data.remaining())
         .setClose(close);
 
     final WriteRequestProto.Builder write = WriteRequestProto.newBuilder()

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
@@ -87,7 +87,7 @@ public class FileStoreStateMachine extends BaseStateMachine {
     }
 
     final String path = proto.getPath().toStringUtf8();
-    return files.read(path, proto.getOffset(), proto.getLength())
+    return files.read(path, proto.getOffset(), proto.getLength(), true)
         .thenApply(reply -> Message.valueOf(reply.toByteString()));
   }
 
@@ -149,7 +149,7 @@ public class FileStoreStateMachine extends BaseStateMachine {
 
     final WriteRequestHeaderProto h = proto.getWriteHeader();
     CompletableFuture<ExamplesProtos.ReadReplyProto> reply =
-        files.read(h.getPath().toStringUtf8(), h.getOffset(), h.getLength());
+        files.read(h.getPath().toStringUtf8(), h.getOffset(), h.getLength(), false);
 
     return reply.thenApply(ExamplesProtos.ReadReplyProto::getData);
   }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
@@ -132,7 +132,7 @@ public class DataStream extends Client {
       } else if (bytesRead > 0) {
         offset += bytesRead;
 
-        final CompletableFuture<DataStreamReply> f = dataStreamOutput.writeAsync(buf.nioBuffer(), offset == fileSize);
+        final CompletableFuture<DataStreamReply> f = dataStreamOutput.writeAsync(buf.nioBuffer());
         f.thenRun(buf::release);
         futures.add(f);
       }
@@ -145,7 +145,7 @@ public class DataStream extends Client {
       FileChannel fileChannel) throws IOException {
     List<CompletableFuture<DataStreamReply>> futures = new ArrayList<>();
     MappedByteBuffer mappedByteBuffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, getFileSizeInBytes());
-    futures.add(dataStreamOutput.writeAsync(mappedByteBuffer, true));
+    futures.add(dataStreamOutput.writeAsync(mappedByteBuffer));
     return futures;
   }
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
@@ -40,6 +40,7 @@ import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.NetUtils;
+import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 
 import java.io.File;
@@ -79,6 +80,8 @@ public class Server extends SubCommandBase {
     RaftConfigKeys.DataStream.setType(properties, SupportedDataStreamType.NETTY);
     properties.setInt(GrpcConfigKeys.OutputStream.RETRY_TIMES_KEY, Integer.MAX_VALUE);
     RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(storageDir));
+    RaftServerConfigKeys.Write.setElementLimit(properties, 40960);
+    RaftServerConfigKeys.Write.setByteLimit(properties, SizeInBytes.valueOf("1000MB"));
     ConfUtils.setFile(properties::setFile, FileStoreCommon.STATEMACHINE_DIR_KEY,
         storageDir);
     StateMachine stateMachine = new FileStoreStateMachine(properties);


### PR DESCRIPTION


## What changes were proposed in this pull request?

1. There are two usage for FileStore#read, the first is for FileStoreStateMachine#query which read  data has been committed, the second if for FileStoreStateMachine#read which read data has been written by leader, and leader read the data to appendEntry to follower. So in the second case, we should not check `offset + length > committedSize`, we should check `offset + length > writeSize`

![image](https://user-images.githubusercontent.com/51938049/101448240-a6eb9500-3961-11eb-95fe-f706dc288577.png)


2. data length should use ByteBuffer#remaining()
```
     final WriteRequestHeaderProto.Builder header = WriteRequestHeaderProto.newBuilder()
         .setPath(ProtoUtils.toByteString(path))
         .setOffset(offset)
-        .setLength(data.position())
+        .setLength(data.remaining())
         .setClose(close);
```


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1217

## How was this patch tested?

manually execute following command many times.
${BIN}/client.sh filestore loadgen --size 100000000 --numFiles 10 --bufferSize 4000000 --peers ${PEERS}
