### PR TITLE
RATIS-1278. Resource leak when decoding DataStreamReplyByteBuffer.

### DIFF
--- a/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/NettyDataStreamUtils.java
@@ -119,12 +119,18 @@ public interface NettyDataStreamUtils {
         .orElse(null);
   }
 
+  static ByteBuffer copy(ByteBuf buf) {
+    final byte[] bytes = new byte[buf.readableBytes()];
+    buf.readBytes(bytes);
+    return ByteBuffer.wrap(bytes);
+  }
+
   static DataStreamReplyByteBuffer decodeDataStreamReplyByteBuffer(ByteBuf buf) {
     return Optional.ofNullable(DataStreamReplyHeader.read(buf))
         .map(header -> checkHeader(header, buf))
         .map(header -> DataStreamReplyByteBuffer.newBuilder()
             .setDataStreamReplyHeader(header)
-            .setBuffer(decodeData(buf, header, b -> b.copy().nioBuffer()))
+            .setBuffer(decodeData(buf, header, NettyDataStreamUtils::copy))
             .build())
         .orElse(null);
   }


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1278