### PR TITLE
RATIS-1276. Use ClientInvocationId as key instead of StreamMap.Key

### DIFF
--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -322,12 +322,12 @@ message DataStreamPacketHeaderProto {
     CLOSE = 1;
   }
 
-  uint64 streamId = 1;
-  uint64 streamOffset = 2;
-  Type type = 3;
-  repeated Option options = 4;
+  bytes clientId = 1;
+  Type type = 2;
+  uint64 streamId = 3;
+  uint64 streamOffset = 4;
   uint64 dataLength = 5;
-  bytes clientId = 6;
+  repeated Option options = 6;
 }
 
 message DataStreamRequestHeaderProto {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use ClientInvocationId as key instead of StreamMap.Key

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1276

## How was this patch tested?

no need new ut
