### PR TITLE
RATIS-1235. Update slack invite in ratis website

### DIFF
--- a/content/community.md
+++ b/content/community.md
@@ -45,5 +45,4 @@ To post to the list, it is necessary to subscribe to it.
 
 ### Slack
 
-There is also a slack instance for discussion at https://apacheratisdev.slack.com.
-Please write to the mailing list if you need an invite.
+You can join the #ratis channel in Apache slack workspace [http://s.apache.org/slack-invite](http://s.apache.org/slack-invite) for any discussions.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis website lists the old slack workspace. This should be updated to the channel being used currently.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1235

## How was this patch tested?

Manually
