### PR TITLE
RATIS-1266. Leader send StartLeaderElectionRequest to higher priority peer

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -100,6 +100,13 @@ public class GrpcServerProtocolClient implements Closeable {
     return r;
   }
 
+  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) {
+    TimeoutNowReplyProto r =
+        blockingStub.withDeadlineAfter(requestTimeoutDuration.getDuration(), requestTimeoutDuration.getUnit())
+            .timeoutNow(request);
+    return r;
+  }
+
   StreamObserver<AppendEntriesRequestProto> appendEntries(
       StreamObserver<AppendEntriesReplyProto> responseHandler) {
     return asyncStub.appendEntries(responseHandler);

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolClient.java
@@ -100,10 +100,10 @@ public class GrpcServerProtocolClient implements Closeable {
     return r;
   }
 
-  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) {
-    TimeoutNowReplyProto r =
+  public StartLeaderElectionReplyProto startLeaderElection(StartLeaderElectionRequestProto request) {
+    StartLeaderElectionReplyProto r =
         blockingStub.withDeadlineAfter(requestTimeoutDuration.getDuration(), requestTimeoutDuration.getUnit())
-            .timeoutNow(request);
+            .startLeaderElection(request);
     return r;
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -177,14 +177,14 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
   }
 
   @Override
-  public void timeoutNow(TimeoutNowRequestProto request,
-      StreamObserver<TimeoutNowReplyProto> responseObserver) {
+  public void startLeaderElection(StartLeaderElectionRequestProto request,
+      StreamObserver<StartLeaderElectionReplyProto> responseObserver) {
     try {
-      final TimeoutNowReplyProto reply = server.timeoutNow(request);
+      final StartLeaderElectionReplyProto reply = server.startLeaderElection(request);
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
     } catch (Throwable e) {
-      GrpcUtil.warn(LOG, () -> getId() + ": Failed timeoutNow " + ProtoUtils.toString(request.getServerRequest()), e);
+      GrpcUtil.warn(LOG, () -> getId() + ": Failed startLeaderElection " + ProtoUtils.toString(request.getServerRequest()), e);
       responseObserver.onError(GrpcUtil.wrapException(e));
     }
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -184,7 +184,8 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
       responseObserver.onNext(reply);
       responseObserver.onCompleted();
     } catch (Throwable e) {
-      GrpcUtil.warn(LOG, () -> getId() + ": Failed startLeaderElection " + ProtoUtils.toString(request.getServerRequest()), e);
+      GrpcUtil.warn(LOG,
+          () -> getId() + ": Failed startLeaderElection " + ProtoUtils.toString(request.getServerRequest()), e);
       responseObserver.onError(GrpcUtil.wrapException(e));
     }
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -177,6 +177,19 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
   }
 
   @Override
+  public void timeoutNow(TimeoutNowRequestProto request,
+      StreamObserver<TimeoutNowReplyProto> responseObserver) {
+    try {
+      final TimeoutNowReplyProto reply = server.timeoutNow(request);
+      responseObserver.onNext(reply);
+      responseObserver.onCompleted();
+    } catch (Throwable e) {
+      GrpcUtil.warn(LOG, () -> getId() + ": Failed timeoutNow " + ProtoUtils.toString(request.getServerRequest()), e);
+      responseObserver.onError(GrpcUtil.wrapException(e));
+    }
+  }
+
+  @Override
   public StreamObserver<AppendEntriesRequestProto> appendEntries(
       StreamObserver<AppendEntriesReplyProto> responseObserver) {
     return new ServerRequestStreamObserver<AppendEntriesRequestProto, AppendEntriesReplyProto>(

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -225,10 +225,10 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
   }
 
   @Override
-  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
+  public StartLeaderElectionReplyProto startLeaderElection(StartLeaderElectionRequestProto request) throws IOException {
     CodeInjectionForTesting.execute(GRPC_SEND_SERVER_REQUEST, getId(), null, request);
 
     final RaftPeerId target = RaftPeerId.valueOf(request.getServerRequest().getReplyId());
-    return getProxies().getProxy(target).timeoutNow(request);
+    return getProxies().getProxy(target).startLeaderElection(request);
   }
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcService.java
@@ -223,4 +223,12 @@ public final class GrpcService extends RaftServerRpcWithProxy<GrpcServerProtocol
     final RaftPeerId target = RaftPeerId.valueOf(request.getServerRequest().getReplyId());
     return getProxies().getProxy(target).requestVote(request);
   }
+
+  @Override
+  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
+    CodeInjectionForTesting.execute(GRPC_SEND_SERVER_REQUEST, getId(), null, request);
+
+    final RaftPeerId target = RaftPeerId.valueOf(request.getServerRequest().getReplyId());
+    return getProxies().getProxy(target).timeoutNow(request);
+  }
 }

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/HadoopRpcService.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/HadoopRpcService.java
@@ -30,6 +30,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
 import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.HadoopServerProtocolService;
 import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.HadoopClientProtocolService;
 import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.ServerOps;
@@ -181,6 +183,13 @@ public final class HadoopRpcService extends RaftServerRpcWithProxy<Proxy<RaftSer
       RequestVoteRequestProto request) throws IOException {
     return processRequest(request, request.getServerRequest().getReplyId(),
         ServerOps.requestVote, RequestVoteReplyProto::parseFrom);
+  }
+
+  @Override
+  public TimeoutNowReplyProto timeoutNow(
+      TimeoutNowRequestProto request) throws IOException {
+    return processRequest(request, request.getServerRequest().getReplyId(),
+        ServerOps.timeoutNow, TimeoutNowReplyProto::parseFrom);
   }
 
   private <REQUEST extends GeneratedMessageV3, REPLY> REPLY processRequest(

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/HadoopRpcService.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/HadoopRpcService.java
@@ -30,8 +30,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
 import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.HadoopServerProtocolService;
 import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.HadoopClientProtocolService;
 import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.ServerOps;
@@ -186,10 +186,10 @@ public final class HadoopRpcService extends RaftServerRpcWithProxy<Proxy<RaftSer
   }
 
   @Override
-  public TimeoutNowReplyProto timeoutNow(
-      TimeoutNowRequestProto request) throws IOException {
+  public StartLeaderElectionReplyProto startLeaderElection(
+      StartLeaderElectionRequestProto request) throws IOException {
     return processRequest(request, request.getServerRequest().getReplyId(),
-        ServerOps.timeoutNow, TimeoutNowReplyProto::parseFrom);
+        ServerOps.startLeaderElection, StartLeaderElectionReplyProto::parseFrom);
   }
 
   private <REQUEST extends GeneratedMessageV3, REPLY> REPLY processRequest(

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/RaftServerProtocolServerSideTranslatorPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/RaftServerProtocolServerSideTranslatorPB.java
@@ -33,6 +33,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.GeneratedMessageV3;
 
 @InterfaceAudience.Private
@@ -53,6 +55,9 @@ public class RaftServerProtocolServerSideTranslatorPB
       switch (type) {
         case requestVote:
           respone = requestVote(RequestVoteRequestProto.parseFrom(buffer));
+          break;
+        case timeoutNow:
+          respone = timeoutNow(TimeoutNowRequestProto.parseFrom(buffer));
           break;
         case installSnapshot:
           respone = installSnapshot(InstallSnapshotRequestProto.parseFrom(buffer));
@@ -75,6 +80,10 @@ public class RaftServerProtocolServerSideTranslatorPB
   public RequestVoteReplyProto requestVote(RequestVoteRequestProto request)
       throws IOException {
     return impl.requestVote(request);
+  }
+
+  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
+    return impl.timeoutNow(request);
   }
 
   public AppendEntriesReplyProto appendEntries(AppendEntriesRequestProto request)

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/RaftServerProtocolServerSideTranslatorPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/server/RaftServerProtocolServerSideTranslatorPB.java
@@ -33,8 +33,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
 import org.apache.ratis.thirdparty.com.google.protobuf.GeneratedMessageV3;
 
 @InterfaceAudience.Private
@@ -56,8 +56,8 @@ public class RaftServerProtocolServerSideTranslatorPB
         case requestVote:
           respone = requestVote(RequestVoteRequestProto.parseFrom(buffer));
           break;
-        case timeoutNow:
-          respone = timeoutNow(TimeoutNowRequestProto.parseFrom(buffer));
+        case startLeaderElection:
+          respone = startLeaderElection(StartLeaderElectionRequestProto.parseFrom(buffer));
           break;
         case installSnapshot:
           respone = installSnapshot(InstallSnapshotRequestProto.parseFrom(buffer));
@@ -82,8 +82,8 @@ public class RaftServerProtocolServerSideTranslatorPB
     return impl.requestVote(request);
   }
 
-  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
-    return impl.timeoutNow(request);
+  public StartLeaderElectionReplyProto startLeaderElection(StartLeaderElectionRequestProto request) throws IOException {
+    return impl.startLeaderElection(request);
   }
 
   public AppendEntriesReplyProto appendEntries(AppendEntriesRequestProto request)

--- a/ratis-hadoop/src/main/proto/HadoopCompatability.proto
+++ b/ratis-hadoop/src/main/proto/HadoopCompatability.proto
@@ -34,7 +34,7 @@ enum ServerOps {
   requestVote = 1;
   appendEntries = 2;
   installSnapshot = 3;
-  timeoutNow = 4;
+  startLeaderElection = 4;
 }
 
 message ServerRequestProto {

--- a/ratis-hadoop/src/main/proto/HadoopCompatability.proto
+++ b/ratis-hadoop/src/main/proto/HadoopCompatability.proto
@@ -34,6 +34,7 @@ enum ServerOps {
   requestVote = 1;
   appendEntries = 2;
   installSnapshot = 3;
+  timeoutNow = 4;
 }
 
 message ServerRequestProto {

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyRpcProxy.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyRpcProxy.java
@@ -79,8 +79,8 @@ public class NettyRpcProxy implements Closeable {
     switch (proto.getRaftNettyServerReplyCase()) {
       case REQUESTVOTEREPLY:
         return proto.getRequestVoteReply().getServerReply().getCallId();
-      case TIMEOUTNOWREPLY:
-        return proto.getTimeoutNowReply().getServerReply().getCallId();
+      case STARTLEADERELECTIONREPLY:
+        return proto.getStartLeaderElectionReply().getServerReply().getCallId();
       case APPENDENTRIESREPLY:
         return proto.getAppendEntriesReply().getServerReply().getCallId();
       case INSTALLSNAPSHOTREPLY:

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyRpcProxy.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyRpcProxy.java
@@ -79,6 +79,8 @@ public class NettyRpcProxy implements Closeable {
     switch (proto.getRaftNettyServerReplyCase()) {
       case REQUESTVOTEREPLY:
         return proto.getRequestVoteReply().getServerReply().getCallId();
+      case TIMEOUTNOWREPLY:
+        return proto.getTimeoutNowReply().getServerReply().getCallId();
       case APPENDENTRIESREPLY:
         return proto.getAppendEntriesReply().getServerReply().getCallId();
       case INSTALLSNAPSHOTREPLY:

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -184,11 +184,11 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
               .setRaftClientReply(ClientProtoUtils.toRaftClientReplyProto(transferLeadershipReply))
               .build();
 
-        case TIMEOUTNOWREQUEST:
-          final TimeoutNowRequestProto timeoutNowRequest = proto.getTimeoutNowRequest();
-          rpcRequest = timeoutNowRequest.getServerRequest();
-          final TimeoutNowReplyProto timeoutNowReply = server.timeoutNow(timeoutNowRequest);
-          return RaftNettyServerReplyProto.newBuilder().setTimeoutNowReply(timeoutNowReply).build();
+        case STARTLEADERELECTIONREQUEST:
+          final StartLeaderElectionRequestProto startLeaderElectionRequest = proto.getStartLeaderElectionRequest();
+          rpcRequest = startLeaderElectionRequest.getServerRequest();
+          final StartLeaderElectionReplyProto startLeaderElectionReply = server.startLeaderElection(startLeaderElectionRequest);
+          return RaftNettyServerReplyProto.newBuilder().setStartLeaderElectionReply(startLeaderElectionReply).build();
 
         case APPENDENTRIESREQUEST:
           final AppendEntriesRequestProto appendEntriesRequest = proto.getAppendEntriesRequest();
@@ -290,14 +290,14 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
 
 
   @Override
-  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
+  public StartLeaderElectionReplyProto startLeaderElection(StartLeaderElectionRequestProto request) throws IOException {
     CodeInjectionForTesting.execute(SEND_SERVER_REQUEST, getId(), null, request);
 
     final RaftNettyServerRequestProto proto = RaftNettyServerRequestProto.newBuilder()
-        .setTimeoutNowRequest(request)
+        .setStartLeaderElectionRequest(request)
         .build();
     final RaftRpcRequestProto serverRequest = request.getServerRequest();
-    return sendRaftNettyServerRequestProto(serverRequest, proto).getTimeoutNowReply();
+    return sendRaftNettyServerRequestProto(serverRequest, proto).getStartLeaderElectionReply();
   }
 
   @Override

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -187,7 +187,8 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
         case STARTLEADERELECTIONREQUEST:
           final StartLeaderElectionRequestProto startLeaderElectionRequest = proto.getStartLeaderElectionRequest();
           rpcRequest = startLeaderElectionRequest.getServerRequest();
-          final StartLeaderElectionReplyProto startLeaderElectionReply = server.startLeaderElection(startLeaderElectionRequest);
+          final StartLeaderElectionReplyProto startLeaderElectionReply =
+              server.startLeaderElection(startLeaderElectionRequest);
           return RaftNettyServerReplyProto.newBuilder().setStartLeaderElectionReply(startLeaderElectionReply).build();
 
         case APPENDENTRIESREQUEST:

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/NettyRpcService.java
@@ -184,6 +184,12 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
               .setRaftClientReply(ClientProtoUtils.toRaftClientReplyProto(transferLeadershipReply))
               .build();
 
+        case TIMEOUTNOWREQUEST:
+          final TimeoutNowRequestProto timeoutNowRequest = proto.getTimeoutNowRequest();
+          rpcRequest = timeoutNowRequest.getServerRequest();
+          final TimeoutNowReplyProto timeoutNowReply = server.timeoutNow(timeoutNowRequest);
+          return RaftNettyServerReplyProto.newBuilder().setTimeoutNowReply(timeoutNowReply).build();
+
         case APPENDENTRIESREQUEST:
           final AppendEntriesRequestProto appendEntriesRequest = proto.getAppendEntriesRequest();
           rpcRequest = appendEntriesRequest.getServerRequest();
@@ -280,6 +286,18 @@ public final class NettyRpcService extends RaftServerRpcWithProxy<NettyRpcProxy,
         .build();
     final RaftRpcRequestProto serverRequest = request.getServerRequest();
     return sendRaftNettyServerRequestProto(serverRequest, proto).getRequestVoteReply();
+  }
+
+
+  @Override
+  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
+    CodeInjectionForTesting.execute(SEND_SERVER_REQUEST, getId(), null, request);
+
+    final RaftNettyServerRequestProto proto = RaftNettyServerRequestProto.newBuilder()
+        .setTimeoutNowRequest(request)
+        .build();
+    final RaftRpcRequestProto serverRequest = request.getServerRequest();
+    return sendRaftNettyServerRequestProto(serverRequest, proto).getTimeoutNowReply();
   }
 
   @Override

--- a/ratis-proto/src/main/proto/Grpc.proto
+++ b/ratis-proto/src/main/proto/Grpc.proto
@@ -44,6 +44,9 @@ service RaftServerProtocolService {
   rpc requestVote(ratis.common.RequestVoteRequestProto)
       returns(ratis.common.RequestVoteReplyProto) {}
 
+  rpc timeoutNow(ratis.common.TimeoutNowRequestProto)
+      returns(ratis.common.TimeoutNowReplyProto) {}
+
   rpc appendEntries(stream ratis.common.AppendEntriesRequestProto)
       returns(stream ratis.common.AppendEntriesReplyProto) {}
 

--- a/ratis-proto/src/main/proto/Grpc.proto
+++ b/ratis-proto/src/main/proto/Grpc.proto
@@ -44,8 +44,8 @@ service RaftServerProtocolService {
   rpc requestVote(ratis.common.RequestVoteRequestProto)
       returns(ratis.common.RequestVoteReplyProto) {}
 
-  rpc timeoutNow(ratis.common.TimeoutNowRequestProto)
-      returns(ratis.common.TimeoutNowReplyProto) {}
+  rpc startLeaderElection(ratis.common.StartLeaderElectionRequestProto)
+      returns(ratis.common.StartLeaderElectionReplyProto) {}
 
   rpc appendEntries(stream ratis.common.AppendEntriesRequestProto)
       returns(stream ratis.common.AppendEntriesReplyProto) {}

--- a/ratis-proto/src/main/proto/Netty.proto
+++ b/ratis-proto/src/main/proto/Netty.proto
@@ -39,7 +39,7 @@ message RaftNettyServerRequestProto {
     ratis.common.GroupListRequestProto groupListRequest = 7;
     ratis.common.GroupInfoRequestProto groupInfoRequest = 8;
     ratis.common.TransferLeadershipRequestProto transferLeadershipRequest = 9;
-    ratis.common.TimeoutNowRequestProto timeoutNowRequest = 10;
+    ratis.common.StartLeaderElectionRequestProto startLeaderElectionRequest = 10;
   }
 }
 
@@ -52,6 +52,6 @@ message RaftNettyServerReplyProto {
     ratis.common.GroupListReplyProto groupListReply = 5;
     ratis.common.GroupInfoReplyProto groupInfoReply = 6;
     RaftNettyExceptionReplyProto exceptionReply = 7;
-    ratis.common.TimeoutNowReplyProto timeoutNowReply = 8;
+    ratis.common.StartLeaderElectionReplyProto startLeaderElectionReply = 8;
   }
 }

--- a/ratis-proto/src/main/proto/Netty.proto
+++ b/ratis-proto/src/main/proto/Netty.proto
@@ -39,6 +39,7 @@ message RaftNettyServerRequestProto {
     ratis.common.GroupListRequestProto groupListRequest = 7;
     ratis.common.GroupInfoRequestProto groupInfoRequest = 8;
     ratis.common.TransferLeadershipRequestProto transferLeadershipRequest = 9;
+    ratis.common.TimeoutNowRequestProto timeoutNowRequest = 10;
   }
 }
 
@@ -51,5 +52,6 @@ message RaftNettyServerReplyProto {
     ratis.common.GroupListReplyProto groupListReply = 5;
     ratis.common.GroupInfoReplyProto groupInfoReply = 6;
     RaftNettyExceptionReplyProto exceptionReply = 7;
+    ratis.common.TimeoutNowReplyProto timeoutNowReply = 8;
   }
 }

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -392,6 +392,16 @@ message TransferLeadershipRequestProto {
   RaftPeerProto newLeader = 2;
 }
 
+message TimeoutNowRequestProto {
+  RaftRpcRequestProto serverRequest = 1;
+  uint64 leaderTerm = 2;
+  TermIndexProto leaderLastEntry = 3;
+}
+
+message TimeoutNowReplyProto {
+  RaftRpcReplyProto serverReply = 1;
+}
+
 // A request to add a new group
 message GroupAddRequestProto {
   RaftGroupProto group = 1; // the group to be added.

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -392,13 +392,13 @@ message TransferLeadershipRequestProto {
   RaftPeerProto newLeader = 2;
 }
 
-message TimeoutNowRequestProto {
+message StartLeaderElectionRequestProto {
   RaftRpcRequestProto serverRequest = 1;
   uint64 leaderTerm = 2;
   TermIndexProto leaderLastEntry = 3;
 }
 
-message TimeoutNowReplyProto {
+message StartLeaderElectionReplyProto {
   RaftRpcReplyProto serverReply = 1;
 }
 

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -394,8 +394,7 @@ message TransferLeadershipRequestProto {
 
 message StartLeaderElectionRequestProto {
   RaftRpcRequestProto serverRequest = 1;
-  uint64 leaderTerm = 2;
-  TermIndexProto leaderLastEntry = 3;
+  TermIndexProto leaderLastEntry = 2;
 }
 
 message StartLeaderElectionReplyProto {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/RaftServerProtocol.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/RaftServerProtocol.java
@@ -25,6 +25,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
 
 public interface RaftServerProtocol {
   enum Op {REQUEST_VOTE, APPEND_ENTRIES, INSTALL_SNAPSHOT}
@@ -34,4 +36,6 @@ public interface RaftServerProtocol {
   AppendEntriesReplyProto appendEntries(AppendEntriesRequestProto request) throws IOException;
 
   InstallSnapshotReplyProto installSnapshot(InstallSnapshotRequestProto request) throws IOException;
+
+  TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException;
 }

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/RaftServerProtocol.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/protocol/RaftServerProtocol.java
@@ -25,8 +25,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
 
 public interface RaftServerProtocol {
   enum Op {REQUEST_VOTE, APPEND_ENTRIES, INSTALL_SNAPSHOT}
@@ -37,5 +37,5 @@ public interface RaftServerProtocol {
 
   InstallSnapshotReplyProto installSnapshot(InstallSnapshotRequestProto request) throws IOException;
 
-  TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException;
+  StartLeaderElectionReplyProto startLeaderElection(StartLeaderElectionRequestProto request) throws IOException;
 }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -538,8 +538,8 @@ class LeaderStateImpl implements LeaderState {
     ServerState state = server.getState();
     TermIndex currLastEntry = state.getLastEntry();
     if (ServerState.compareLog(currLastEntry, lastEntry) != 0) {
-      LOG.warn("{} can not send StartLeaderElectionRequest to follower:{} because currLastEntry:{} did not match lastEntry:{}",
-          this, follower, currLastEntry, lastEntry);
+      LOG.warn("{} can not send StartLeaderElectionRequest to follower:{} because currLastEntry:{} " +
+              "did not match lastEntry:{}", this, follower, currLastEntry, lastEntry);
       return;
     }
 
@@ -885,8 +885,8 @@ class LeaderStateImpl implements LeaderState {
 
       final TermIndex leaderLastEntry = server.getState().getLastEntry();
       if (leaderLastEntry == null) {
-        LOG.info("{} send StartLeaderElectionRequest to follower:{} on term:{} because follower's priority:{} is higher than " +
-                "leader's:{} and leader's lastEntry is null",
+        LOG.info("{} send StartLeaderElectionRequest to follower:{} on term:{} because follower's priority:{} " +
+                "is higher than leader's:{} and leader's lastEntry is null",
             this, followerID, currentTerm, followerPriority, leaderPriority);
 
         sendStartLeaderElectionToHigherPriorityPeer(followerID, leaderLastEntry);
@@ -894,8 +894,8 @@ class LeaderStateImpl implements LeaderState {
       }
 
       if (followerInfo.getMatchIndex() >= leaderLastEntry.getIndex()) {
-        LOG.info("{} send StartLeaderElectionRequest to follower:{} on term:{} because follower's priority:{} is higher than " +
-                "leader's:{} and follower's lastEntry index:{} catch up with leader's:{}",
+        LOG.info("{} send StartLeaderElectionRequest to follower:{} on term:{} because follower's priority:{} " +
+                "is higher than leader's:{} and follower's lastEntry index:{} catch up with leader's:{}",
             this, followerID, currentTerm, followerPriority, leaderPriority, followerInfo.getMatchIndex(),
             leaderLastEntry.getIndex());
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -544,13 +544,12 @@ class LeaderStateImpl implements LeaderState {
     }
 
     final StartLeaderElectionRequestProto r = ServerProtoUtils.toStartLeaderElectionRequestProto(
-        server.getMemberId(), follower, state.getCurrentTerm(), lastEntry);
+        server.getMemberId(), follower, lastEntry);
     CompletableFuture.supplyAsync(() -> {
       try {
         StartLeaderElectionReplyProto replyProto = server.getServerRpc().startLeaderElection(r);
-        if (replyProto.getServerReply().getSuccess()) {
-          LOG.warn("{} received failed reply of StartLeaderElectionRequest from follower:{}", this, follower);
-        }
+        LOG.info("{} received {} reply of StartLeaderElectionRequest from follower:{}",
+            this, replyProto.getServerReply().getSuccess() ? "success" : "fail", follower);
       } catch (IOException e) {
         LOG.warn("{} send StartLeaderElectionRequest throw exception", this, e);
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1404,6 +1404,13 @@ class RaftServerImpl implements RaftServer.Division,
     assertGroup(leaderId, leaderGroupId);
 
     synchronized (this) {
+      // leaderLastEntry should not be null because LeaderStateImpl#start append a placeHolder entry
+      // so leader at each term should has at least one entry
+      if (leaderLastEntry == null) {
+        LOG.warn("{}: receive null leaderLastEntry which is unexpected", getMemberId());
+        return ServerProtoUtils.toStartLeaderElectionReplyProto(leaderId, getMemberId(), false);
+      }
+
       // Check life cycle state again to avoid the PAUSING/PAUSED state.
       assertLifeCycleState(LifeCycle.States.STARTING_OR_RUNNING);
       final boolean recognized = state.recognizeLeader(leaderId, leaderLastEntry.getTerm());

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -28,8 +28,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RaftRpcRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.protocol.exceptions.AlreadyExistsException;
@@ -547,8 +547,8 @@ class RaftServerProxy implements RaftServer {
   }
 
   @Override
-  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
-    return getImpl(request.getServerRequest()).timeoutNow(request);
+  public StartLeaderElectionReplyProto startLeaderElection(StartLeaderElectionRequestProto request) throws IOException {
+    return getImpl(request.getServerRequest()).startLeaderElection(request);
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -28,6 +28,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RaftRpcRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
 import org.apache.ratis.protocol.*;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.protocol.exceptions.AlreadyExistsException;
@@ -542,6 +544,11 @@ class RaftServerProxy implements RaftServer {
   @Override
   public RequestVoteReplyProto requestVote(RequestVoteRequestProto request) throws IOException {
     return getImpl(request.getServerRequest()).requestVote(request);
+  }
+
+  @Override
+  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
+    return getImpl(request.getServerRequest()).timeoutNow(request);
   }
 
   @Override

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
@@ -66,10 +66,9 @@ final class ServerProtoUtils {
   }
 
   static StartLeaderElectionRequestProto toStartLeaderElectionRequestProto(
-      RaftGroupMemberId requestorId, RaftPeerId replyId, long term, TermIndex lastEntry) {
+      RaftGroupMemberId requestorId, RaftPeerId replyId, TermIndex lastEntry) {
     final StartLeaderElectionRequestProto.Builder b = StartLeaderElectionRequestProto.newBuilder()
-        .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId))
-        .setLeaderTerm(term);
+        .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId));
     if (lastEntry != null) {
       b.setLeaderLastEntry(lastEntry.toProto());
     }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
@@ -58,6 +58,24 @@ final class ServerProtoUtils {
     return b.build();
   }
 
+  static TimeoutNowReplyProto toTimeoutNowReplyProto(
+      RaftPeerId requestorId, RaftGroupMemberId replyId, boolean success) {
+    return TimeoutNowReplyProto.newBuilder()
+        .setServerReply(toRaftRpcReplyProtoBuilder(requestorId, replyId, success))
+        .build();
+  }
+
+  static TimeoutNowRequestProto toTimeoutNowRequestProto(
+      RaftGroupMemberId requestorId, RaftPeerId replyId, long term, TermIndex lastEntry) {
+    final TimeoutNowRequestProto.Builder b = TimeoutNowRequestProto.newBuilder()
+        .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId))
+        .setLeaderTerm(term);
+    if (lastEntry != null) {
+      b.setLeaderLastEntry(lastEntry.toProto());
+    }
+    return b.build();
+  }
+
   static InstallSnapshotReplyProto toInstallSnapshotReplyProto(
       RaftPeerId requestorId, RaftGroupMemberId replyId,
       long currentTerm, int requestIndex, InstallSnapshotResult result) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerProtoUtils.java
@@ -58,16 +58,16 @@ final class ServerProtoUtils {
     return b.build();
   }
 
-  static TimeoutNowReplyProto toTimeoutNowReplyProto(
+  static StartLeaderElectionReplyProto toStartLeaderElectionReplyProto(
       RaftPeerId requestorId, RaftGroupMemberId replyId, boolean success) {
-    return TimeoutNowReplyProto.newBuilder()
+    return StartLeaderElectionReplyProto.newBuilder()
         .setServerReply(toRaftRpcReplyProtoBuilder(requestorId, replyId, success))
         .build();
   }
 
-  static TimeoutNowRequestProto toTimeoutNowRequestProto(
+  static StartLeaderElectionRequestProto toStartLeaderElectionRequestProto(
       RaftGroupMemberId requestorId, RaftPeerId replyId, long term, TermIndex lastEntry) {
-    final TimeoutNowRequestProto.Builder b = TimeoutNowRequestProto.newBuilder()
+    final StartLeaderElectionRequestProto.Builder b = StartLeaderElectionRequestProto.newBuilder()
         .setServerRequest(ClientProtoUtils.toRaftRpcRequestProtoBuilder(requestorId, replyId))
         .setLeaderTerm(term);
     if (lastEntry != null) {

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/BlockRequestHandlingInjection.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/BlockRequestHandlingInjection.java
@@ -33,6 +33,7 @@ public class BlockRequestHandlingInjection implements CodeInjectionForTesting.Co
     CodeInjectionForTesting.put(RaftServerImpl.REQUEST_VOTE, INSTANCE);
     CodeInjectionForTesting.put(RaftServerImpl.APPEND_ENTRIES, INSTANCE);
     CodeInjectionForTesting.put(RaftServerImpl.INSTALL_SNAPSHOT, INSTANCE);
+    CodeInjectionForTesting.put(RaftServerImpl.START_LEADER_ELECTION, INSTANCE);
   }
 
   public static BlockRequestHandlingInjection getInstance() {

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/RaftServerReply.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/RaftServerReply.java
@@ -17,11 +17,13 @@
  */
 package org.apache.ratis.server.simulation;
 
+import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftRpcMessage;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
 import org.apache.ratis.util.ProtoUtils;
 
 import java.util.Objects;
@@ -30,23 +32,34 @@ public class RaftServerReply implements RaftRpcMessage {
   private final AppendEntriesReplyProto appendEntries;
   private final RequestVoteReplyProto requestVote;
   private final InstallSnapshotReplyProto installSnapshot;
+  private final TimeoutNowReplyProto timeoutNow;
 
   RaftServerReply(AppendEntriesReplyProto a) {
     appendEntries = Objects.requireNonNull(a);
     requestVote = null;
     installSnapshot = null;
+    timeoutNow = null;
   }
 
   RaftServerReply(RequestVoteReplyProto r) {
     appendEntries = null;
     requestVote = Objects.requireNonNull(r);
     installSnapshot = null;
+    timeoutNow = null;
   }
 
   RaftServerReply(InstallSnapshotReplyProto i) {
     appendEntries = null;
     requestVote = null;
     installSnapshot = Objects.requireNonNull(i);
+    timeoutNow = null;
+  }
+
+  RaftServerReply(TimeoutNowReplyProto i) {
+    appendEntries = null;
+    requestVote = null;
+    installSnapshot = null;
+    timeoutNow = Objects.requireNonNull(i);
   }
 
   boolean isAppendEntries() {
@@ -61,6 +74,10 @@ public class RaftServerReply implements RaftRpcMessage {
     return installSnapshot != null;
   }
 
+  boolean isTimeoutNow() {
+    return timeoutNow != null;
+  }
+
   AppendEntriesReplyProto getAppendEntries() {
     return appendEntries;
   }
@@ -71,6 +88,10 @@ public class RaftServerReply implements RaftRpcMessage {
 
   InstallSnapshotReplyProto getInstallSnapshot() {
     return installSnapshot;
+  }
+
+  TimeoutNowReplyProto getTimeoutNow() {
+    return timeoutNow;
   }
 
   @Override
@@ -84,8 +105,10 @@ public class RaftServerReply implements RaftRpcMessage {
       return appendEntries.getServerReply().getRequestorId().toStringUtf8();
     } else if (isRequestVote()) {
       return requestVote.getServerReply().getRequestorId().toStringUtf8();
-    } else {
+    } else if (isInstallSnapshot()) {
       return installSnapshot.getServerReply().getRequestorId().toStringUtf8();
+    } else {
+      return timeoutNow.getServerReply().getRequestorId().toStringUtf8();
     }
   }
 
@@ -95,8 +118,10 @@ public class RaftServerReply implements RaftRpcMessage {
       return appendEntries.getServerReply().getReplyId().toStringUtf8();
     } else if (isRequestVote()) {
       return requestVote.getServerReply().getReplyId().toStringUtf8();
-    } else {
+    } else if (isInstallSnapshot()) {
       return installSnapshot.getServerReply().getReplyId().toStringUtf8();
+    } else {
+      return timeoutNow.getServerReply().getReplyId().toStringUtf8();
     }
   }
 
@@ -106,8 +131,10 @@ public class RaftServerReply implements RaftRpcMessage {
       return ProtoUtils.toRaftGroupId(appendEntries.getServerReply().getRaftGroupId());
     } else if (isRequestVote()) {
       return ProtoUtils.toRaftGroupId(requestVote.getServerReply().getRaftGroupId());
-    } else {
+    } else if (isInstallSnapshot()) {
       return ProtoUtils.toRaftGroupId(installSnapshot.getServerReply().getRaftGroupId());
+    } else {
+      return ProtoUtils.toRaftGroupId(timeoutNow.getServerReply().getRaftGroupId());
     }
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/RaftServerReply.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/RaftServerReply.java
@@ -23,7 +23,7 @@ import org.apache.ratis.protocol.RaftRpcMessage;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
 import org.apache.ratis.util.ProtoUtils;
 
 import java.util.Objects;
@@ -32,34 +32,34 @@ public class RaftServerReply implements RaftRpcMessage {
   private final AppendEntriesReplyProto appendEntries;
   private final RequestVoteReplyProto requestVote;
   private final InstallSnapshotReplyProto installSnapshot;
-  private final TimeoutNowReplyProto timeoutNow;
+  private final StartLeaderElectionReplyProto startLeaderElection;
 
   RaftServerReply(AppendEntriesReplyProto a) {
     appendEntries = Objects.requireNonNull(a);
     requestVote = null;
     installSnapshot = null;
-    timeoutNow = null;
+    startLeaderElection = null;
   }
 
   RaftServerReply(RequestVoteReplyProto r) {
     appendEntries = null;
     requestVote = Objects.requireNonNull(r);
     installSnapshot = null;
-    timeoutNow = null;
+    startLeaderElection = null;
   }
 
   RaftServerReply(InstallSnapshotReplyProto i) {
     appendEntries = null;
     requestVote = null;
     installSnapshot = Objects.requireNonNull(i);
-    timeoutNow = null;
+    startLeaderElection = null;
   }
 
-  RaftServerReply(TimeoutNowReplyProto i) {
+  RaftServerReply(StartLeaderElectionReplyProto i) {
     appendEntries = null;
     requestVote = null;
     installSnapshot = null;
-    timeoutNow = Objects.requireNonNull(i);
+    startLeaderElection = Objects.requireNonNull(i);
   }
 
   boolean isAppendEntries() {
@@ -74,8 +74,8 @@ public class RaftServerReply implements RaftRpcMessage {
     return installSnapshot != null;
   }
 
-  boolean isTimeoutNow() {
-    return timeoutNow != null;
+  boolean isStartLeaderElection() {
+    return startLeaderElection != null;
   }
 
   AppendEntriesReplyProto getAppendEntries() {
@@ -90,8 +90,8 @@ public class RaftServerReply implements RaftRpcMessage {
     return installSnapshot;
   }
 
-  TimeoutNowReplyProto getTimeoutNow() {
-    return timeoutNow;
+  StartLeaderElectionReplyProto getStartLeaderElection() {
+    return startLeaderElection;
   }
 
   @Override
@@ -108,7 +108,7 @@ public class RaftServerReply implements RaftRpcMessage {
     } else if (isInstallSnapshot()) {
       return installSnapshot.getServerReply().getRequestorId().toStringUtf8();
     } else {
-      return timeoutNow.getServerReply().getRequestorId().toStringUtf8();
+      return startLeaderElection.getServerReply().getRequestorId().toStringUtf8();
     }
   }
 
@@ -121,7 +121,7 @@ public class RaftServerReply implements RaftRpcMessage {
     } else if (isInstallSnapshot()) {
       return installSnapshot.getServerReply().getReplyId().toStringUtf8();
     } else {
-      return timeoutNow.getServerReply().getReplyId().toStringUtf8();
+      return startLeaderElection.getServerReply().getReplyId().toStringUtf8();
     }
   }
 
@@ -134,7 +134,7 @@ public class RaftServerReply implements RaftRpcMessage {
     } else if (isInstallSnapshot()) {
       return ProtoUtils.toRaftGroupId(installSnapshot.getServerReply().getRaftGroupId());
     } else {
-      return ProtoUtils.toRaftGroupId(timeoutNow.getServerReply().getRaftGroupId());
+      return ProtoUtils.toRaftGroupId(startLeaderElection.getServerReply().getRaftGroupId());
     }
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/RaftServerRequest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/RaftServerRequest.java
@@ -22,41 +22,41 @@ import org.apache.ratis.protocol.RaftRpcMessage;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
 import org.apache.ratis.util.ProtoUtils;
 
 class RaftServerRequest implements RaftRpcMessage {
   private final AppendEntriesRequestProto appendEntries;
   private final RequestVoteRequestProto requestVote;
   private final InstallSnapshotRequestProto installSnapshot;
-  private final TimeoutNowRequestProto timeoutNow;
+  private final StartLeaderElectionRequestProto startLeaderElection;
 
   RaftServerRequest(AppendEntriesRequestProto a) {
     appendEntries = a;
     requestVote = null;
     installSnapshot = null;
-    timeoutNow = null;
+    startLeaderElection = null;
   }
 
   RaftServerRequest(RequestVoteRequestProto r) {
     appendEntries = null;
     requestVote = r;
     installSnapshot = null;
-    timeoutNow = null;
+    startLeaderElection = null;
   }
 
   RaftServerRequest(InstallSnapshotRequestProto i) {
     appendEntries = null;
     requestVote = null;
     installSnapshot = i;
-    timeoutNow = null;
+    startLeaderElection = null;
   }
 
-  RaftServerRequest(TimeoutNowRequestProto i) {
+  RaftServerRequest(StartLeaderElectionRequestProto i) {
     appendEntries = null;
     requestVote = null;
     installSnapshot = null;
-    timeoutNow = i;
+    startLeaderElection = i;
   }
 
   boolean isAppendEntries() {
@@ -71,8 +71,8 @@ class RaftServerRequest implements RaftRpcMessage {
     return installSnapshot != null;
   }
 
-  boolean isTimeoutNow() {
-    return timeoutNow != null;
+  boolean isStartLeaderElection() {
+    return startLeaderElection != null;
   }
 
   AppendEntriesRequestProto getAppendEntries() {
@@ -87,8 +87,8 @@ class RaftServerRequest implements RaftRpcMessage {
     return installSnapshot;
   }
 
-  TimeoutNowRequestProto getTimeoutNow() {
-    return timeoutNow;
+  StartLeaderElectionRequestProto getStartLeaderElection() {
+    return startLeaderElection;
   }
 
   @Override
@@ -105,7 +105,7 @@ class RaftServerRequest implements RaftRpcMessage {
     } else if (isInstallSnapshot()) {
       return installSnapshot.getServerRequest().getRequestorId().toStringUtf8();
     } else {
-      return timeoutNow.getServerRequest().getRequestorId().toStringUtf8();
+      return startLeaderElection.getServerRequest().getRequestorId().toStringUtf8();
     }
   }
 
@@ -118,7 +118,7 @@ class RaftServerRequest implements RaftRpcMessage {
     } else if (isInstallSnapshot()) {
       return installSnapshot.getServerRequest().getReplyId().toStringUtf8();
     } else {
-      return timeoutNow.getServerRequest().getReplyId().toStringUtf8();
+      return startLeaderElection.getServerRequest().getReplyId().toStringUtf8();
     }
   }
 
@@ -131,7 +131,7 @@ class RaftServerRequest implements RaftRpcMessage {
     } else if (isInstallSnapshot()) {
       return ProtoUtils.toRaftGroupId(installSnapshot.getServerRequest().getRaftGroupId());
     } else {
-      return ProtoUtils.toRaftGroupId(timeoutNow.getServerRequest().getRaftGroupId());
+      return ProtoUtils.toRaftGroupId(startLeaderElection.getServerRequest().getRaftGroupId());
     }
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/RaftServerRequest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/RaftServerRequest.java
@@ -22,29 +22,41 @@ import org.apache.ratis.protocol.RaftRpcMessage;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
 import org.apache.ratis.util.ProtoUtils;
 
 class RaftServerRequest implements RaftRpcMessage {
   private final AppendEntriesRequestProto appendEntries;
   private final RequestVoteRequestProto requestVote;
   private final InstallSnapshotRequestProto installSnapshot;
+  private final TimeoutNowRequestProto timeoutNow;
 
   RaftServerRequest(AppendEntriesRequestProto a) {
     appendEntries = a;
     requestVote = null;
     installSnapshot = null;
+    timeoutNow = null;
   }
 
   RaftServerRequest(RequestVoteRequestProto r) {
     appendEntries = null;
     requestVote = r;
     installSnapshot = null;
+    timeoutNow = null;
   }
 
   RaftServerRequest(InstallSnapshotRequestProto i) {
     appendEntries = null;
     requestVote = null;
     installSnapshot = i;
+    timeoutNow = null;
+  }
+
+  RaftServerRequest(TimeoutNowRequestProto i) {
+    appendEntries = null;
+    requestVote = null;
+    installSnapshot = null;
+    timeoutNow = i;
   }
 
   boolean isAppendEntries() {
@@ -59,6 +71,10 @@ class RaftServerRequest implements RaftRpcMessage {
     return installSnapshot != null;
   }
 
+  boolean isTimeoutNow() {
+    return timeoutNow != null;
+  }
+
   AppendEntriesRequestProto getAppendEntries() {
     return appendEntries;
   }
@@ -69,6 +85,10 @@ class RaftServerRequest implements RaftRpcMessage {
 
   InstallSnapshotRequestProto getInstallSnapshot() {
     return installSnapshot;
+  }
+
+  TimeoutNowRequestProto getTimeoutNow() {
+    return timeoutNow;
   }
 
   @Override
@@ -82,8 +102,10 @@ class RaftServerRequest implements RaftRpcMessage {
       return appendEntries.getServerRequest().getRequestorId().toStringUtf8();
     } else if (isRequestVote()) {
       return requestVote.getServerRequest().getRequestorId().toStringUtf8();
-    } else {
+    } else if (isInstallSnapshot()) {
       return installSnapshot.getServerRequest().getRequestorId().toStringUtf8();
+    } else {
+      return timeoutNow.getServerRequest().getRequestorId().toStringUtf8();
     }
   }
 
@@ -93,8 +115,10 @@ class RaftServerRequest implements RaftRpcMessage {
       return appendEntries.getServerRequest().getReplyId().toStringUtf8();
     } else if (isRequestVote()) {
       return requestVote.getServerRequest().getReplyId().toStringUtf8();
-    } else {
+    } else if (isInstallSnapshot()) {
       return installSnapshot.getServerRequest().getReplyId().toStringUtf8();
+    } else {
+      return timeoutNow.getServerRequest().getReplyId().toStringUtf8();
     }
   }
 
@@ -104,8 +128,10 @@ class RaftServerRequest implements RaftRpcMessage {
       return ProtoUtils.toRaftGroupId(appendEntries.getServerRequest().getRaftGroupId());
     } else if (isRequestVote()) {
       return ProtoUtils.toRaftGroupId(requestVote.getServerRequest().getRaftGroupId());
-    } else {
+    } else if (isInstallSnapshot()) {
       return ProtoUtils.toRaftGroupId(installSnapshot.getServerRequest().getRaftGroupId());
+    } else {
+      return ProtoUtils.toRaftGroupId(timeoutNow.getServerRequest().getRaftGroupId());
     }
   }
 }

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedServerRpc.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedServerRpc.java
@@ -24,8 +24,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
 import org.apache.ratis.protocol.GroupInfoRequest;
 import org.apache.ratis.protocol.GroupListRequest;
 import org.apache.ratis.protocol.GroupManagementRequest;
@@ -129,10 +129,10 @@ class SimulatedServerRpc implements RaftServerRpc {
   }
 
   @Override
-  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request)
+  public StartLeaderElectionReplyProto startLeaderElection(StartLeaderElectionRequestProto request)
       throws IOException {
     RaftServerReply reply = serverHandler.getRpc().sendRequest(new RaftServerRequest(request));
-    return reply.getTimeoutNow();
+    return reply.getStartLeaderElection();
   }
 
   @Override
@@ -161,8 +161,8 @@ class SimulatedServerRpc implements RaftServerRpc {
         return new RaftServerReply(server.requestVote(r.getRequestVote()));
       } else if (r.isInstallSnapshot()) {
         return new RaftServerReply(server.installSnapshot(r.getInstallSnapshot()));
-      } else if (r.isTimeoutNow()) {
-        return new RaftServerReply(server.timeoutNow(r.getTimeoutNow()));
+      } else if (r.isStartLeaderElection()) {
+        return new RaftServerReply(server.startLeaderElection(r.getStartLeaderElection()));
       } else {
         throw new IllegalStateException("unexpected state");
       }

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedServerRpc.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/SimulatedServerRpc.java
@@ -17,12 +17,15 @@
  */
 package org.apache.ratis.server.simulation;
 
+import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
 import org.apache.ratis.protocol.GroupInfoRequest;
 import org.apache.ratis.protocol.GroupListRequest;
 import org.apache.ratis.protocol.GroupManagementRequest;
@@ -126,6 +129,13 @@ class SimulatedServerRpc implements RaftServerRpc {
   }
 
   @Override
+  public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request)
+      throws IOException {
+    RaftServerReply reply = serverHandler.getRpc().sendRequest(new RaftServerRequest(request));
+    return reply.getTimeoutNow();
+  }
+
+  @Override
   public void addRaftPeers(Collection<RaftPeer> peers) {
     // do nothing
   }
@@ -151,6 +161,8 @@ class SimulatedServerRpc implements RaftServerRpc {
         return new RaftServerReply(server.requestVote(r.getRequestVote()));
       } else if (r.isInstallSnapshot()) {
         return new RaftServerReply(server.installSnapshot(r.getInstallSnapshot()));
+      } else if (r.isTimeoutNow()) {
+        return new RaftServerReply(server.timeoutNow(r.getTimeoutNow()));
       } else {
         throw new IllegalStateException("unexpected state");
       }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -39,6 +39,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
+import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.ClientInvocationId;
 import org.apache.ratis.protocol.DataStreamReply;
@@ -253,6 +255,11 @@ abstract class DataStreamBaseTest extends BaseTest {
       }
 
       @Override
+      public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
+        return null;
+      }
+
+    @Override
       public CompletableFuture<AppendEntriesReplyProto> appendEntriesAsync(AppendEntriesRequestProto request) {
         return null;
       }

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/DataStreamBaseTest.java
@@ -39,8 +39,8 @@ import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowReplyProto;
-import org.apache.ratis.proto.RaftProtos.TimeoutNowRequestProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionReplyProto;
+import org.apache.ratis.proto.RaftProtos.StartLeaderElectionRequestProto;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.ClientInvocationId;
 import org.apache.ratis.protocol.DataStreamReply;
@@ -255,7 +255,7 @@ abstract class DataStreamBaseTest extends BaseTest {
       }
 
       @Override
-      public TimeoutNowReplyProto timeoutNow(TimeoutNowRequestProto request) throws IOException {
+      public StartLeaderElectionReplyProto startLeaderElection(StartLeaderElectionRequestProto request) throws IOException {
         return null;
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Leader send TimeoutNow request to higher priority peer

For example, there are 3 servers, server1 with priority 1 and is leader, server2 with priority 2 and is follower. 
If server1 find server2's log catch up, server1 send TimeoutNowRequest to server2, and server2 become candidate and ask for vote, most case only server2 is candidate, so server2 can win the election directly. Compared to server1 stepDown to follower, and some server wait timeout and become candidate, TimeoutNowRequest can save the election time.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1266

## How was this patch tested?

no need new ut.
