### PR TITLE
RATIS-1218. Add sync option when test filestore performance

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
@@ -195,7 +195,7 @@ public class FileStore implements Closeable {
   }
 
   CompletableFuture<Integer> write(
-      long index, String relative, boolean close, long offset, ByteString data) {
+      long index, String relative, boolean close, boolean sync, long offset, ByteString data) {
     final int size = data != null? data.size(): 0;
     LOG.trace("write {}, offset={}, size={}, close? {} @{}:{}",
         relative, offset, size, close, getId(), index);
@@ -214,8 +214,8 @@ public class FileStore implements Closeable {
     }
 
     return size == 0 && !close? CompletableFuture.completedFuture(0)
-        : createNew? uc.submitCreate(this::resolve, data, close, writer, getId(), index)
-        : uc.submitWrite(offset, data, close, writer, getId(), index);
+        : createNew? uc.submitCreate(this::resolve, data, close, sync, writer, getId(), index)
+        : uc.submitWrite(offset, data, close, sync, writer, getId(), index);
   }
 
   @Override
@@ -266,7 +266,7 @@ public class FileStore implements Closeable {
     }, writer);
   }
 
-  class FileStoreDataChannel implements StateMachine.DataChannel {
+  static class FileStoreDataChannel implements StateMachine.DataChannel {
     private final RandomAccessFile randomAccessFile;
 
     FileStoreDataChannel(RandomAccessFile file) {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
@@ -127,7 +127,8 @@ public class FileStoreStateMachine extends BaseStateMachine {
 
     final WriteRequestHeaderProto h = proto.getWriteHeader();
     final CompletableFuture<Integer> f = files.write(entry.getIndex(),
-        h.getPath().toStringUtf8(), h.getClose(), h.getOffset(), smLog.getStateMachineEntry().getStateMachineData());
+        h.getPath().toStringUtf8(), h.getClose(),  h.getSync(), h.getOffset(),
+        smLog.getStateMachineEntry().getStateMachineData());
     // sync only if closing the file
     return h.getClose()? f: null;
   }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
@@ -41,6 +41,7 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -107,19 +108,25 @@ public abstract class Client extends SubCommandBase {
     operation(client);
   }
 
-  public List<String> generateFiles() throws IOException {
+
+  protected void stop(RaftClient client) throws IOException {
+    client.close();
+    System.exit(0);
+  }
+
+  protected List<String> generateFiles() throws IOException {
     String entropy = RandomStringUtils.randomAlphanumeric(numFiles);
     List<String> paths = new ArrayList<>();
     for (int i = 0; i < numFiles; i ++) {
       String path = "file-" + entropy + "-" + i;
       paths.add(path);
-      writeFile(path, fileSizeInBytes, bufferSizeInBytes);
+      writeFile(path, fileSizeInBytes, bufferSizeInBytes, new Random().nextInt(127) + 1);
     }
 
     return paths;
   }
 
-  public void writeFile(String path, int fileSize, int bufferSize) throws IOException {
+  protected void writeFile(String path, int fileSize, int bufferSize, int random) throws IOException {
     RandomAccessFile raf = null;
     try {
       raf = new RandomAccessFile(path, "rw");
@@ -129,7 +136,7 @@ public abstract class Client extends SubCommandBase {
         final int chunkSize = Math.min(remaining, bufferSize);
         byte[] buffer = new byte[chunkSize];
         for (int i = 0; i < chunkSize; i ++) {
-          buffer[i]= (byte) ('A' + i % 23);
+          buffer[i]= (byte) (i % random);
         }
         raf.write(buffer);
         offset += chunkSize;

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreAsyncBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreAsyncBaseTest.java
@@ -77,7 +77,7 @@ public abstract class FileStoreAsyncBaseTest<CLUSTER extends MiniRaftCluster>
         .setAsyncExecutor(executor)
         .setFileStoreClientSupplier(() -> client)
         .build()
-        .writeAsync()
+        .writeAsync(false)
         .thenCompose(FileStoreWriter::verifyAsync)
         .thenCompose(FileStoreWriter::deleteAsync)
         .get();
@@ -99,7 +99,7 @@ public abstract class FileStoreAsyncBaseTest<CLUSTER extends MiniRaftCluster>
               .setAsyncExecutor(executor)
               .setFileStoreClientSupplier(() -> client)
               .build()
-              .writeAsync(),
+              .writeAsync(false),
           () -> path + ":" + fileLength);
       writerFutures.add(callable.call());
     }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreBaseTest.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreBaseTest.java
@@ -92,7 +92,7 @@ public abstract class FileStoreBaseTest<CLUSTER extends MiniRaftCluster>
                  .setFileSize(fileLength)
                  .setFileStoreClientSupplier(newClient)
                  .build()) {
-      w.write().verify().delete();
+      w.write(false).verify().delete();
     }
   }
 
@@ -112,7 +112,7 @@ public abstract class FileStoreBaseTest<CLUSTER extends MiniRaftCluster>
               .setFileName(path)
               .setFileSize(fileLength)
               .setFileStoreClientSupplier(newClient)
-              .build().write(),
+              .build().write(false),
           () -> path + ":" + fileLength);
       writerFutures.add(executor.submit(callable));
     }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreWriter.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreWriter.java
@@ -113,7 +113,7 @@ class FileStoreWriter implements Closeable {
     return b;
   }
 
-  FileStoreWriter write() throws IOException {
+  FileStoreWriter write(boolean sync) throws IOException {
     final Random r = new Random(seed);
     final int size = fileSize.getSizeInt();
 
@@ -126,7 +126,7 @@ class FileStoreWriter implements Closeable {
 
       LOG.trace("write {}, offset={}, length={}, close? {}",
           fileName, offset, length, close);
-      final long written = client.write(fileName, offset, close, b);
+      final long written = client.write(fileName, offset, close, b, sync);
       Assert.assertEquals(length, written);
       offset += written;
     }
@@ -167,7 +167,7 @@ class FileStoreWriter implements Closeable {
     return this;
   }
 
-  CompletableFuture<FileStoreWriter> writeAsync() {
+  CompletableFuture<FileStoreWriter> writeAsync(boolean sync) {
     Objects.requireNonNull(asyncExecutor, "asyncExecutor == null");
     final Random r = new Random(seed);
     final int size = fileSize.getSizeInt();
@@ -188,7 +188,7 @@ class FileStoreWriter implements Closeable {
 
       LOG.trace("writeAsync {}, offset={}, length={}, close? {}",
           fileName, offset, length, close);
-      client.writeAsync(fileName, offset, close, b)
+      client.writeAsync(fileName, offset, close, b, sync)
           .thenAcceptAsync(written -> Assert.assertEquals(length, (long)written), asyncExecutor)
           .thenRun(() -> {
             final int count = callCount.decrementAndGet();

--- a/ratis-proto/src/main/proto/Examples.proto
+++ b/ratis-proto/src/main/proto/Examples.proto
@@ -41,6 +41,7 @@ message WriteRequestHeaderProto {
   bool close = 2; // close the file after write?
   uint64 offset = 3;
   uint64 length = 4;
+  bool sync = 5;
 }
 
 message StreamWriteRequestProto {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add sync option when test filestore performance

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1218

## How was this patch tested?

Test it manually

The test command of sync:
```
${BIN}/client.sh filestore datastream --size 128000000 --numFiles 10 --bufferSize 4000000 --syncSize 16000000 --type DirectByteBuffer --peers ${PEERS}
${BIN}/client.sh filestore loadgen --size 128000000 --numFiles 10 --bufferSize 4000000 --sync 1 --peers ${PEERS}
```

The test command of no sync:
```
${BIN}/client.sh filestore datastream --size 128000000 --numFiles 10 --bufferSize 4000000 --syncSize -1 --type DirectByteBuffer --peers ${PEERS}
${BIN}/client.sh filestore loadgen --size 128000000 --numFiles 10 --bufferSize 4000000 --sync 0 --peers ${PEERS}
```

