### PR TITLE
RATIS-1275. Add slf4j-log4j12 runtime dependency to ratis-example.

### DIFF
--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -123,6 +123,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RetryCacheTestUtil.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RetryCacheTestUtil.java
@@ -31,7 +31,7 @@ import org.junit.Assert;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1275