### PR TITLE
RATIS-1246. Move out LogPathAndIndex from RaftStorageDirectory.

### DIFF
--- a/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmeticLogDump.java
+++ b/ratis-examples/src/test/java/org/apache/ratis/examples/arithmetic/TestArithmeticLogDump.java
@@ -28,8 +28,8 @@ import org.apache.ratis.RaftTestUtil;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.server.raftlog.segmented.LogSegmentPath;
 import org.apache.ratis.server.simulation.MiniRaftClusterWithSimulatedRpc;
-import org.apache.ratis.server.storage.RaftStorageDirectory;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.tools.ParseRatisLog;
@@ -76,8 +76,7 @@ public class TestArithmeticLogDump extends BaseTest {
   @Test
   public void testLogDump() throws Exception {
     final RaftServer.Division leaderServer = RaftTestUtil.waitForLeader(cluster);
-    List<RaftStorageDirectory.LogPathAndIndex> files =
-        leaderServer.getRaftStorage().getStorageDir().getLogSegmentFiles();
+    final List<LogSegmentPath> files = LogSegmentPath.getLogSegmentPaths(leaderServer.getRaftStorage());
     Assert.assertEquals(1, files.size());
     cluster.shutdown();
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegmentPath.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegmentPath.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.raftlog.segmented;
+
+import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+
+/**
+ * {@link LogSegmentStartEnd} with a {@link Path}.
+ *
+ * This is a value-based class.
+ */
+public final class LogSegmentPath implements Comparable<LogSegmentPath> {
+  static final Logger LOG = LoggerFactory.getLogger(LogSegmentPath.class);
+
+  private final Path path;
+  private final LogSegmentStartEnd startEnd;
+
+  private LogSegmentPath(Path path, long startIndex, Long endIndex) {
+    this.path = path;
+    this.startEnd = LogSegmentStartEnd.valueOf(startIndex, endIndex);
+  }
+
+  public Path getPath() {
+    return path;
+  }
+
+  public LogSegmentStartEnd getStartEnd() {
+    return startEnd;
+  }
+
+  @Override
+  public int compareTo(LogSegmentPath that) {
+    return Comparator.comparing(LogSegmentPath::getStartEnd).compare(this, that);
+  }
+
+  @Override
+  public String toString() {
+    return path+ "(" + startEnd + ")";
+  }
+
+  /**
+   * Get a list of {@link LogSegmentPath} from the given storage.
+   *
+   * @return a list of log segment paths sorted by the indices.
+   */
+  public static List<LogSegmentPath> getLogSegmentPaths(RaftStorage storage) throws IOException {
+    return getLogSegmentPaths(storage.getStorageDir().getCurrentDir().toPath());
+  }
+
+  private static List<LogSegmentPath> getLogSegmentPaths(Path dir) throws IOException {
+    final List<LogSegmentPath> list = new ArrayList<>();
+    try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+      for (Path path : stream) {
+        Optional.ofNullable(matchLogSegment(path)).ifPresent(list::add);
+      }
+    }
+    list.sort(Comparator.naturalOrder());
+    return list;
+  }
+
+  /**
+   * Match the given path with the {@link LogSegmentStartEnd#getClosedSegmentPattern()}
+   * or the {@link LogSegmentStartEnd#getOpenSegmentPattern()}.
+   *
+   * Note that if the path is a zero size open segment, this method will try to delete it.
+   *
+   * @return the log segment file matching the given path.
+   */
+  public static LogSegmentPath matchLogSegment(Path path) {
+    return Optional.ofNullable(matchCloseSegment(path)).orElseGet(() -> matchOpenSegment(path));
+  }
+
+  private static LogSegmentPath matchCloseSegment(Path path) {
+    final Matcher matcher = LogSegmentStartEnd.getClosedSegmentPattern().matcher(path.getFileName().toString());
+    if (matcher.matches()) {
+      Preconditions.assertTrue(matcher.groupCount() == 2);
+      return newInstance(path, matcher.group(1), matcher.group(2));
+    }
+    return null;
+  }
+
+  private static LogSegmentPath matchOpenSegment(Path path) {
+    final Matcher matcher = LogSegmentStartEnd.getOpenSegmentPattern().matcher(path.getFileName().toString());
+    if (matcher.matches()) {
+      if (path.toFile().length() > 0L) {
+        return newInstance(path, matcher.group(1), null);
+      }
+
+      LOG.info("Found zero size open segment file " + path);
+      try {
+        Files.delete(path);
+        LOG.info("Deleted zero size open segment file " + path);
+      } catch (IOException e) {
+        LOG.warn("Failed to delete zero size open segment file " + path + ": " + e);
+      }
+    }
+    return null;
+  }
+
+  private static LogSegmentPath newInstance(Path path, String startIndexString, String endIndexString) {
+    final long startIndex = Long.parseLong(startIndexString);
+    final Long endIndex = Optional.ofNullable(endIndexString).map(Long::parseLong).orElse(null);
+    return new LogSegmentPath(path, startIndex, endIndex);
+  }
+}

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegmentStartEnd.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegmentStartEnd.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.server.raftlog.segmented;
+
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.apache.ratis.server.storage.RaftStorage;
+import org.apache.ratis.util.Preconditions;
+
+import java.io.File;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * The start index and an end index of a log segment.
+ *
+ * This is a value-based class.
+ */
+public final class LogSegmentStartEnd implements Comparable<LogSegmentStartEnd> {
+  private static final String LOG_FILE_NAME_PREFIX = "log";
+  private static final String IN_PROGRESS = "inprogress";
+  private static final Pattern CLOSED_SEGMENT_PATTERN;
+  private static final Pattern OPEN_SEGMENT_PATTERN;
+
+  static {
+    final String digits = "(\\d+)";
+    CLOSED_SEGMENT_PATTERN = Pattern.compile(LOG_FILE_NAME_PREFIX + "_" + digits + "-" + digits);
+    OPEN_SEGMENT_PATTERN = Pattern.compile(LOG_FILE_NAME_PREFIX + "_" + IN_PROGRESS + "_" + digits + "(?:\\..*)?");
+  }
+
+  private static String getOpenLogFileName(long startIndex) {
+    return LOG_FILE_NAME_PREFIX + "_" + IN_PROGRESS + "_" + startIndex;
+  }
+
+  static Pattern getOpenSegmentPattern() {
+    return OPEN_SEGMENT_PATTERN;
+  }
+
+  private static String getClosedLogFileName(long startIndex, long endIndex) {
+    return LOG_FILE_NAME_PREFIX + "_" + startIndex + "-" + endIndex;
+  }
+
+  static Pattern getClosedSegmentPattern() {
+    return CLOSED_SEGMENT_PATTERN;
+  }
+
+  static LogSegmentStartEnd valueOf(long startIndex) {
+    return new LogSegmentStartEnd(startIndex, null);
+  }
+
+  static LogSegmentStartEnd valueOf(long startIndex, Long endIndex) {
+    return new LogSegmentStartEnd(startIndex, endIndex);
+  }
+
+  static LogSegmentStartEnd valueOf(long startIndex, long endIndex, boolean isOpen) {
+    return new LogSegmentStartEnd(startIndex, isOpen? null: endIndex);
+  }
+
+  private final long startIndex;
+  private final Long endIndex;
+
+  private LogSegmentStartEnd(long startIndex, Long endIndex) {
+    Preconditions.assertTrue(startIndex >= RaftLog.LEAST_VALID_LOG_INDEX);
+    Preconditions.assertTrue(endIndex == null || endIndex >= startIndex);
+    this.startIndex = startIndex;
+    this.endIndex = endIndex;
+  }
+
+  public long getStartIndex() {
+    return startIndex;
+  }
+
+  public long getEndIndex() {
+    return Optional.ofNullable(endIndex).orElse(RaftLog.INVALID_LOG_INDEX);
+  }
+
+  public boolean isOpen() {
+    return endIndex == null;
+  }
+
+  private String getFileName() {
+    return isOpen()? getOpenLogFileName(startIndex): getClosedLogFileName(startIndex, endIndex);
+  }
+
+  File getFile(File dir) {
+    return new File(dir, getFileName());
+  }
+
+  File getFile(RaftStorage storage) {
+    return getFile(storage.getStorageDir().getCurrentDir());
+  }
+
+  @Override
+  public int compareTo(LogSegmentStartEnd that) {
+    return Comparator.comparingLong(LogSegmentStartEnd::getStartIndex)
+        .thenComparingLong(LogSegmentStartEnd::getEndIndex)
+        .compare(this, that);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    } else if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    final LogSegmentStartEnd that = (LogSegmentStartEnd) obj;
+    return startIndex == that.startIndex && Objects.equals(endIndex, that.endIndex);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(startIndex, endIndex);
+  }
+
+  @Override
+  public String toString() {
+    return startIndex + "-" + Optional.ofNullable(endIndex).map(Object::toString).orElse("");
+  }
+}

--- a/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/ServerRestartTests.java
@@ -37,7 +37,7 @@ import org.apache.ratis.server.raftlog.RaftLogIOException;
 import org.apache.ratis.server.raftlog.segmented.SegmentedRaftLogFormat;
 import org.apache.ratis.server.RaftServerConfigKeys.Log;
 import org.apache.ratis.server.raftlog.segmented.TestSegmentedRaftLog;
-import org.apache.ratis.server.storage.RaftStorageDirectory.LogPathAndIndex;
+import org.apache.ratis.server.raftlog.segmented.LogSegmentPath;
 import org.apache.ratis.statemachine.SimpleStateMachine4Testing;
 import org.apache.ratis.statemachine.StateMachine;
 import org.apache.ratis.util.FileUtils;
@@ -169,9 +169,9 @@ public abstract class ServerRestartTests<CLUSTER extends MiniRaftCluster>
   }
 
   static List<Path> getOpenLogFiles(RaftServer.Division server) throws Exception {
-    return server.getRaftStorage().getStorageDir().getLogSegmentFiles().stream()
-        .filter(LogPathAndIndex::isOpen)
-        .map(LogPathAndIndex::getPath)
+    return LogSegmentPath.getLogSegmentPaths(server.getRaftStorage()).stream()
+        .filter(p -> p.getStartEnd().isOpen())
+        .map(LogSegmentPath::getPath)
         .collect(Collectors.toList());
   }
 

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestRaftLogReadWrite.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestRaftLogReadWrite.java
@@ -103,7 +103,7 @@ public class TestRaftLogReadWrite extends BaseTest {
   @Test
   public void testReadWriteLog() throws IOException {
     final RaftStorage storage = RaftStorageTestUtils.newRaftStorage(storageDir);
-    File openSegment = storage.getStorageDir().getOpenLogFile(0);
+    final File openSegment = LogSegmentStartEnd.valueOf(0).getFile(storage);
     long size = SegmentedRaftLogFormat.getHeaderLength();
 
     final LogEntryProto[] entries = new LogEntryProto[100];
@@ -123,7 +123,7 @@ public class TestRaftLogReadWrite extends BaseTest {
   @Test
   public void testAppendLog() throws IOException {
     final RaftStorage storage = RaftStorageTestUtils.newRaftStorage(storageDir);
-    File openSegment = storage.getStorageDir().getOpenLogFile(0);
+    final File openSegment = LogSegmentStartEnd.valueOf(0).getFile(storage);
     LogEntryProto[] entries = new LogEntryProto[200];
     try (SegmentedRaftLogOutputStream out = new SegmentedRaftLogOutputStream(openSegment, false,
         segmentMaxSize, preallocatedSize, ByteBuffer.allocateDirect(bufferSize))) {
@@ -156,7 +156,7 @@ public class TestRaftLogReadWrite extends BaseTest {
   @Test
   public void testReadWithPadding() throws IOException {
     final RaftStorage storage = RaftStorageTestUtils.newRaftStorage(storageDir);
-    File openSegment = storage.getStorageDir().getOpenLogFile(0);
+    final File openSegment = LogSegmentStartEnd.valueOf(0).getFile(storage);
     long size = SegmentedRaftLogFormat.getHeaderLength();
 
     LogEntryProto[] entries = new LogEntryProto[100];
@@ -185,7 +185,7 @@ public class TestRaftLogReadWrite extends BaseTest {
   @Test
   public void testReadWithCorruptPadding() throws IOException {
     final RaftStorage storage = RaftStorageTestUtils.newRaftStorage(storageDir);
-    File openSegment = storage.getStorageDir().getOpenLogFile(0);
+    final File openSegment = LogSegmentStartEnd.valueOf(0).getFile(storage);
 
     LogEntryProto[] entries = new LogEntryProto[10];
     final SegmentedRaftLogOutputStream out = new SegmentedRaftLogOutputStream(openSegment, false,
@@ -234,7 +234,7 @@ public class TestRaftLogReadWrite extends BaseTest {
   @Test
   public void testReadWithEntryCorruption() throws IOException {
     RaftStorage storage = RaftStorageTestUtils.newRaftStorage(storageDir);
-    File openSegment = storage.getStorageDir().getOpenLogFile(0);
+    final File openSegment = LogSegmentStartEnd.valueOf(0).getFile(storage);
     try (SegmentedRaftLogOutputStream out = new SegmentedRaftLogOutputStream(openSegment, false,
         segmentMaxSize, preallocatedSize, ByteBuffer.allocateDirect(bufferSize))) {
       for (int i = 0; i < 100; i++) {

--- a/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
+++ b/ratis-test/src/test/java/org/apache/ratis/server/raftlog/segmented/TestSegmentedRaftLog.java
@@ -95,6 +95,10 @@ public class TestSegmentedRaftLog extends BaseTest {
       this.term = term;
       this.isOpen = isOpen;
     }
+
+    File getFile(RaftStorage storage) {
+      return LogSegmentStartEnd.valueOf(start, end, isOpen).getFile(storage);
+    }
   }
 
   private File storageDir;
@@ -147,10 +151,7 @@ public class TestSegmentedRaftLog extends BaseTest {
   private LogEntryProto[] prepareLog(List<SegmentRange> list) throws IOException {
     List<LogEntryProto> entryList = new ArrayList<>();
     for (SegmentRange range : list) {
-      File file = range.isOpen ?
-          storage.getStorageDir().getOpenLogFile(range.start) :
-          storage.getStorageDir().getClosedLogFile(range.start, range.end);
-
+      final File file = range.getFile(storage);
       final int size = (int) (range.end - range.start + 1);
       LogEntryProto[] entries = new LogEntryProto[size];
       try (SegmentedRaftLogOutputStream out = new SegmentedRaftLogOutputStream(file, false,

--- a/ratis-tools/src/main/java/org/apache/ratis/tools/ParseRatisLog.java
+++ b/ratis-tools/src/main/java/org/apache/ratis/tools/ParseRatisLog.java
@@ -22,8 +22,8 @@ import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.raftlog.LogProtoUtils;
+import org.apache.ratis.server.raftlog.segmented.LogSegmentPath;
 import org.apache.ratis.server.raftlog.segmented.LogSegment;
-import org.apache.ratis.server.storage.RaftStorageDirectory;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,14 +49,14 @@ public final class ParseRatisLog {
   }
 
   public void dumpSegmentFile() throws IOException {
-    RaftStorageDirectory.LogPathAndIndex pi = RaftStorageDirectory.processOnePath(file.toPath());
+    final LogSegmentPath pi = LogSegmentPath.matchLogSegment(file.toPath());
     if (pi == null) {
       System.out.println("Invalid segment file");
       return;
     }
 
     System.out.println("Processing Raft Log file: " + file.getAbsolutePath() + " size:" + file.length());
-    final int entryCount = LogSegment.readSegmentFile(file, pi.getStartIndex(), pi.getEndIndex(), pi.isOpen(),
+    final int entryCount = LogSegment.readSegmentFile(file, pi.getStartEnd(),
         RaftServerConfigKeys.Log.CorruptionPolicy.EXCEPTION, null, this::processLogEntry);
     System.out.println("Num Total Entries: " + entryCount);
     System.out.println("Num Conf Entries: " + numConfEntries);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1246