### PR TITLE
RATIS-1229. FileStore client generate files in parallel

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreCommon.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreCommon.java
@@ -25,7 +25,17 @@ import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 
 public interface FileStoreCommon {
-  String STATEMACHINE_DIR_KEY = "example.filestore.statemachine.dir";
+  String STATEMACHINE_PREFIX = "example.filestore.statemachine";
+
+  String STATEMACHINE_DIR_KEY = STATEMACHINE_PREFIX + ".dir";
+
+  String STATEMACHINE_WRITE_THREAD_NUM = STATEMACHINE_PREFIX + ".write.thread.num";
+
+  String STATEMACHINE_READ_THREAD_NUM = STATEMACHINE_PREFIX + ".read.thread.num";
+
+  String STATEMACHINE_COMMIT_THREAD_NUM = STATEMACHINE_PREFIX + ".commit.thread.num";
+
+  String STATEMACHINE_DELETE_THREAD_NUM = STATEMACHINE_PREFIX + ".delete.thread.num";
 
   SizeInBytes MAX_CHUNK_SIZE = SizeInBytes.valueOf(64, TraditionalBinaryPrefix.MEGA);
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
@@ -55,10 +55,7 @@ public class FileStoreStateMachine extends BaseStateMachine {
   private final FileStore files;
 
   public FileStoreStateMachine(RaftProperties properties) {
-    final List<File> dirs = ConfUtils.getFiles(properties::getFiles, FileStoreCommon.STATEMACHINE_DIR_KEY,
-        null, LOG::info);
-    Objects.requireNonNull(dirs, FileStoreCommon.STATEMACHINE_DIR_KEY + " is not set.");
-    this.files = new FileStore(this::getId, dirs);
+    this.files = new FileStore(this::getId, properties);
   }
 
   @Override

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
@@ -17,7 +17,6 @@
  */
 package org.apache.ratis.examples.filestore;
 
-import org.apache.ratis.conf.ConfUtils;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.ExamplesProtos;
 import org.apache.ratis.proto.ExamplesProtos.DeleteReplyProto;
@@ -42,11 +41,8 @@ import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.thirdparty.com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.ratis.util.FileUtils;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 public class FileStoreStateMachine extends BaseStateMachine {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
@@ -40,7 +40,6 @@ import org.apache.ratis.util.TimeDuration;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -137,6 +136,12 @@ public abstract class Client extends SubCommandBase {
   public String getPath(String fileName) {
     int hash = fileName.hashCode() % storageDir.size();
     return new File(storageDir.get(Math.abs(hash)), fileName).getAbsolutePath();
+  }
+
+  protected void dropCache() throws InterruptedException, IOException {
+    String[] cmds = {"/bin/sh","-c","echo 3 > /proc/sys/vm/drop_caches"};
+    Process pro = Runtime.getRuntime().exec(cmds);
+    pro.waitFor();
   }
 
   private CompletableFuture<Long> writeFileAsync(String path, ExecutorService executor) {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
@@ -33,16 +33,21 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -51,7 +56,7 @@ import java.util.concurrent.TimeUnit;
 public abstract class Client extends SubCommandBase {
 
   @Parameter(names = {"--size"}, description = "Size of each file in bytes", required = true)
-  private int fileSizeInBytes;
+  private long fileSizeInBytes;
 
   @Parameter(names = {"--bufferSize"}, description = "Size of buffer in bytes, should less than 4MB, " +
       "i.e BUFFER_BYTE_LIMIT_DEFAULT", required = true)
@@ -60,13 +65,17 @@ public abstract class Client extends SubCommandBase {
   @Parameter(names = {"--numFiles"}, description = "Number of files to be written", required = true)
   private int numFiles;
 
+  @Parameter(names = {"--storage", "-s"}, description = "Storage dir, eg. --storage dir1 --storage dir2",
+      required = true)
+  private List<File> storageDir = new ArrayList<>();
+
   private static final int MAX_THREADS_NUM = 100;
 
   public int getNumThread() {
     return numFiles < MAX_THREADS_NUM ? numFiles : MAX_THREADS_NUM;
   }
 
-  public int getFileSizeInBytes() {
+  public long getFileSizeInBytes() {
     return fileSizeInBytes;
   }
 
@@ -112,6 +121,10 @@ public abstract class Client extends SubCommandBase {
     builder.setPrimaryDataStreamServer(getPrimary());
     RaftClient client = builder.build();
 
+    for (File dir : storageDir) {
+      FileUtils.createDirectories(dir);
+    }
+
     operation(client);
   }
 
@@ -121,27 +134,55 @@ public abstract class Client extends SubCommandBase {
     System.exit(0);
   }
 
-  protected List<String> generateFiles() throws IOException {
+  public String getPath(String fileName) {
+    int hash = fileName.hashCode() % storageDir.size();
+    return new File(storageDir.get(Math.abs(hash)), fileName).getAbsolutePath();
+  }
+
+  private CompletableFuture<Long> writeFileAsync(String path, ExecutorService executor) {
+    final CompletableFuture<Long> future = new CompletableFuture<>();
+    CompletableFuture.supplyAsync(() -> {
+      try {
+        future.complete(
+            writeFile(path, fileSizeInBytes, bufferSizeInBytes, new Random().nextInt(127) + 1));
+      } catch (IOException e) {
+        future.completeExceptionally(e);
+      }
+      return future;
+    }, executor);
+    return future;
+  }
+
+  protected List<String> generateFiles(ExecutorService executor) {
     UUID uuid = UUID.randomUUID();
     List<String> paths = new ArrayList<>();
+    List<CompletableFuture<Long>> futures = new ArrayList<>();
     for (int i = 0; i < numFiles; i ++) {
-      String path = "file-" + uuid + "-" + i;
+      String path = getPath("file-" + uuid + "-" + i);
       paths.add(path);
-      writeFile(path, fileSizeInBytes, bufferSizeInBytes, new Random().nextInt(127) + 1);
+      futures.add(writeFileAsync(path, executor));
+    }
+
+    for (int i = 0; i < futures.size(); i ++) {
+      long size = futures.get(i).join();
+      if (size != fileSizeInBytes) {
+        System.err.println("Error: path:" + paths.get(i) + " write:" + size +
+            " mismatch expected size:" + fileSizeInBytes);
+      }
     }
 
     return paths;
   }
 
-  protected void writeFile(String path, int fileSize, int bufferSize, int random) throws IOException {
+  protected long writeFile(String path, long fileSize, long bufferSize, int random) throws IOException {
     RandomAccessFile raf = null;
+    long offset = 0;
     try {
       raf = new RandomAccessFile(path, "rw");
-      int offset = 0;
       while (offset < fileSize) {
-        final int remaining = fileSize - offset;
-        final int chunkSize = Math.min(remaining, bufferSize);
-        byte[] buffer = new byte[chunkSize];
+        final long remaining = fileSize - offset;
+        final long chunkSize = Math.min(remaining, bufferSize);
+        byte[] buffer = new byte[(int)chunkSize];
         for (int i = 0; i < chunkSize; i ++) {
           buffer[i]= (byte) (i % random);
         }
@@ -153,6 +194,7 @@ public abstract class Client extends SubCommandBase {
         raf.close();
       }
     }
+    return offset;
   }
 
   protected abstract void operation(RaftClient client) throws IOException, ExecutionException, InterruptedException;

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
@@ -117,11 +117,11 @@ public class DataStream extends Client {
       stop(client);
     }
 
-    List<String> paths = generateFiles();
+    final ExecutorService executor = Executors.newFixedThreadPool(getNumThread());
+
+    List<String> paths = generateFiles(executor);
     FileStoreClient fileStoreClient = new FileStoreClient(client);
     System.out.println("Starting DataStream write now ");
-
-    final ExecutorService executor = Executors.newFixedThreadPool(getNumThread());
 
     long startTime = System.currentTimeMillis();
 
@@ -230,7 +230,7 @@ public class DataStream extends Client {
       }
 
       final List<CompletableFuture<DataStreamReply>> futures = new ArrayList<>();
-      final DataStreamOutput out = client.getStreamOutput(path, fileSize);
+      final DataStreamOutput out = client.getStreamOutput(file.getName(), fileSize);
       try (FileInputStream fis = new FileInputStream(file)) {
         final FileChannel in = fis.getChannel();
         for (long offset = 0L; offset < fileSize; ) {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/DataStream.java
@@ -118,8 +118,8 @@ public class DataStream extends Client {
     }
 
     final ExecutorService executor = Executors.newFixedThreadPool(getNumThread());
-
     List<String> paths = generateFiles(executor);
+    dropCache();
     FileStoreClient fileStoreClient = new FileStoreClient(client);
     System.out.println("Starting DataStream write now ");
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/LoadGen.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/LoadGen.java
@@ -48,11 +48,10 @@ public class LoadGen extends Client {
 
   @Override
   protected void operation(RaftClient client) throws IOException, ExecutionException, InterruptedException {
-    List<String> paths = generateFiles();
+    final ExecutorService executor = Executors.newFixedThreadPool(getNumThread());
+    List<String> paths = generateFiles(executor);
     FileStoreClient fileStoreClient = new FileStoreClient(client);
     System.out.println("Starting Async write now ");
-
-    final ExecutorService executor = Executors.newFixedThreadPool(getNumThread());
 
     long startTime = System.currentTimeMillis();
 
@@ -99,7 +98,7 @@ public class LoadGen extends Client {
         try (FileInputStream fis = new FileInputStream(file)) {
           final FileChannel in = fis.getChannel();
           for (long offset = 0L; offset < getFileSizeInBytes(); ) {
-            offset += write(in, offset, fileStoreClient, path, futures);
+            offset += write(in, offset, fileStoreClient, file.getName(), futures);
           }
         } catch (Throwable e) {
           future.completeExceptionally(e);

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/LoadGen.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/LoadGen.java
@@ -50,6 +50,7 @@ public class LoadGen extends Client {
   protected void operation(RaftClient client) throws IOException, ExecutionException, InterruptedException {
     final ExecutorService executor = Executors.newFixedThreadPool(getNumThread());
     List<String> paths = generateFiles(executor);
+    dropCache();
     FileStoreClient fileStoreClient = new FileStoreClient(client);
     System.out.println("Starting Async write now ");
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
@@ -60,10 +60,10 @@ public class Server extends SubCommandBase {
   private List<File> storageDir = new ArrayList<>();
 
   @Parameter(names = {"--writeThreadNum"}, description = "Number of write thread")
-  private int writeThreadNum = 10;
+  private int writeThreadNum = 20;
 
   @Parameter(names = {"--readThreadNum"}, description = "Number of read thread")
-  private int readThreadNum = 10;
+  private int readThreadNum = 20;
 
   @Parameter(names = {"--commitThreadNum"}, description = "Number of commit thread")
   private int commitThreadNum = 3;

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
@@ -31,7 +31,6 @@ import org.apache.ratis.metrics.JVMMetrics;
 import org.apache.ratis.netty.NettyConfigKeys;
 import org.apache.ratis.protocol.RaftGroup;
 import org.apache.ratis.protocol.RaftGroupId;
-import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
@@ -44,10 +43,8 @@ import org.apache.ratis.util.TimeDuration;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Class to start a ratis arithmetic example server.


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. FileStore client generate files by multi-thread, in multi-disk

2. config write, read, commit, delete thread number in FileStoreStateMachine

3. client drop system cache before read.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1229

## How was this patch tested?

test it manually by command
client:
`${BIN}/client.sh filestore datastream --size 128000000 --numFiles 1000 --bufferSize 4000000 --syncSize 16000000 --type DirectByteBuffer --peers ${PEERS} --storage /data/ratis/n2 --storage /data1/ratis/n2 --storage /data2/ratis/n2 --storage /data3/ratis/n2 --storage /data4/ratis/n2 --storage /data5/ratis/n2 --storage /data6/ratis/n2 --storage /data7/ratis/n2 --storage /data8/ratis/n2 --storage /data9/ratis/n2 --storage /data10/ratis/n2 --storage /data11/ratis/n2`

server:
`nohup ${BIN}/server.sh filestore server --id n2 --storage /data/ratis/n2 --storage /data1/ratis/n2 --storage /data2/ratis/n2 --storage /data3/ratis/n2 --storage /data4/ratis/n2 --storage /data5/ratis/n2 --storage /data6/ratis/n2 --storage /data7/ratis/n2 --storage /data8/ratis/n2 --storage /data9/ratis/n2 --storage /data10/ratis/n2 --storage /data11/ratis/n2 --peers ${PEERS} --writeThreadNum 100 --readThreadNum 100 --commitThreadNum 20 --deleteThreadNum 20 >> n2.log 2>&1 &`
