### PR TITLE
RATIS-1238. Seperate request and write executor

### DIFF
--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
@@ -54,9 +54,6 @@ public abstract class SubCommandBase {
     return parsePeers(peers)[0];
   }
 
-  public boolean isPrimary(String id) {
-    return getPrimary().getId().toString().equals(id);
-  }
   public abstract void run() throws Exception;
 
   public String getRaftGroupId() {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
@@ -43,7 +43,6 @@ import java.io.RandomAccessFile;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -140,7 +139,7 @@ public abstract class Client extends SubCommandBase {
     return new File(storageDir.get(Math.abs(hash)), fileName).getAbsolutePath();
   }
 
-  protected void dropCache() throws InterruptedException, IOException {
+  protected void dropCache() {
     String[] cmds = {"/bin/sh","-c","echo 3 > /proc/sys/vm/drop_caches"};
     try {
       Process pro = Runtime.getRuntime().exec(cmds);
@@ -154,8 +153,7 @@ public abstract class Client extends SubCommandBase {
     final CompletableFuture<Long> future = new CompletableFuture<>();
     CompletableFuture.supplyAsync(() -> {
       try {
-        future.complete(
-            writeFile(path, fileSizeInBytes, bufferSizeInBytes, new Random().nextInt(127) + 1));
+        future.complete(writeFile(path, fileSizeInBytes, bufferSizeInBytes));
       } catch (IOException e) {
         future.completeExceptionally(e);
       }
@@ -185,7 +183,7 @@ public abstract class Client extends SubCommandBase {
     return paths;
   }
 
-  protected long writeFile(String path, long fileSize, long bufferSize, int random) throws IOException {
+  protected long writeFile(String path, long fileSize, long bufferSize) throws IOException {
     final byte[] buffer = new byte[Math.toIntExact(bufferSize)];
     long offset = 0;
     try(RandomAccessFile raf = new RandomAccessFile(path, "rw")) {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
@@ -92,6 +92,8 @@ public class Server extends SubCommandBase {
     RaftServerConfigKeys.Write.setElementLimit(properties, 40960);
     RaftServerConfigKeys.Write.setByteLimit(properties, SizeInBytes.valueOf("1000MB"));
     ConfUtils.setFiles(properties::setFiles, FileStoreCommon.STATEMACHINE_DIR_KEY, storageDir);
+    RaftServerConfigKeys.DataStream.setAsyncRequestThreadPoolSize(properties, writeThreadNum);
+    RaftServerConfigKeys.DataStream.setAsyncWriteThreadPoolSize(properties, writeThreadNum);
     ConfUtils.setInt(properties::setInt, FileStoreCommon.STATEMACHINE_WRITE_THREAD_NUM, writeThreadNum);
     ConfUtils.setInt(properties::setInt, FileStoreCommon.STATEMACHINE_READ_THREAD_NUM, readThreadNum);
     ConfUtils.setInt(properties::setInt, FileStoreCommon.STATEMACHINE_COMMIT_THREAD_NUM, commitThreadNum);

--- a/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/RaftServerConfigKeys.java
@@ -420,16 +420,30 @@ public interface RaftServerConfigKeys {
   interface DataStream {
     String PREFIX = RaftServerConfigKeys.PREFIX + ".data-stream";
 
-    String ASYNC_THREAD_POOL_SIZE_KEY = PREFIX + ".async.thread.pool.size";
-    int ASYNC_THREAD_POOL_SIZE_DEFAULT = 16;
+    String ASYNC_REQUEST_THREAD_POOL_SIZE_KEY = PREFIX + ".async.request.thread.pool.size";
+    int ASYNC_REQUEST_THREAD_POOL_SIZE_DEFAULT = 16;
 
-    static int asyncThreadPoolSize(RaftProperties properties) {
-      return getInt(properties::getInt, ASYNC_THREAD_POOL_SIZE_KEY, ASYNC_THREAD_POOL_SIZE_DEFAULT, getDefaultLog(),
+    static int asyncRequestThreadPoolSize(RaftProperties properties) {
+      return getInt(properties::getInt, ASYNC_REQUEST_THREAD_POOL_SIZE_KEY,
+          ASYNC_REQUEST_THREAD_POOL_SIZE_DEFAULT, getDefaultLog(),
           requireMin(0), requireMax(65536));
     }
 
-    static void setAsyncThreadPoolSize(RaftProperties properties, int port) {
-      setInt(properties::setInt, ASYNC_THREAD_POOL_SIZE_KEY, port);
+    static void setAsyncRequestThreadPoolSize(RaftProperties properties, int port) {
+      setInt(properties::setInt, ASYNC_REQUEST_THREAD_POOL_SIZE_KEY, port);
+    }
+
+    String ASYNC_WRITE_THREAD_POOL_SIZE_KEY = PREFIX + ".async.write.thread.pool.size";
+    int ASYNC_WRITE_THREAD_POOL_SIZE_DEFAULT = 16;
+
+    static int asyncWriteThreadPoolSize(RaftProperties properties) {
+      return getInt(properties::getInt, ASYNC_WRITE_THREAD_POOL_SIZE_KEY,
+          ASYNC_WRITE_THREAD_POOL_SIZE_DEFAULT, getDefaultLog(),
+          requireMin(0), requireMax(65536));
+    }
+
+    static void setAsyncWriteThreadPoolSize(RaftProperties properties, int port) {
+      setInt(properties::setInt, ASYNC_WRITE_THREAD_POOL_SIZE_KEY, port);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Seperate the thread pool of request and write disk 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1238

## How was this patch tested?

No need to add new ut.
