### PR TITLE
RATIS-1268. Fix leader can not vote for candidate

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1054,11 +1054,10 @@ class RaftServerImpl implements RaftServer.Division,
             fs != null? fs.getLastRpcTime().elapsedTimeMs() + "ms": null);
       } else if (state.recognizeCandidate(candidateId, candidateTerm)) {
         final boolean termUpdated = changeToFollower(candidateTerm, true, "recognizeCandidate:" + candidateId);
-        if (fs == null) {
-          // if current server is leader, before changeToFollower FollowerState should be null,
-          // so after leader changeToFollower we should get FollowerState again.
-          fs = role.getFollowerState().orElse(null);
-        }
+        // if current server is leader, before changeToFollower FollowerState should be null,
+        // so after leader changeToFollower we should get FollowerState again.
+        fs = role.getFollowerState().orElse(null);
+
         // see Section 5.4.1 Election restriction
         RaftPeer candidate = getRaftConf().getPeer(candidateId);
         if (fs != null && candidate != null) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -1047,13 +1047,18 @@ class RaftServerImpl implements RaftServer.Division,
     synchronized (this) {
       // Check life cycle state again to avoid the PAUSING/PAUSED state.
       assertLifeCycleState(LifeCycle.States.RUNNING);
-      final FollowerState fs = role.getFollowerState().orElse(null);
+      FollowerState fs = role.getFollowerState().orElse(null);
       if (shouldWithholdVotes(candidateTerm)) {
         LOG.info("{}-{}: Withhold vote from candidate {} with term {}. State: leader={}, term={}, lastRpcElapsed={}",
             getMemberId(), role, candidateId, candidateTerm, state.getLeaderId(), state.getCurrentTerm(),
             fs != null? fs.getLastRpcTime().elapsedTimeMs() + "ms": null);
       } else if (state.recognizeCandidate(candidateId, candidateTerm)) {
         final boolean termUpdated = changeToFollower(candidateTerm, true, "recognizeCandidate:" + candidateId);
+        if (fs == null) {
+          // if current server is leader, before changeToFollower FollowerState should be null,
+          // so after leader changeToFollower we should get FollowerState again.
+          fs = role.getFollowerState().orElse(null);
+        }
         // see Section 5.4.1 Election restriction
         RaftPeer candidate = getRaftConf().getPeer(candidateId);
         if (fs != null && candidate != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

**What's the problem ?**
For example, when s0 is leader, and s1 askForVote, in the first rpc of askForVote, s0 can not vote for s1, even though s1's log catch up. When s1 askForVote the second time, s0 has become follower in the first askForVote, so s0 can vote for s1, waste one rpc call.

**What's the reason ?**
As the following code shows, when s0 is leader, `role.getFollowerState().orElse(null)` should return null,
then can not pass check `if (fs != null && candidate != null)` because fs is null,  so s0 can not vote for s1.
```
      FollowerState fs = role.getFollowerState().orElse(null);
      if (shouldWithholdVotes(candidateTerm)) {
        ...
      } else if (state.recognizeCandidate(candidateId, candidateTerm)) {
        final boolean termUpdated = changeToFollower(candidateTerm, true, "recognizeCandidate:" + candidateId);
        RaftPeer candidate = getRaftConf().getPeer(candidateId);
        if (fs != null && candidate != null) {
         ...
       }
```

**How to fix ?**

After leader `final boolean termUpdated = changeToFollower(candidateTerm, true, "recognizeCandidate:" + candidateId);`, we can get fs again.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1268

## How was this patch tested?

no need to add new ut.