### PR TITLE
RATIS-1289. Support skip the storagedir with multiple volumes which cause by bad disk

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -104,15 +104,16 @@ class ServerState implements Closeable {
     LOG.info("{}: {}", getMemberId(), configurationManager);
 
     List<File> directories = RaftServerConfigKeys.storageDir(prop);
-    // use full uuid string to create a subdirectory
-    File dir = chooseStorageDir(RaftServerConfigKeys.storageDir(prop),
-            group.getGroupId().getUuid().toString());
-    try {
-      storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
-    } catch (IOException e) {
-      directories.remove(dir);
-      dir = chooseStorageDir(directories, group.getGroupId().getUuid().toString());
-      storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
+    boolean flag = false;
+    while (!flag) {
+      // use full uuid string to create a subdirectory
+      File dir = chooseStorageDir(directories, group.getGroupId().getUuid().toString());
+      try {
+        storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
+        flag = true;
+      } catch (IOException e) {
+        directories.remove(dir);
+      }
     }
     snapshotManager = new SnapshotManager(storage, id);
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -104,15 +104,23 @@ class ServerState implements Closeable {
     LOG.info("{}: {}", getMemberId(), configurationManager);
 
     List<File> directories = RaftServerConfigKeys.storageDir(prop);
-    boolean flag = false;
-    while (!flag) {
+    // the flag is true means the storagedir create successful or iterate all storagedir whill exit this loop
+    boolean Flag = false;
+    int FileCount = 0;
+    int FileSize = directories.size();
+    while (!Flag) {
       // use full uuid string to create a subdirectory
       File dir = chooseStorageDir(directories, group.getGroupId().getUuid().toString());
       try {
         storage = new RaftStorageImpl(dir, RaftServerConfigKeys.Log.corruptionPolicy(prop));
-        flag = true;
+        Flag = true;
       } catch (IOException e) {
         directories.remove(dir);
+      } finally {
+        FileCount = FileCount + 1;
+        if (FileCount == FileSize) {
+          Flag = true;
+        }
       }
     }
     snapshotManager = new SnapshotManager(storage, id);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support skip the storagedir with multiple volumes which cause by bad disk
the problem statement:
when ratis created the storagedir on the bad disk,it would throw java.nio.file.AccessDeniedException

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/RATIS-1289

## How was this patch tested?

I started the Ozone server which the ratis was replaced by my local changed ratis, when the one of volumes thrown the IOException caused by bad disk ,this volume would be skipped