### PR TITLE
RATIS-1228. FileStore support multi disk

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
@@ -44,6 +44,8 @@ import org.apache.ratis.util.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
@@ -53,9 +55,10 @@ public class FileStoreStateMachine extends BaseStateMachine {
   private final FileStore files;
 
   public FileStoreStateMachine(RaftProperties properties) {
-    final File dir = ConfUtils.getFile(properties::getFile, FileStoreCommon.STATEMACHINE_DIR_KEY, null, LOG::info);
-    Objects.requireNonNull(dir, FileStoreCommon.STATEMACHINE_DIR_KEY + " is not set.");
-    this.files = new FileStore(this::getId, dir.toPath());
+    final List<File> dirs = ConfUtils.getFiles(properties::getFiles, FileStoreCommon.STATEMACHINE_DIR_KEY,
+        null, LOG::info);
+    Objects.requireNonNull(dirs, FileStoreCommon.STATEMACHINE_DIR_KEY + " is not set.");
+    this.files = new FileStore(this::getId, dirs);
   }
 
   @Override
@@ -63,7 +66,9 @@ public class FileStoreStateMachine extends BaseStateMachine {
       throws IOException {
     super.initialize(server, groupId, raftStorage);
     this.storage.init(raftStorage);
-    FileUtils.createDirectories(files.getRoot());
+    for (Path path : files.getRoots()) {
+      FileUtils.createDirectories(path);
+    }
   }
 
   @Override

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
@@ -43,8 +43,9 @@ import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -57,8 +58,9 @@ public class Server extends SubCommandBase {
   @Parameter(names = {"--id", "-i"}, description = "Raft id of this server", required = true)
   private String id;
 
-  @Parameter(names = {"--storage", "-s"}, description = "Storage dir", required = true)
-  private File storageDir;
+  @Parameter(names = {"--storage", "-s"}, description = "Storage dir, eg. --storage dir1 --storage dir2",
+      required = true)
+  private List<File> storageDir = new ArrayList<>();
 
   @Override
   public void run() throws Exception {
@@ -77,10 +79,10 @@ public class Server extends SubCommandBase {
     NettyConfigKeys.DataStream.setPort(properties, dataStreamport);
     RaftConfigKeys.DataStream.setType(properties, SupportedDataStreamType.NETTY);
     properties.setInt(GrpcConfigKeys.OutputStream.RETRY_TIMES_KEY, Integer.MAX_VALUE);
-    RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(storageDir));
+    RaftServerConfigKeys.setStorageDir(properties, storageDir);
     RaftServerConfigKeys.Write.setElementLimit(properties, 40960);
     RaftServerConfigKeys.Write.setByteLimit(properties, SizeInBytes.valueOf("1000MB"));
-    ConfUtils.setFile(properties::setFile, FileStoreCommon.STATEMACHINE_DIR_KEY,
+    ConfUtils.setFiles(properties::setFiles, FileStoreCommon.STATEMACHINE_DIR_KEY,
         storageDir);
     StateMachine stateMachine = new FileStoreStateMachine(properties);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

FileStore support multi disk

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1228

## How was this patch tested?

`nohup ${BIN}/server.sh filestore server --id n0 --storage /data/ratis/n0 --storage /data1/ratis/n0 --storage /data2/ratis/n0 --storage /data3/ratis/n0 --storage /data4/ratis/n0 --storage /data5/ratis/n0 --storage /data6/ratis/n0 --storage /data7/ratis/n0 --storage /data8/ratis/n0 --storage /data9/ratis/n0 --storage /data10/ratis/n0 --storage /data11/ratis/n0 --peers ${PEERS} >> n0.log 2>&1 &`
