### PR TITLE
RATIS-1274. Close DataStreamClient when close RaftClient

### DIFF
--- a/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/api/DataStreamApi.java
@@ -19,6 +19,7 @@ package org.apache.ratis.client.api;
 
 import org.apache.ratis.protocol.RoutingTable;
 
+import java.io.Closeable;
 import java.nio.ByteBuffer;
 
 /**
@@ -38,7 +39,7 @@ import java.nio.ByteBuffer;
  * this API streams data to all the servers in the {@link org.apache.ratis.protocol.RaftGroup}
  * but {@link MessageStreamApi} streams messages only to the leader.
  */
-public interface DataStreamApi {
+public interface DataStreamApi extends Closeable {
   /** Create a stream to write data. */
   default DataStreamOutput stream() {
     return stream(null);

--- a/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
+++ b/ratis-client/src/main/java/org/apache/ratis/client/impl/RaftClientImpl.java
@@ -40,6 +40,7 @@ import org.apache.ratis.protocol.exceptions.ResourceUnavailableException;
 import org.apache.ratis.retry.RetryPolicy;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.JavaUtils;
+import org.apache.ratis.util.MemoizedSupplier;
 import org.apache.ratis.util.TimeDuration;
 import org.apache.ratis.util.TimeoutScheduler;
 
@@ -128,7 +129,7 @@ public final class RaftClientImpl implements RaftClient {
   private final Supplier<AsyncImpl> asyncApi;
   private final Supplier<BlockingImpl> blockingApi;
   private final Supplier<MessageStreamImpl> messageStreamApi;
-  private final Supplier<DataStreamApi> dataStreamApi;
+  private final MemoizedSupplier<DataStreamApi> dataStreamApi;
 
   private final Supplier<AdminImpl> adminApi;
   private final ConcurrentMap<RaftPeerId, GroupManagementImpl> groupManagmenets = new ConcurrentHashMap<>();
@@ -345,5 +346,8 @@ public final class RaftClientImpl implements RaftClient {
   public void close() throws IOException {
     scheduler.close();
     clientRpc.close();
+    if (dataStreamApi.isInitialized()) {
+      dataStreamApi.get().close();
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When create dataStreamApi in RaftClientImpl, we need to create DataStreamClient, so we need to  close DataStreamClient when close RaftClient. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1274

## How was this patch tested?

no need new ut
