### PR TITLE
RATIS-1196. Save STREAM_CLOSE RPC call

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamOutput.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamOutput.java
@@ -19,6 +19,8 @@ package org.apache.ratis.client.api;
 
 import org.apache.ratis.io.CloseAsync;
 import org.apache.ratis.io.FilePositionCount;
+import org.apache.ratis.io.StandardWriteOption;
+import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.RaftClientReply;
 
@@ -34,17 +36,17 @@ public interface DataStreamOutput extends CloseAsync<DataStreamReply> {
    * where sync_default depends on the underlying implementation.
    */
   default CompletableFuture<DataStreamReply> writeAsync(ByteBuffer src) {
-    return writeAsync(src, false);
+    return writeAsync(src, StandardWriteOption.WRITE);
   }
 
   /**
    * Send out the data in the source buffer asynchronously.
    *
    * @param src the source buffer to be sent.
-   * @param sync Should the data be sync'ed to the underlying storage?
+   * @param options - options specifying how the data was written
    * @return a future of the reply.
    */
-  CompletableFuture<DataStreamReply> writeAsync(ByteBuffer src, boolean sync);
+  CompletableFuture<DataStreamReply> writeAsync(ByteBuffer src, WriteOption... options);
 
 
   /**
@@ -52,24 +54,24 @@ public interface DataStreamOutput extends CloseAsync<DataStreamReply> {
    * where sync_default depends on the underlying implementation.
    */
   default CompletableFuture<DataStreamReply> writeAsync(File src) {
-    return writeAsync(src, 0, src.length(), false);
+    return writeAsync(src, 0, src.length(), StandardWriteOption.WRITE);
   }
 
   /**
-   * The same as writeAsync(FilePositionCount.valueOf(src, position, count), sync).
+   * The same as writeAsync(FilePositionCount.valueOf(src, position, count), options).
    */
-  default CompletableFuture<DataStreamReply> writeAsync(File src, long position, long count, boolean sync) {
-    return writeAsync(FilePositionCount.valueOf(src, position, count), sync);
+  default CompletableFuture<DataStreamReply> writeAsync(File src, long position, long count, WriteOption... options) {
+    return writeAsync(FilePositionCount.valueOf(src, position, count), options);
   }
 
   /**
    * Send out the data in the source file asynchronously.
    *
    * @param src the source file with the starting position and the number of bytes.
-   * @param sync Should the data be sync'ed to the underlying storage?
+   * @param options options specifying how the data was written
    * @return a future of the reply.
    */
-  CompletableFuture<DataStreamReply> writeAsync(FilePositionCount src, boolean sync);
+  CompletableFuture<DataStreamReply> writeAsync(FilePositionCount src, WriteOption... options);
 
   /**
    * Return the future of the {@link RaftClientReply}

--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamOutput.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamOutput.java
@@ -19,7 +19,6 @@ package org.apache.ratis.client.api;
 
 import org.apache.ratis.io.CloseAsync;
 import org.apache.ratis.io.FilePositionCount;
-import org.apache.ratis.io.StandardWriteOption;
 import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -31,14 +30,6 @@ import java.util.concurrent.CompletableFuture;
 
 /** An asynchronous output stream supporting zero buffer copying. */
 public interface DataStreamOutput extends CloseAsync<DataStreamReply> {
-  /**
-   * This method is the same as writeAsync(src, sync_default),
-   * where sync_default depends on the underlying implementation.
-   */
-  default CompletableFuture<DataStreamReply> writeAsync(ByteBuffer src) {
-    return writeAsync(src, StandardWriteOption.WRITE);
-  }
-
   /**
    * Send out the data in the source buffer asynchronously.
    *
@@ -54,7 +45,7 @@ public interface DataStreamOutput extends CloseAsync<DataStreamReply> {
    * where sync_default depends on the underlying implementation.
    */
   default CompletableFuture<DataStreamReply> writeAsync(File src) {
-    return writeAsync(src, 0, src.length(), StandardWriteOption.WRITE);
+    return writeAsync(src, 0, src.length());
   }
 
   /**

--- a/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamRequestByteBuffer.java
+++ b/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamRequestByteBuffer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.datastream.impl;
 
+import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.protocol.DataStreamRequest;
 import org.apache.ratis.protocol.DataStreamRequestHeader;
 import org.apache.ratis.util.Preconditions;
@@ -29,8 +30,16 @@ import java.nio.ByteBuffer;
  * This class is immutable.
  */
 public class DataStreamRequestByteBuffer extends DataStreamPacketByteBuffer implements DataStreamRequest {
+  private WriteOption[] options;
+
   public DataStreamRequestByteBuffer(DataStreamRequestHeader header, ByteBuffer buffer) {
     super(header.getType(), header.getStreamId(), header.getStreamOffset(), buffer);
+    this.options = header.getWriteOptions();
     Preconditions.assertTrue(header.getDataLength() == buffer.remaining());
+  }
+
+  @Override
+  public WriteOption[] getWriteOptions() {
+    return options;
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamRequestFilePositionCount.java
+++ b/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamRequestFilePositionCount.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.datastream.impl;
 
 import org.apache.ratis.io.FilePositionCount;
+import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.protocol.DataStreamRequest;
 import org.apache.ratis.protocol.DataStreamRequestHeader;
 
@@ -28,9 +29,11 @@ import org.apache.ratis.protocol.DataStreamRequestHeader;
  */
 public class DataStreamRequestFilePositionCount extends DataStreamPacketImpl implements DataStreamRequest {
   private final FilePositionCount file;
+  private WriteOption[] options;
 
   public DataStreamRequestFilePositionCount(DataStreamRequestHeader header, FilePositionCount file) {
     super(header.getType(), header.getStreamId(), header.getStreamOffset());
+    this.options = header.getWriteOptions();
     this.file = file;
   }
 
@@ -42,5 +45,10 @@ public class DataStreamRequestFilePositionCount extends DataStreamPacketImpl imp
   /** @return the file with the starting position and the byte count. */
   public FilePositionCount getFile() {
     return file;
+  }
+
+  @Override
+  public WriteOption[] getWriteOptions() {
+    return options;
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/io/StandardWriteOption.java
+++ b/ratis-common/src/main/java/org/apache/ratis/io/StandardWriteOption.java
@@ -18,8 +18,6 @@
 package org.apache.ratis.io;
 
 public enum StandardWriteOption implements WriteOption {
-  /** Write the data to the underlying storage. */
-  WRITE,
   /** Sync the data to the underlying storage. */
   SYNC,
   /** Close the data to the underlying storage. */

--- a/ratis-common/src/main/java/org/apache/ratis/io/StandardWriteOption.java
+++ b/ratis-common/src/main/java/org/apache/ratis/io/StandardWriteOption.java
@@ -15,11 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.ratis.io;
 
-package org.apache.ratis.protocol;
-
-import org.apache.ratis.io.WriteOption;
-
-public interface DataStreamRequest extends DataStreamPacket {
-  WriteOption[] getWriteOptions();
+public enum StandardWriteOption implements WriteOption {
+  /** Write the data to the underlying storage. */
+  WRITE,
+  /** Sync the data to the underlying storage. */
+  SYNC,
+  /** Close the data to the underlying storage. */
+  CLOSE
 }

--- a/ratis-common/src/main/java/org/apache/ratis/io/WriteOption.java
+++ b/ratis-common/src/main/java/org/apache/ratis/io/WriteOption.java
@@ -15,11 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.ratis.io;
 
-package org.apache.ratis.protocol;
+public interface WriteOption {
+  static boolean containsOption(WriteOption[] options, WriteOption target) {
+    for (WriteOption option : options) {
+      if (option == target) {
+        return true;
+      }
+    }
 
-import org.apache.ratis.io.WriteOption;
-
-public interface DataStreamRequest extends DataStreamPacket {
-  WriteOption[] getWriteOptions();
+    return false;
+  }
 }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
@@ -22,6 +22,7 @@ import com.beust.jcommander.Parameters;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.api.DataStreamOutput;
 import org.apache.ratis.examples.filestore.FileStoreClient;
+import org.apache.ratis.io.StandardWriteOption;
 import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.thirdparty.io.netty.buffer.ByteBuf;
 import org.apache.ratis.thirdparty.io.netty.buffer.PooledByteBufAllocator;
@@ -268,7 +269,8 @@ public class DataStream extends Client {
         throw new IllegalStateException("Failed to read " + bufferSize + " byte(s) from " + this
             + ". The channel has reached end-of-stream at " + offset);
       } else if (bytesRead > 0) {
-        final CompletableFuture<DataStreamReply> f = out.writeAsync(buf.nioBuffer(), isSync(offset + bytesRead));
+        final CompletableFuture<DataStreamReply> f = out.writeAsync(buf.nioBuffer(),
+            isSync(offset + bytesRead) ? StandardWriteOption.SYNC : StandardWriteOption.WRITE);
         f.thenRun(buf::release);
         futures.add(f);
       }
@@ -287,7 +289,8 @@ public class DataStream extends Client {
       final long packetSize = getPacketSize(offset);
       final MappedByteBuffer mappedByteBuffer = in.map(FileChannel.MapMode.READ_ONLY, offset, packetSize);
       final int remaining = mappedByteBuffer.remaining();
-      futures.add(out.writeAsync(mappedByteBuffer, isSync(offset + remaining)));
+      futures.add(out.writeAsync(mappedByteBuffer,
+          isSync(offset + remaining) ? StandardWriteOption.SYNC : StandardWriteOption.WRITE));
       return remaining;
     }
   }
@@ -300,7 +303,8 @@ public class DataStream extends Client {
     @Override
     long write(FileChannel in, DataStreamOutput out, long offset, List<CompletableFuture<DataStreamReply>> futures) {
       final long packetSize = getPacketSize(offset);
-      futures.add(out.writeAsync(getFile(), offset, packetSize, isSync(offset + packetSize)));
+      futures.add(out.writeAsync(getFile(), offset, packetSize,
+          isSync(offset + packetSize) ? StandardWriteOption.SYNC : StandardWriteOption.WRITE));
       return packetSize;
     }
   }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
@@ -269,8 +269,8 @@ public class DataStream extends Client {
         throw new IllegalStateException("Failed to read " + bufferSize + " byte(s) from " + this
             + ". The channel has reached end-of-stream at " + offset);
       } else if (bytesRead > 0) {
-        final CompletableFuture<DataStreamReply> f = out.writeAsync(buf.nioBuffer(),
-            isSync(offset + bytesRead) ? StandardWriteOption.SYNC : StandardWriteOption.WRITE);
+        final CompletableFuture<DataStreamReply> f = isSync(offset + bytesRead) ?
+            out.writeAsync(buf.nioBuffer(), StandardWriteOption.SYNC) : out.writeAsync(buf.nioBuffer());
         f.thenRun(buf::release);
         futures.add(f);
       }
@@ -289,8 +289,8 @@ public class DataStream extends Client {
       final long packetSize = getPacketSize(offset);
       final MappedByteBuffer mappedByteBuffer = in.map(FileChannel.MapMode.READ_ONLY, offset, packetSize);
       final int remaining = mappedByteBuffer.remaining();
-      futures.add(out.writeAsync(mappedByteBuffer,
-          isSync(offset + remaining) ? StandardWriteOption.SYNC : StandardWriteOption.WRITE));
+      futures.add(isSync(offset + remaining) ?
+          out.writeAsync(mappedByteBuffer, StandardWriteOption.SYNC) : out.writeAsync(mappedByteBuffer));
       return remaining;
     }
   }
@@ -303,8 +303,9 @@ public class DataStream extends Client {
     @Override
     long write(FileChannel in, DataStreamOutput out, long offset, List<CompletableFuture<DataStreamReply>> futures) {
       final long packetSize = getPacketSize(offset);
-      futures.add(out.writeAsync(getFile(), offset, packetSize,
-          isSync(offset + packetSize) ? StandardWriteOption.SYNC : StandardWriteOption.WRITE));
+      futures.add(isSync(offset + packetSize) ?
+          out.writeAsync(getFile(), offset, packetSize, StandardWriteOption.SYNC) :
+          out.writeAsync(getFile(), offset, packetSize));
       return packetSize;
     }
   }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreWriter.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreWriter.java
@@ -148,8 +148,8 @@ class FileStoreWriter implements Closeable {
       LOG.trace("write {}, offset={}, length={}, close? {}",
           fileName, offset, length, close);
       final ByteBuffer bf = DataStreamTestUtils.initBuffer(0, length);
-      futures.add(dataStreamOutput.writeAsync(bf,
-          close ? StandardWriteOption.CLOSE : StandardWriteOption.WRITE));
+      futures.add(close ?
+          dataStreamOutput.writeAsync(bf, StandardWriteOption.CLOSE) : dataStreamOutput.writeAsync(bf));
       sizes.add(length);
       offset += length;
     }

--- a/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreWriter.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/filestore/FileStoreWriter.java
@@ -19,6 +19,7 @@ package org.apache.ratis.examples.filestore;
 
 import org.apache.ratis.client.api.DataStreamOutput;
 import org.apache.ratis.datastream.DataStreamTestUtils;
+import org.apache.ratis.io.StandardWriteOption;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.DataStreamReply;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
@@ -147,7 +148,8 @@ class FileStoreWriter implements Closeable {
       LOG.trace("write {}, offset={}, length={}, close? {}",
           fileName, offset, length, close);
       final ByteBuffer bf = DataStreamTestUtils.initBuffer(0, length);
-      futures.add(dataStreamOutput.writeAsync(bf, close));
+      futures.add(dataStreamOutput.writeAsync(bf,
+          close ? StandardWriteOption.CLOSE : StandardWriteOption.WRITE));
       sizes.add(length);
       offset += length;
     }
@@ -161,7 +163,7 @@ class FileStoreWriter implements Closeable {
       reply = futures.get(i).join();
       Assert.assertTrue(reply.isSuccess());
       Assert.assertEquals(sizes.get(i).longValue(), reply.getBytesWritten());
-      Assert.assertEquals(reply.getType(), i == futures.size() - 1 ? RaftProtos.DataStreamPacketHeaderProto.Type.STREAM_DATA_SYNC : RaftProtos.DataStreamPacketHeaderProto.Type.STREAM_DATA);
+      Assert.assertEquals(reply.getType(), RaftProtos.DataStreamPacketHeaderProto.Type.STREAM_DATA);
     }
 
     return this;

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
@@ -21,6 +21,8 @@ import org.apache.ratis.datastream.impl.DataStreamReplyByteBuffer;
 import org.apache.ratis.datastream.impl.DataStreamRequestByteBuffer;
 import org.apache.ratis.datastream.impl.DataStreamRequestFilePositionCount;
 import org.apache.ratis.io.FilePositionCount;
+import org.apache.ratis.io.StandardWriteOption;
+import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.netty.server.DataStreamRequestByteBuf;
 import org.apache.ratis.proto.RaftProtos.DataStreamReplyHeaderProto;
 import org.apache.ratis.proto.RaftProtos.DataStreamRequestHeaderProto;
@@ -47,6 +49,10 @@ public interface NettyDataStreamUtils {
         .setStreamOffset(request.getStreamOffset())
         .setType(request.getType())
         .setDataLength(request.getDataLength());
+    for (WriteOption option : request.getWriteOptions()) {
+      b.addOptions(DataStreamPacketHeaderProto.Option.forNumber(
+          ((StandardWriteOption) option).ordinal()));
+    }
     return DataStreamRequestHeaderProto
         .newBuilder()
         .setPacketHeader(b)

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamRequestByteBuf.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamRequestByteBuf.java
@@ -19,6 +19,7 @@
 package org.apache.ratis.netty.server;
 
 import org.apache.ratis.datastream.impl.DataStreamPacketImpl;
+import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.protocol.DataStreamRequest;
 import org.apache.ratis.protocol.DataStreamRequestHeader;
 import org.apache.ratis.proto.RaftProtos.DataStreamPacketHeaderProto.Type;
@@ -32,14 +33,16 @@ import org.apache.ratis.thirdparty.io.netty.buffer.Unpooled;
  */
 public class DataStreamRequestByteBuf extends DataStreamPacketImpl implements DataStreamRequest {
   private final ByteBuf buf;
+  private final WriteOption[] options;
 
-  public DataStreamRequestByteBuf(Type type, long streamId, long streamOffset, ByteBuf buf) {
+  public DataStreamRequestByteBuf(Type type, long streamId, long streamOffset, WriteOption[] options, ByteBuf buf) {
     super(type, streamId, streamOffset);
     this.buf = buf != null? buf.asReadOnly(): Unpooled.EMPTY_BUFFER;
+    this.options = options;
   }
 
   public DataStreamRequestByteBuf(DataStreamRequestHeader header, ByteBuf buf) {
-    this(header.getType(), header.getStreamId(), header.getStreamOffset(), buf);
+    this(header.getType(), header.getStreamId(), header.getStreamOffset(), header.getWriteOptions(), buf);
   }
 
   @Override
@@ -49,5 +52,10 @@ public class DataStreamRequestByteBuf extends DataStreamPacketImpl implements Da
 
   public ByteBuf slice() {
     return buf.slice();
+  }
+
+  @Override
+  public WriteOption[] getWriteOptions() {
+    return options;
   }
 }

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -303,9 +303,8 @@ message DataStreamPacketHeaderProto {
   }
 
   enum Option {
-    WRITE = 0;
-    SYNC = 1;
-    CLOSE = 2;
+    SYNC = 0;
+    CLOSE = 1;
   }
 
   uint64 streamId = 1;

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -300,14 +300,19 @@ message DataStreamPacketHeaderProto {
   enum Type {
     STREAM_HEADER = 0;
     STREAM_DATA = 1;
-    STREAM_DATA_SYNC = 2;
-    STREAM_CLOSE = 3;
+  }
+
+  enum Option {
+    WRITE = 0;
+    SYNC = 1;
+    CLOSE = 2;
   }
 
   uint64 streamId = 1;
   uint64 streamOffset = 2;
   Type type = 3;
-  uint64 dataLength = 4;
+  repeated Option options = 4;
+  uint64 dataLength = 5;
 }
 
 message DataStreamRequestHeaderProto {

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
@@ -22,6 +22,7 @@ import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.client.impl.DataStreamClientImpl.DataStreamOutputImpl;
 import org.apache.ratis.datastream.impl.DataStreamReplyByteBuffer;
 import org.apache.ratis.datastream.impl.DataStreamRequestByteBuffer;
+import org.apache.ratis.io.StandardWriteOption;
 import org.apache.ratis.proto.RaftProtos.DataStreamPacketHeaderProto.Type;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;
@@ -260,7 +261,7 @@ public interface DataStreamTestUtils {
       sizes.add(size);
 
       final ByteBuffer bf = initBuffer(dataSize, size);
-      futures.add(out.writeAsync(bf, i == bufferNum - 1));
+      futures.add(out.writeAsync(bf, i == bufferNum -1 ? StandardWriteOption.SYNC : StandardWriteOption.WRITE));
       dataSize += size;
     }
 
@@ -272,7 +273,7 @@ public interface DataStreamTestUtils {
     // check writeAsync requests
     for (int i = 0; i < futures.size(); i++) {
       final DataStreamReply reply = futures.get(i).join();
-      final Type expectedType = i == futures.size() - 1 ? Type.STREAM_DATA_SYNC : Type.STREAM_DATA;
+      final Type expectedType = Type.STREAM_DATA;
       assertSuccessReply(expectedType, sizes.get(i).longValue(), reply);
     }
     return dataSize;

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamTestUtils.java
@@ -261,7 +261,7 @@ public interface DataStreamTestUtils {
       sizes.add(size);
 
       final ByteBuffer bf = initBuffer(dataSize, size);
-      futures.add(out.writeAsync(bf, i == bufferNum -1 ? StandardWriteOption.SYNC : StandardWriteOption.WRITE));
+      futures.add(i == bufferNum - 1 ? out.writeAsync(bf, StandardWriteOption.SYNC) : out.writeAsync(bf));
       dataSize += size;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

For the CLOSE, we can add a new API, writeAndClose(..) to save STREAM_CLOSE RPC call.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1196

## How was this patch tested?

