### PR TITLE
RATIS-1235. Update slack invite in ratis website

### DIFF
--- a/community.html
+++ b/community.html
@@ -116,8 +116,7 @@ questions and discussion.</p>
 </ul>
 <p>To post to the list, it is necessary to subscribe to it.</p>
 <h3 id="slack">Slack</h3>
-<p>There is also a slack instance for discussion at <a href="https://apacheratisdev.slack.com">https://apacheratisdev.slack.com</a>.
-Please write to the mailing list if you need an invite.</p>
+<p>You can join the #ratis channel in Apache slack workspace <a href="http://s.apache.org/slack-invite">http://s.apache.org/slack-invite</a> for any discussions</p>
 
 </div>
 

--- a/index.html
+++ b/index.html
@@ -352,8 +352,7 @@ questions and discussion.</p>
 </ul>
 <p>To post to the list, it is necessary to subscribe to it.</p>
 <h3 id="slack">Slack</h3>
-<p>There is also a slack instance for discussion at <a href="https://apacheratisdev.slack.com">https://apacheratisdev.slack.com</a>.
-Please write to the mailing list if you need an invite.</p>
+<p>You can join the #ratis channel in Apache slack workspace <a href="http://s.apache.org/slack-invite">http://s.apache.org/slack-invite</a> for any discussions</p>
 
             
         </div>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ratis website lists the old slack workspace. This should be updated to the channel being used currently.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1235

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
