### PR TITLE
RATIS-1245. Support change priority dynamically

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
@@ -164,7 +164,7 @@ public final class RaftPeer {
   public String toString() {
     final String rpc = address != null? "|rpc:" + address: "";
     final String data = dataStreamAddress != null? "|dataStream:" + dataStreamAddress: "";
-    final String p = priority > 0? "|p" +  priority: "";
+    final String p = "|priority:" +  priority;
     return id + rpc + data + p;
   }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
@@ -219,7 +219,7 @@ final class RaftConfigurationImpl implements RaftConfiguration {
       return false;
     }
     for (RaftPeer peer : newMembers) {
-      if (!conf.contains(peer.getId())) {
+      if (!conf.contains(peer.getId()) || conf.getPeer(peer.getId()).getPriority() != peer.getPriority()) {
         return false;
       }
     }

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/GroupManagementBaseTest.java
@@ -77,6 +77,17 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     return getClusterFactory().newCluster(peerNum, prop);
   }
 
+  private List<RaftPeer> getPeersWithPriority(List<RaftPeer> peers, int suggestedLeaderIndex) {
+    List<RaftPeer> peersWithPriority = new ArrayList<>();
+    for (int i = 0; i < peers.size(); i++) {
+      RaftPeer peer = peers.get(i);
+      final int priority = i == suggestedLeaderIndex? 2: 1;
+      peersWithPriority.add(
+          RaftPeer.newBuilder().setId(peer.getId()).setAddress(peer.getAddress()).setPriority(priority).build());
+    }
+    return peersWithPriority;
+  }
+
   @Test
   public void testGroupWithPriority() throws Exception {
     final MiniRaftCluster cluster = getCluster(0);
@@ -98,16 +109,8 @@ public abstract class GroupManagementBaseTest extends BaseTest {
     // Add groups
     List<RaftPeer> peers = cluster.getPeers();
     Random r = new Random(1);
-    int suggestedLeaderIndex = r.nextInt(peers.size());
-
-    List<RaftPeer> peersWithPriority = new ArrayList<>();
-    for (int i = 0; i < peers.size(); i++) {
-      RaftPeer peer = peers.get(i);
-      final int priority = i == suggestedLeaderIndex? 2: 1;
-      peersWithPriority.add(
-          RaftPeer.newBuilder().setId(peer.getId()).setAddress(peer.getAddress()).setPriority(priority).build());
-    }
-
+    final int suggestedLeaderIndex = r.nextInt(peers.size());
+    List<RaftPeer> peersWithPriority = getPeersWithPriority(peers, suggestedLeaderIndex);
     final RaftGroup newGroup = RaftGroup.valueOf(RaftGroupId.randomId(), peersWithPriority);
     LOG.info("add new group: " + newGroup);
     try (final RaftClient client = cluster.createClient(newGroup)) {
@@ -157,10 +160,23 @@ public abstract class GroupManagementBaseTest extends BaseTest {
       Assert.assertTrue(leader.getId() == peers.get(suggestedLeaderIndex).getId());
     }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
 
-    cluster.killServer(peers.get(suggestedLeaderIndex).getId());
+    // change the suggest leader
+    final int newSuggestedLeaderIndex = (suggestedLeaderIndex + 1) % peersWithPriority.size();
+    List<RaftPeer> peersWithNewPriority = getPeersWithPriority(peers, newSuggestedLeaderIndex);
+    try (final RaftClient client = cluster.createClient(newGroup)) {
+      RaftClientReply reply = client.setConfiguration(peersWithNewPriority.toArray(new RaftPeer[0]));
+      Assert.assertTrue(reply.isSuccess());
+    }
+
     JavaUtils.attempt(() -> {
       final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
-      Assert.assertTrue(leader.getId() != peers.get(suggestedLeaderIndex).getId());
+      Assert.assertTrue(leader.getId() == peers.get(newSuggestedLeaderIndex).getId());
+    }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
+
+    cluster.killServer(peers.get(newSuggestedLeaderIndex).getId());
+    JavaUtils.attempt(() -> {
+      final RaftServer.Division leader = RaftTestUtil.waitForLeader(cluster, newGroup.getGroupId());
+      Assert.assertTrue(leader.getId() != peers.get(newSuggestedLeaderIndex).getId());
     }, 10, TimeDuration.valueOf(1, TimeUnit.SECONDS), "testMultiGroupWithPriority", LOG);
 
     cluster.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HA case, such as there are three server: server1, server2, server3, server1 is the leader.
1. if we want to rolling upgrade leader, we can upgrade server2, and then assign server2 with the highest priority, and server1 stop accepting client request, then server2 will try to grab the leader once catch up the log
2. if we want to rollback, we can assign server1 with the highest priority again and server2 stop accepting client request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1245

## How was this patch tested?

new ut

