### PR TITLE
RATIS-1281. TestRetryCacheWithGrpc#testRetryOnResourceUnavailableException fails

### DIFF
--- a/ratis-test/src/test/java/org/apache/ratis/grpc/TestRetryCacheWithGrpc.java
+++ b/ratis-test/src/test/java/org/apache/ratis/grpc/TestRetryCacheWithGrpc.java
@@ -81,9 +81,12 @@ public class TestRetryCacheWithGrpc
     while (failure.get()) {
       try {
         // retry until the request failed with ResourceUnavailableException succeeds.
-        leaderProxy.submitClientRequestAsync(r).get();
+        RaftClientReply reply = leaderProxy.submitClientRequestAsync(r).get();
+        if (reply.isSuccess()) {
+          failure.set(false);
+        }
       } catch (Exception e) {
-        failure.set(false);
+        // Ignore the exception
       }
     }
     cluster.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA

(Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. RATIS-XXXX. Fix a typo in YYY.)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
