### PR TITLE
RATIS-1227. RaftServerRpcWithProxy constructor and the abstract impl methods should be protected.

### DIFF
--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmeticLogDump.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmeticLogDump.java
@@ -28,7 +28,6 @@ import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
-import org.apache.ratis.server.impl.RaftServerTestUtil;
 import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
 import org.apache.ratis.server.storage.RaftStorageDirectory;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
@@ -78,7 +77,7 @@ public class TestArithmeticLogDump extends BaseTest {
   public void testLogDump() throws Exception {
     final RaftServer.Division leaderServer = RaftTestUtil.waitForLeader(cluster);
     List<RaftStorageDirectory.LogPathAndIndex> files =
-        RaftServerTestUtil.getRaftStorage(leaderServer).getStorageDir().getLogSegmentFiles();
+        leaderServer.getRaftStorage().getStorageDir().getLogSegmentFiles();
     Assert.assertEquals(1, files.size());
     cluster.shutdown();
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -65,7 +65,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class RaftServerProxy implements RaftServer {
+class RaftServerProxy implements RaftServer {
   /**
    * A map: {@link RaftGroupId} -> {@link RaftServerImpl} futures.
    *

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -131,7 +131,7 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
 
       // wait for the snapshot to be done
       final RaftServer.Division leader = cluster.getLeader();
-      final RaftStorageDirectory storageDirectory = RaftServerTestUtil.getRaftStorage(leader).getStorageDir();
+      final RaftStorageDirectory storageDirectory = leader.getRaftStorage().getStorageDir();
 
       final long nextIndex = leader.getRaftLog().getNextIndex();
       LOG.info("nextIndex = {}", nextIndex);

--- a/ratis-server/src/test/java/org/apache/ratis/LogAppenderTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/LogAppenderTests.java
@@ -142,7 +142,7 @@ public abstract class LogAppenderTests<CLUSTER extends MiniRaftCluster>
       throw e;
     }
 
-    final RatisMetricRegistry ratisMetricRegistry = RaftServerTestUtil.getRaftServerMetrics(leaderServer).getRegistry();
+    final RatisMetricRegistry ratisMetricRegistry = leaderServer.getRaftServerMetrics().getRegistry();
 
     // Get all last_heartbeat_elapsed_time metric gauges. Should be equal to number of followers.
     SortedMap<String, Gauge> heartbeatElapsedTimeGauges = ratisMetricRegistry.getGauges((s, metric) ->
@@ -158,7 +158,7 @@ public abstract class LogAppenderTests<CLUSTER extends MiniRaftCluster>
       // Metric in nanos > 0.
       assertTrue((long)metric.getValue() > 0);
       // Try to get Heartbeat metrics for follower.
-      final RaftServerMetrics followerMetrics = RaftServerTestUtil.getRaftServerMetrics(followerServer);
+      final RaftServerMetrics followerMetrics = followerServer.getRaftServerMetrics();
       // Metric should not exist. It only exists in leader.
       assertTrue(followerMetrics.getRegistry().getGauges((s, m) -> s.contains("lastHeartbeatElapsedTime")).isEmpty());
       for (boolean heartbeat : new boolean[] { true, false }) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -291,7 +291,7 @@ public abstract class GroupManagementBaseTest extends BaseTest {
         LOG.info(i + ") close " + cluster.printServers(g.getGroupId()));
         for(RaftPeer p : g.getPeers()) {
           final RaftServer.Division d = cluster.getDivision(p.getId(), g.getGroupId());
-          final File root = RaftServerTestUtil.getRaftStorage(d).getStorageDir().getRoot();
+          final File root = d.getRaftStorage().getStorageDir().getRoot();
           Assert.assertTrue(root.exists());
           Assert.assertTrue(root.isDirectory());
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/MiniRaftCluster.java
@@ -354,6 +354,10 @@ public abstract class MiniRaftCluster implements Closeable {
     }
   }
 
+  public RaftServer newRaftServer(RaftPeerId id, StateMachine stateMachine, RaftProperties p) throws IOException {
+    return ServerImplUtils.newRaftServer(id, getGroup(), gid -> stateMachine, p, null);
+  }
+
   protected abstract Parameters setPropertiesAndInitParameters(
       RaftPeerId id, RaftGroup group, RaftProperties properties);
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -86,7 +86,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
     for (int i = 0; i < peersWithPriority.size(); i ++) {
       RaftPeerId peerId = peersWithPriority.get(i).getId();
       final RaftServer.Division server = cluster.getDivision(peerId, groupId);
-      final RaftConfiguration conf = RaftServerTestUtil.getRaftConf(server);
+      final RaftConfiguration conf = server.getRaftConf();
 
       for (int j = 0; j < peersWithPriority.size(); j ++) {
         int priorityInConf = conf.getPeer(peersWithPriority.get(j).getId()).getPriority();
@@ -474,7 +474,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
 
       final RaftLog leaderLog = leader.getRaftLog();
       final long committedIndex = leaderLog.getLastCommittedIndex();
-      final RaftConfiguration confBefore = RaftServerTestUtil.getRaftConf(cluster.getLeader());
+      final RaftConfiguration confBefore = cluster.getLeader().getRaftConf();
 
       // no real configuration change in the request
       final RaftClientReply reply = client.setConfiguration(cluster.getPeers().toArray(RaftPeer.emptyArray()));
@@ -484,7 +484,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
         final LogEntryProto e = leaderLog.get(i);
         Assert.assertTrue(e.hasMetadataEntry());
       }
-      Assert.assertSame(confBefore, RaftServerTestUtil.getRaftConf(cluster.getLeader()));
+      Assert.assertSame(confBefore, cluster.getLeader().getRaftConf());
       client.close();
     }
   }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftServerTestUtil.java
@@ -30,7 +30,6 @@ import org.apache.ratis.server.RaftConfiguration;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerRpc;
 import org.apache.ratis.server.leader.LogAppender;
-import org.apache.ratis.server.metrics.RaftServerMetrics;
 import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLog;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.util.JavaUtils;
@@ -118,18 +117,6 @@ public class RaftServerTestUtil {
 
   public static RaftConfiguration newRaftConfiguration(Collection<RaftPeer> peers) {
     return RaftConfigurationImpl.newBuilder().setConf(peers).build();
-  }
-
-  public static RaftConfiguration getRaftConf(RaftServer.Division server) {
-    return ((RaftServerImpl)server).getRaftConf();
-  }
-
-  public static RaftStorage getRaftStorage(RaftServer.Division server) {
-    return ((RaftServerImpl)server).getState().getStorage();
-  }
-
-  public static RaftServerMetrics getRaftServerMetrics(RaftServer.Division server) {
-    return ((RaftServerImpl)server).getRaftServerMetrics();
   }
 
   public static RaftServerRpc getServerRpc(RaftServer.Division server) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRatisServerMetricsBase.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/TestRatisServerMetricsBase.java
@@ -61,7 +61,7 @@ public abstract class TestRatisServerMetricsBase<CLUSTER extends MiniRaftCluster
         0, Message.EMPTY, RaftClientRequest.staleReadRequestType(Long.MAX_VALUE), null);
     final CompletableFuture<RaftClientReply> f = leaderImpl.getRaftServer().submitClientRequestAsync(r);
     Assert.assertTrue(!f.get().isSuccess());
-    assertEquals(1L, RaftServerTestUtil.getRaftServerMetrics(leaderImpl).getRegistry()
+    assertEquals(1L, leaderImpl.getRaftServerMetrics().getRegistry()
         .counter(RATIS_SERVER_FAILED_CLIENT_STALE_READ_COUNT).getCount());
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/statemachine/RaftSnapshotBaseTest.java
@@ -198,7 +198,7 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
       }
 
       // wait for the snapshot to be done
-      RaftStorageDirectory storageDirectory = RaftServerTestUtil.getRaftStorage(cluster.getLeader()).getStorageDir();
+      final RaftStorageDirectory storageDirectory = cluster.getLeader().getRaftStorage().getStorageDir();
 
       final long nextIndex = cluster.getLeader().getRaftLog().getNextIndex();
       LOG.info("nextIndex = {}", nextIndex);
@@ -261,7 +261,7 @@ public abstract class RaftSnapshotBaseTest extends BaseTest {
   }
 
   protected void verifyInstallSnapshotMetric(RaftServer.Division leader) {
-    final Counter installSnapshotCounter = RaftServerTestUtil.getRaftServerMetrics(leader)
+    final Counter installSnapshotCounter = leader.getRaftServerMetrics()
         .getCounter(LOG_APPENDER_INSTALL_SNAPSHOT_METRIC);
     Assert.assertNotNull(installSnapshotCounter);
     Assert.assertTrue(installSnapshotCounter.getCount() >= 1);

--- a/ratis-test/src/test/java/org/apache/ratis/TestRaftServerSlownessDetection.java
+++ b/ratis-test/src/test/java/org/apache/ratis/TestRaftServerSlownessDetection.java
@@ -90,7 +90,7 @@ public class TestRaftServerSlownessDetection extends BaseTest {
         .slownessTimeout(cluster.getProperties()).toIntExact(TimeUnit.MILLISECONDS);
     RaftServer.Division failedFollower = cluster.getFollowers().get(0);
 
-    final RatisMetricRegistry ratisMetricRegistry = RaftServerTestUtil.getRaftServerMetrics(leaderServer).getRegistry();
+    final RatisMetricRegistry ratisMetricRegistry = leaderServer.getRaftServerMetrics().getRegistry();
     SortedMap<String, Gauge> heartbeatElapsedTimeGauges =
         ratisMetricRegistry.getGauges((s, metric) ->
             s.contains("lastHeartbeatElapsedTime"));

--- a/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
@@ -170,7 +170,7 @@ public abstract class ServerRestartTests<CLUSTER extends MiniRaftCluster>
   }
 
   static List<Path> getOpenLogFiles(RaftServer.Division server) throws Exception {
-    return RaftServerTestUtil.getRaftStorage(server).getStorageDir().getLogSegmentFiles().stream()
+    return server.getRaftStorage().getStorageDir().getLogSegmentFiles().stream()
         .filter(LogPathAndIndex::isOpen)
         .map(LogPathAndIndex::getPath)
         .collect(Collectors.toList());


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1227