### PR TITLE
RATIS-1286. Move setConfiguration and transferLeadership to admin GRPC calls

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/AdminAsynchronousProtocol.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/AdminAsynchronousProtocol.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.protocol;
 
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 /** Asynchronous version of {@link AdminProtocol}. */
@@ -26,4 +27,10 @@ public interface AdminAsynchronousProtocol {
   CompletableFuture<GroupInfoReply> getGroupInfoAsync(GroupInfoRequest request);
 
   CompletableFuture<RaftClientReply> groupManagementAsync(GroupManagementRequest request);
+
+  CompletableFuture<RaftClientReply> setConfigurationAsync(
+      SetConfigurationRequest request) throws IOException;
+
+  CompletableFuture<RaftClientReply> transferLeadershipAsync(
+      TransferLeadershipRequest request) throws IOException;
 }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/AdminProtocol.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/AdminProtocol.java
@@ -26,4 +26,8 @@ public interface AdminProtocol {
   GroupInfoReply getGroupInfo(GroupInfoRequest request) throws IOException;
 
   RaftClientReply groupManagement(GroupManagementRequest request) throws IOException;
+
+  RaftClientReply setConfiguration(SetConfigurationRequest request) throws IOException;
+
+  RaftClientReply transferLeadership(TransferLeadershipRequest request) throws IOException;
 }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientAsynchronousProtocol.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientAsynchronousProtocol.java
@@ -25,9 +25,4 @@ public interface RaftClientAsynchronousProtocol {
   CompletableFuture<RaftClientReply> submitClientRequestAsync(
       RaftClientRequest request) throws IOException;
 
-  CompletableFuture<RaftClientReply> setConfigurationAsync(
-      SetConfigurationRequest request) throws IOException;
-
-  CompletableFuture<RaftClientReply> transferLeadershipAsync(
-      TransferLeadershipRequest request) throws IOException;
 }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientProtocol.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftClientProtocol.java
@@ -21,8 +21,4 @@ import java.io.IOException;
 
 public interface RaftClientProtocol {
   RaftClientReply submitClientRequest(RaftClientRequest request) throws IOException;
-
-  RaftClientReply setConfiguration(SetConfigurationRequest request) throws IOException;
-
-  RaftClientReply transferLeadership(TransferLeadershipRequest request) throws IOException;
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
@@ -172,10 +172,9 @@ public class GrpcClientProtocolClient implements Closeable {
         .groupInfo(request);
   }
 
-
   RaftClientReplyProto setConfiguration(
       SetConfigurationRequestProto request) throws IOException {
-    return blockingCall(() -> blockingStub
+    return blockingCall(() -> adminBlockingStub
         .withDeadlineAfter(requestTimeoutDuration.getDuration(), requestTimeoutDuration.getUnit())
         .setConfiguration(request));
   }
@@ -184,7 +183,7 @@ public class GrpcClientProtocolClient implements Closeable {
       TransferLeadershipRequestProto request) throws IOException {
     TimeDuration newDuration = requestTimeoutDuration.add(
         request.getRpcRequest().getTimeoutMs(), TimeUnit.MILLISECONDS);
-    return blockingCall(() -> blockingStub
+    return blockingCall(() -> adminBlockingStub
         .withDeadlineAfter(newDuration.getDuration(), newDuration.getUnit())
         .transferLeadership(request));
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolService.java
@@ -26,8 +26,6 @@ import org.apache.ratis.protocol.exceptions.RaftException;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.proto.RaftProtos.RaftClientReplyProto;
 import org.apache.ratis.proto.RaftProtos.RaftClientRequestProto;
-import org.apache.ratis.proto.RaftProtos.SetConfigurationRequestProto;
-import org.apache.ratis.proto.RaftProtos.TransferLeadershipRequestProto;
 import org.apache.ratis.proto.grpc.RaftClientProtocolServiceGrpc.RaftClientProtocolServiceImplBase;
 import org.apache.ratis.util.CollectionUtils;
 import org.apache.ratis.util.JavaUtils;
@@ -143,22 +141,6 @@ public class GrpcClientProtocolService extends RaftClientProtocolServiceImplBase
 
   RaftPeerId getId() {
     return idSupplier.get();
-  }
-
-  @Override
-  public void setConfiguration(SetConfigurationRequestProto proto,
-      StreamObserver<RaftClientReplyProto> responseObserver) {
-    final SetConfigurationRequest request = ClientProtoUtils.toSetConfigurationRequest(proto);
-    GrpcUtil.asyncCall(responseObserver, () -> protocol.setConfigurationAsync(request),
-        ClientProtoUtils::toRaftClientReplyProto);
-  }
-
-  @Override
-  public void transferLeadership(TransferLeadershipRequestProto proto,
-      StreamObserver<RaftClientReplyProto> responseObserver) {
-    final TransferLeadershipRequest request = ClientProtoUtils.toTransferLeadershipRequest(proto);
-    GrpcUtil.asyncCall(responseObserver, () -> protocol.transferLeadershipAsync(request),
-        ClientProtoUtils::toRaftClientReplyProto);
   }
 
   @Override

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcAdminProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcAdminProtocolService.java
@@ -24,6 +24,8 @@ import org.apache.ratis.protocol.AdminAsynchronousProtocol;
 import org.apache.ratis.protocol.GroupInfoRequest;
 import org.apache.ratis.protocol.GroupListRequest;
 import org.apache.ratis.protocol.GroupManagementRequest;
+import org.apache.ratis.protocol.SetConfigurationRequest;
+import org.apache.ratis.protocol.TransferLeadershipRequest;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
 import org.apache.ratis.proto.RaftProtos.RaftClientReplyProto;
 import org.apache.ratis.proto.RaftProtos.GroupManagementRequestProto;
@@ -57,5 +59,21 @@ public class GrpcAdminProtocolService extends AdminProtocolServiceImplBase {
     final GroupInfoRequest request = ClientProtoUtils.toGroupInfoRequest(proto);
     GrpcUtil.asyncCall(responseObserver, () -> protocol.getGroupInfoAsync(request),
         ClientProtoUtils::toGroupInfoReplyProto);
+  }
+
+  @Override
+  public void setConfiguration(SetConfigurationRequestProto proto,
+      StreamObserver<RaftClientReplyProto> responseObserver) {
+    final SetConfigurationRequest request = ClientProtoUtils.toSetConfigurationRequest(proto);
+    GrpcUtil.asyncCall(responseObserver, () -> protocol.setConfigurationAsync(request),
+        ClientProtoUtils::toRaftClientReplyProto);
+  }
+
+  @Override
+  public void transferLeadership(TransferLeadershipRequestProto proto,
+      StreamObserver<RaftClientReplyProto> responseObserver) {
+    final TransferLeadershipRequest request = ClientProtoUtils.toTransferLeadershipRequest(proto);
+    GrpcUtil.asyncCall(responseObserver, () -> protocol.transferLeadershipAsync(request),
+        ClientProtoUtils::toRaftClientReplyProto);
   }
 }

--- a/ratis-proto/src/main/proto/Grpc.proto
+++ b/ratis-proto/src/main/proto/Grpc.proto
@@ -24,13 +24,6 @@ package ratis.grpc;
 import "Raft.proto";
 
 service RaftClientProtocolService {
-  // A client-to-server RPC to set new raft configuration
-  rpc setConfiguration(ratis.common.SetConfigurationRequestProto)
-      returns(ratis.common.RaftClientReplyProto) {}
-
-  rpc transferLeadership(ratis.common.TransferLeadershipRequestProto)
-      returns(ratis.common.RaftClientReplyProto) {}
-      
   // A client-to-server stream RPC to ordered async requests
   rpc ordered(stream ratis.common.RaftClientRequestProto)
       returns (stream ratis.common.RaftClientReplyProto) {}
@@ -55,6 +48,13 @@ service RaftServerProtocolService {
 }
 
 service AdminProtocolService {
+  // A client-to-server RPC to set new raft configuration
+  rpc setConfiguration(ratis.common.SetConfigurationRequestProto)
+      returns(ratis.common.RaftClientReplyProto) {}
+
+  rpc transferLeadership(ratis.common.TransferLeadershipRequestProto)
+      returns(ratis.common.RaftClientReplyProto) {}
+
   // A client-to-server RPC to add a new group
   rpc groupManagement(ratis.common.GroupManagementRequestProto)
       returns(ratis.common.RaftClientReplyProto) {}

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerImpl.java
@@ -91,7 +91,7 @@ import com.codahale.metrics.Timer;
 
 class RaftServerImpl implements RaftServer.Division,
     RaftServerProtocol, RaftServerAsynchronousProtocol,
-    RaftClientProtocol, RaftClientAsynchronousProtocol {
+    RaftClientProtocol, RaftClientAsynchronousProtocol{
   private static final String CLASS_NAME = JavaUtils.getClassSimpleName(RaftServerImpl.class);
   static final String REQUEST_VOTE = CLASS_NAME + ".requestVote";
   static final String APPEND_ENTRIES = CLASS_NAME + ".appendEntries";
@@ -881,7 +881,6 @@ class RaftServerImpl implements RaftServer.Division,
     }
   }
 
-  @Override
   public RaftClientReply transferLeadership(TransferLeadershipRequest request) throws IOException {
     return waitForReply(request, transferLeadershipAsync(request));
   }
@@ -901,7 +900,6 @@ class RaftServerImpl implements RaftServer.Division,
     transferLeadership.finish(state.getLeaderId(), false);
   }
 
-  @Override
   public CompletableFuture<RaftClientReply> transferLeadershipAsync(TransferLeadershipRequest request)
       throws IOException {
     LOG.info("{}: receive transferLeadership {}", getMemberId(), request);
@@ -944,7 +942,6 @@ class RaftServerImpl implements RaftServer.Division,
     }
   }
 
-  @Override
   public RaftClientReply setConfiguration(SetConfigurationRequest request) throws IOException {
     return waitForReply(request, setConfigurationAsync(request));
   }
@@ -952,7 +949,6 @@ class RaftServerImpl implements RaftServer.Division,
   /**
    * Handle a raft configuration change request from client.
    */
-  @Override
   public CompletableFuture<RaftClientReply> setConfigurationAsync(SetConfigurationRequest request) throws IOException {
     LOG.info("{}: receive setConfiguration {}", getMemberId(), request);
     assertLifeCycleState(LifeCycle.States.RUNNING);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Discussed [here](https://lists.apache.org/thread.html/r51e13b73d6f3de8ffe2fe5db497535d816e3b1d5ff6f9256f954bf05%40%3Cdev.ratis.apache.org%3E) on dev@ mailing list.


Ratis GRPC has multiple GRPC services:

  * RaftClientProtocolService
  * RaftServerProtocolService
  * AdminProtocolService


If all of them use the same port / netty server a malicious client/user 
may send admin/setConfiguration requests to the servers adding more 
groups or re-configuring existing ones.

For example if somebody implements any authentication/authorization on 
the StateMachine level, it can be ignored by adding more nodes and 
replicating the raw Ratis data.

I suggest improving the GrpcService.java and add only the configured 
services. With this approach mTLS can be turned on for admin and 
server2server communication but not for the client.

The only problem is the RaftClientProtocolService.setConfiguration. It's 
an un-safe operation and more-like an admin command.

This patch moves admin related methods from client to admin protocol.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1286

## How was this patch tested?

Logic has not been changed just the organization of a few methods. Existing unit tests should cover it.