### PR TITLE
RATIS-1216. State machine preAppend callback can throw exception without having leader to step down.

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/StateMachineException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/StateMachineException.java
@@ -20,18 +20,31 @@ package org.apache.ratis.protocol.exceptions;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 
 public class StateMachineException extends RaftException {
+  private boolean leaderShouldStepDown;
+
   public StateMachineException(RaftGroupMemberId serverId, Throwable cause) {
     // cause.getMessage is added to this exception message as the exception received through
     // RPC call contains similar message but Simulated RPC doesn't. Adding the message
     // from cause to this exception makes it consistent across simulated and other RPC implementations.
     super(cause.getClass().getName() + " from Server " + serverId + ": " + cause.getMessage(), cause);
+    this.leaderShouldStepDown = true;
   }
 
   public StateMachineException(String msg) {
     super(msg);
+    this.leaderShouldStepDown = true;
   }
 
   public StateMachineException(String message, Throwable cause) {
     super(message, cause);
+    this.leaderShouldStepDown = true;
+  }
+
+  public boolean leaderShouldStepDown() {
+    return leaderShouldStepDown;
+  }
+
+  public void setLeaderShouldStepDown(boolean shouldStepDown) {
+    leaderShouldStepDown = shouldStepDown;
   }
 }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/StateMachineException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/StateMachineException.java
@@ -20,7 +20,7 @@ package org.apache.ratis.protocol.exceptions;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 
 public class StateMachineException extends RaftException {
-  private boolean leaderShouldStepDown;
+  private final boolean leaderShouldStepDown;
 
   public StateMachineException(RaftGroupMemberId serverId, Throwable cause) {
     // cause.getMessage is added to this exception message as the exception received through
@@ -40,11 +40,25 @@ public class StateMachineException extends RaftException {
     this.leaderShouldStepDown = true;
   }
 
-  public boolean leaderShouldStepDown() {
-    return leaderShouldStepDown;
+  public StateMachineException(RaftGroupMemberId serverId, Throwable cause, boolean leaderShouldStepDown) {
+    // cause.getMessage is added to this exception message as the exception received through
+    // RPC call contains similar message but Simulated RPC doesn't. Adding the message
+    // from cause to this exception makes it consistent across simulated and other RPC implementations.
+    super(cause.getClass().getName() + " from Server " + serverId + ": " + cause.getMessage(), cause);
+    this.leaderShouldStepDown = leaderShouldStepDown;
   }
 
-  public void setLeaderShouldStepDown(boolean shouldStepDown) {
-    leaderShouldStepDown = shouldStepDown;
+  public StateMachineException(String msg, boolean leaderShouldStepDown) {
+    super(msg);
+    this.leaderShouldStepDown = leaderShouldStepDown;
+  }
+
+  public StateMachineException(String message, Throwable cause, boolean leaderShouldStepDown) {
+    super(message, cause);
+    this.leaderShouldStepDown = leaderShouldStepDown;
+  }
+
+  public boolean leaderShouldStepDown() {
+    return leaderShouldStepDown;
   }
 }

--- a/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/TestPreAppendLeaderStepDownWithHadoopRpc.java
+++ b/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/TestPreAppendLeaderStepDownWithHadoopRpc.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ratis.hadooprpc;
 
 import org.apache.ratis.server.impl.PreAppendLeaderStepDownTest;

--- a/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/TestPreAppendLeaderStepDownWithHadoopRpc.java
+++ b/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/TestPreAppendLeaderStepDownWithHadoopRpc.java
@@ -1,0 +1,8 @@
+package org.apache.ratis.hadooprpc;
+
+import org.apache.ratis.server.impl.PreAppendLeaderStepDownTest;
+
+public class TestPreAppendLeaderStepDownWithHadoopRpc
+    extends PreAppendLeaderStepDownTest<MiniRaftClusterWithHadoopRpc>
+    implements MiniRaftClusterWithHadoopRpc.Factory.Get {
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -671,7 +671,7 @@ class RaftServerImpl implements RaftServer.Division,
         RaftClientReply exceptionReply = newExceptionReply(request, e);
         cacheEntry.failWithReply(exceptionReply);
         // leader will step down here
-        if (getInfo().isLeader()) {
+        if (e.leaderShouldStepDown() && getInfo().isLeader()) {
           leaderState.submitStepDownEvent(LeaderState.StepDownReason.STATE_MACHINE_EXCEPTION);
         }
         return CompletableFuture.completedFuture(exceptionReply);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/RaftLog.java
@@ -212,6 +212,8 @@ public abstract class RaftLog implements RaftLogSequentialOps, Closeable {
       // the SM wants to attach a logic depending on ordered execution in the log commit order.
       try {
         operation = operation.preAppendTransaction();
+      } catch (StateMachineException e) {
+        throw e;
       } catch (IOException e) {
         throw new StateMachineException(memberId, e);
       }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/PreAppendLeaderStepDownTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/PreAppendLeaderStepDownTest.java
@@ -97,8 +97,11 @@ public abstract class PreAppendLeaderStepDownTest<CLUSTER extends MiniRaftCluste
       long oldTerm =
           RaftTestUtil.waitForLeader(cluster).getRaftLog().getLastEntryTermIndex().getTerm();
 
-      RaftClientReply reply = rpc.sendRequest(r);
-      Assert.assertTrue(reply.getStateMachineException().leaderShouldStepDown());
+      // Cannot check the state machine exception attached to the reply for the
+      // leader step down flag, because that flag is lost when the exception
+      // is converted to and from a protobuf to pass back from the cluster to
+      // the client.
+      rpc.sendRequest(r);
 
       long newTerm =
           RaftTestUtil.waitForLeader(cluster).getRaftLog().getLastEntryTermIndex().getTerm();

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/PreAppendLeaderStepDownTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/PreAppendLeaderStepDownTest.java
@@ -1,0 +1,98 @@
+package org.apache.ratis.server.impl;
+
+import org.apache.log4j.Level;
+import org.apache.ratis.BaseTest;
+import org.apache.ratis.RaftTestUtil;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.RaftClientRpc;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftClientRequest;
+import org.apache.ratis.protocol.exceptions.StateMachineException;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
+import org.apache.ratis.statemachine.StateMachine;
+import org.apache.ratis.statemachine.TransactionContext;
+import org.apache.ratis.util.Log4jUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+/**
+ * Tests the leader step down flag in {@link StateMachineException}, which
+ * determines whether the leader should step down or not when it receives the
+ * exception from {@link StateMachine#preAppendTransaction}.
+ */
+public abstract class PreAppendLeaderStepDownTest<CLUSTER extends MiniRaftCluster>
+    extends BaseTest implements MiniRaftCluster.Factory.Get<CLUSTER> {
+  {
+    Log4jUtils.setLogLevel(RaftServer.Division.LOG, Level.DEBUG);
+    Log4jUtils.setLogLevel(RaftLog.LOG, Level.DEBUG);
+    Log4jUtils.setLogLevel(RaftClient.LOG, Level.DEBUG);
+  }
+
+  private static volatile boolean leaderShouldStepDown = false;
+
+  protected static class StateMachineWithException extends
+      SimpleStateMachine4Testing {
+
+    @Override
+    public TransactionContext preAppendTransaction(TransactionContext trx)
+        throws IOException {
+      StateMachineException ex = new StateMachineException(
+          "Fake Exception in preAppend");
+      if (!leaderShouldStepDown) {
+        ex.setLeaderShouldStepDown(false);
+        // If leader should step down, do not change the exception state to
+        // ensure that step down being true is the default behavior.
+      }
+      throw ex;
+    }
+  }
+
+  {
+    final RaftProperties prop = getProperties();
+    prop.setClass(MiniRaftCluster.STATEMACHINE_CLASS_KEY, StateMachineWithException.class, StateMachine.class);
+  }
+
+  @Test
+  public void testLeaderStepDown() throws Exception {
+    leaderShouldStepDown = true;
+    runWithNewCluster(3, this::runTestLeaderStepDown);
+  }
+
+  @Test
+  public void testNoLeaderStepDown() throws Exception {
+    leaderShouldStepDown = false;
+    runWithNewCluster(3, this::runTestLeaderStepDown);
+  }
+
+  private void runTestLeaderStepDown(CLUSTER cluster) throws Exception {
+    final RaftServer.Division oldLeader = RaftTestUtil.waitForLeader(cluster);
+    try (final RaftClient client = cluster.createClient(oldLeader.getId())) {
+      final RaftClientRpc rpc = client.getClientRpc();
+      final long callId = 999;
+      final RaftTestUtil.SimpleMessage message = new RaftTestUtil.SimpleMessage("message");
+      RaftClientRequest r = cluster.newRaftClientRequest(client.getId(), oldLeader.getId(), callId, message);
+
+      long oldTerm =
+          RaftTestUtil.waitForLeader(cluster).getRaftLog().getLastEntryTermIndex().getTerm();
+
+      RaftClientReply reply = rpc.sendRequest(r);
+      Assert.assertTrue(reply.getStateMachineException().leaderShouldStepDown());
+
+      long newTerm =
+          RaftTestUtil.waitForLeader(cluster).getRaftLog().getLastEntryTermIndex().getTerm();
+
+      if (leaderShouldStepDown) {
+        Assert.assertTrue(newTerm > oldTerm);
+      } else {
+        Assert.assertEquals(newTerm, oldTerm);
+      }
+
+      cluster.shutdown();
+    }
+  }
+}

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/PreAppendLeaderStepDownTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/PreAppendLeaderStepDownTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ratis.server.impl;
 
 import org.apache.log4j.Level;

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/PreAppendLeaderStepDownTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/PreAppendLeaderStepDownTest.java
@@ -58,14 +58,7 @@ public abstract class PreAppendLeaderStepDownTest<CLUSTER extends MiniRaftCluste
     @Override
     public TransactionContext preAppendTransaction(TransactionContext trx)
         throws IOException {
-      StateMachineException ex = new StateMachineException(
-          "Fake Exception in preAppend");
-      if (!leaderShouldStepDown) {
-        ex.setLeaderShouldStepDown(false);
-        // If leader should step down, do not change the exception state to
-        // ensure that step down being true is the default behavior.
-      }
-      throw ex;
+      throw new StateMachineException("Fake Exception in preAppend", leaderShouldStepDown);
     }
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestPreAppendLeaderStepDownWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestPreAppendLeaderStepDownWithGrpc.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ratis.grpc;
 
 import org.apache.ratis.server.impl.PreAppendLeaderStepDownTest;

--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestPreAppendLeaderStepDownWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestPreAppendLeaderStepDownWithGrpc.java
@@ -1,0 +1,8 @@
+package org.apache.ratis.grpc;
+
+import org.apache.ratis.server.impl.PreAppendLeaderStepDownTest;
+
+public class TestPreAppendLeaderStepDownWithGrpc
+    extends PreAppendLeaderStepDownTest<MiniRaftClusterWithGrpc>
+    implements MiniRaftClusterWithGrpc.FactoryGet {
+}

--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestPreAppendLeaderStepDownWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestPreAppendLeaderStepDownWithNetty.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ratis.netty;
 
 import org.apache.ratis.server.impl.PreAppendLeaderStepDownTest;

--- a/ratis-test/src/test/java/org/apache/ratis/netty/TestPreAppendLeaderStepDownWithNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/netty/TestPreAppendLeaderStepDownWithNetty.java
@@ -1,0 +1,8 @@
+package org.apache.ratis.netty;
+
+import org.apache.ratis.server.impl.PreAppendLeaderStepDownTest;
+
+public class TestPreAppendLeaderStepDownWithNetty
+    extends PreAppendLeaderStepDownTest<MiniRaftClusterWithNetty>
+    implements MiniRaftClusterWithNetty.FactoryGet {
+}

--- a/ratis-test/src/test/java/org/apache/ratis/server/simulation/TestPreAppendLeaderStepDownWithSimulatedRpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/simulation/TestPreAppendLeaderStepDownWithSimulatedRpc.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ratis.server.simulation;
 
 import org.apache.ratis.server.impl.PreAppendLeaderStepDownTest;

--- a/ratis-test/src/test/java/org/apache/ratis/server/simulation/TestPreAppendLeaderStepDownWithSimulatedRpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/simulation/TestPreAppendLeaderStepDownWithSimulatedRpc.java
@@ -1,0 +1,8 @@
+package org.apache.ratis.server.simulation;
+
+import org.apache.ratis.server.impl.PreAppendLeaderStepDownTest;
+
+public class TestPreAppendLeaderStepDownWithSimulatedRpc
+    extends PreAppendLeaderStepDownTest<MiniRaftClusterWithSimulatedRpc>
+    implements MiniRaftClusterWithSimulatedRpc.FactoryGet {
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a flag to `StateMachineException` to indicate whether the exception should cause the leader to step down. In `RaftServerImpl#appendTransaction`, only trigger a leader step down if the flag in the StateMachineException is enabled.

## What is the link to the Apache JIRA

[RATIS-1216](https://issues.apache.org/jira/projects/RATIS/issues/RATIS-1216?filter=allopenissues)

## How was this patch tested?

Integration tests added.
