### PR TITLE
RATIS-1285. Fix the wrong links from Ratis website

### DIFF
--- a/categories.html
+++ b/categories.html
@@ -110,7 +110,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/categories/index.xml
+++ b/categories/index.xml
@@ -5,10 +5,6 @@
     <link>https://ratis.incubator.apache.org/categories.html</link>
     <description>Recent content in Categories on Apache Ratis</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>en-us</language>
-    
-	<atom:link href="https://ratis.incubator.apache.org/categories/index.xml" rel="self" type="application/rss+xml" />
-    
-    
+    <language>en-us</language><atom:link href="https://ratis.incubator.apache.org/categories/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/community.html
+++ b/community.html
@@ -97,7 +97,7 @@
 <!-- raw HTML omitted -->
 <h3 id="mailing-list">Mailing list</h3>
 <h4 id="developers">Developers</h4>
-<p>If you'd like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.</p>
+<p>If you&rsquo;d like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.</p>
 <p>The Ratis developer mailing list is: <a href="mailto:dev@ratis.incubator.apache.org">dev@ratis.incubator.apache.org</a>.</p>
 <ul>
 <li>[Subscribe to List](mailto: <a href="mailto:dev-subscribe@ratis.incubator.apache.org">dev-subscribe@ratis.incubator.apache.org</a>)</li>
@@ -116,8 +116,7 @@ questions and discussion.</p>
 </ul>
 <p>To post to the list, it is necessary to subscribe to it.</p>
 <h3 id="slack">Slack</h3>
-<p>There is also a slack instance for discussion at <a href="https://apacheratisdev.slack.com">https://apacheratisdev.slack.com</a>.
-Please write to the mailing list if you need an invite.</p>
+<p>You can join the #ratis channel in Apache slack workspace <a href="http://s.apache.org/slack-invite">http://s.apache.org/slack-invite</a> for any discussions.</p>
 
 </div>
 
@@ -125,7 +124,7 @@ Please write to the mailing list if you need an invite.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/getting_started.html
+++ b/getting_started.html
@@ -95,7 +95,7 @@
 <h1>Getting started</h1>
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p>Ratis is a <a href="https://raft.github.io/%22">Raft</a> protocol <em>library</em> in Java. It's not a standalone server application like Zookeeper or Consul.</p>
+<p>Ratis is a <a href="https://raft.github.io/">Raft</a> protocol <em>library</em> in Java. It&rsquo;s not a standalone server application like Zookeeper or Consul.</p>
 <h3 id="examples">Examples</h3>
 <p>To demonstrate how to use Ratis from the code, Please look at the following examples.</p>
 <ul>
@@ -111,24 +111,24 @@
 <a href="https://github.com/apache/incubator-ratis/blob/master/ratis-examples/">ratis-examples</a> sub-project.</p>
 <h3 id="maven-usage">Maven usage</h3>
 <p>To use in our project you can access the latest binaries from maven central:</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency</span><span style="color:#f92672">&gt;</span>
-   <span style="color:#f92672">&lt;artifactId</span><span style="color:#f92672">&gt;</span>ratis-server<span style="color:#f92672">&lt;/artifactId&gt;</span>
-   <span style="color:#f92672">&lt;groupId</span><span style="color:#f92672">&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency&gt;</span>
+   <span style="color:#f92672">&lt;artifactId&gt;</span>ratis-server<span style="color:#f92672">&lt;/artifactId&gt;</span>
+   <span style="color:#f92672">&lt;groupId&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
 <span style="color:#f92672">&lt;/dependency&gt;</span></code></pre></div>
 <p>You also need to include <em>one</em> of the transports:</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency</span><span style="color:#f92672">&gt;</span>
-   <span style="color:#f92672">&lt;artifactId</span><span style="color:#f92672">&gt;</span>ratis-grpc<span style="color:#f92672">&lt;/artifactId&gt;</span>
-   <span style="color:#f92672">&lt;groupId</span><span style="color:#f92672">&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency&gt;</span>
+   <span style="color:#f92672">&lt;artifactId&gt;</span>ratis-grpc<span style="color:#f92672">&lt;/artifactId&gt;</span>
+   <span style="color:#f92672">&lt;groupId&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
 <span style="color:#f92672">&lt;/dependency&gt;</span></code></pre></div>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"> <span style="color:#f92672">&lt;dependency</span><span style="color:#f92672">&gt;</span>
-   <span style="color:#f92672">&lt;artifactId</span><span style="color:#f92672">&gt;</span>ratis-netty<span style="color:#f92672">&lt;/artifactId&gt;</span>
-   <span style="color:#f92672">&lt;groupId</span><span style="color:#f92672">&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"> <span style="color:#f92672">&lt;dependency&gt;</span>
+   <span style="color:#f92672">&lt;artifactId&gt;</span>ratis-netty<span style="color:#f92672">&lt;/artifactId&gt;</span>
+   <span style="color:#f92672">&lt;groupId&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
 <span style="color:#f92672">&lt;/dependency&gt;</span></code></pre></div>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency</span><span style="color:#f92672">&gt;</span>
-   <span style="color:#f92672">&lt;artifactId</span><span style="color:#f92672">&gt;</span>ratis-hadoop<span style="color:#f92672">&lt;/artifactId&gt;</span>
-   <span style="color:#f92672">&lt;groupId</span><span style="color:#f92672">&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency&gt;</span>
+   <span style="color:#f92672">&lt;artifactId&gt;</span>ratis-hadoop<span style="color:#f92672">&lt;/artifactId&gt;</span>
+   <span style="color:#f92672">&lt;groupId&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
 <span style="color:#f92672">&lt;/dependency&gt;</span></code></pre></div>
-<p>Please note that Apache Hadoop dependencies are shaded, so it's safe to use hadoop transport with different versions of Hadoop.</p>
+<p>Please note that Apache Hadoop dependencies are shaded, so it&rsquo;s safe to use hadoop transport with different versions of Hadoop.</p>
 
 </div>
 
@@ -136,7 +136,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <html>
 
 <head>
-	<meta name="generator" content="Hugo 0.62.0" />
+	<meta name="generator" content="Hugo 0.79.0" />
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -184,7 +184,7 @@
             <h2>Latest news</h2>
             
             <div class="panel-heading clearfix"><a class="pull-left" href="/post.html">Posts</a>
-                <small class="pull-right">2020 Feb 4 </small>
+                <small class="pull-right">2020 Jul 20 </small>
             </div>
             
         </div>
@@ -206,6 +206,7 @@
             <p>The source tarball contains detailed instruction about how can it be built.</p>
 
             <p>The binaries are also uploaded to the maven central for convenience. (See the getting started guide for more details)</p>
+            <p>1.0.0 is GA release for Apache Ratis</p>
             <table class="table table-striped">
                 <thead>
                 <tr>
@@ -215,6 +216,15 @@
                     <th>Announcement</th>
                 </tr>
                 </thead>
+                
+                <tr>
+                    <td>1.0.0</td>
+                    <td>2020 Jul 20 </td>
+                    <td><a href="https://www.apache.org/dist/incubator/ratis/1.0.0/">
+                        https://www.apache.org/dist/incubator/ratis/1.0.0/</a>
+                    </td>
+                    <td><a href="post/1.0.0.html">Announcement</a></td>
+                </tr>
                 
                 <tr>
                     <td>0.5.0</td>
@@ -273,7 +283,7 @@
             <h2>Getting started</h2>
             <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p>Ratis is a <a href="https://raft.github.io/%22">Raft</a> protocol <em>library</em> in Java. It's not a standalone server application like Zookeeper or Consul.</p>
+<p>Ratis is a <a href="https://raft.github.io/">Raft</a> protocol <em>library</em> in Java. It&rsquo;s not a standalone server application like Zookeeper or Consul.</p>
 <h3 id="examples">Examples</h3>
 <p>To demonstrate how to use Ratis from the code, Please look at the following examples.</p>
 <ul>
@@ -289,24 +299,24 @@
 <a href="https://github.com/apache/incubator-ratis/blob/master/ratis-examples/">ratis-examples</a> sub-project.</p>
 <h3 id="maven-usage">Maven usage</h3>
 <p>To use in our project you can access the latest binaries from maven central:</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency</span><span style="color:#f92672">&gt;</span>
-   <span style="color:#f92672">&lt;artifactId</span><span style="color:#f92672">&gt;</span>ratis-server<span style="color:#f92672">&lt;/artifactId&gt;</span>
-   <span style="color:#f92672">&lt;groupId</span><span style="color:#f92672">&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency&gt;</span>
+   <span style="color:#f92672">&lt;artifactId&gt;</span>ratis-server<span style="color:#f92672">&lt;/artifactId&gt;</span>
+   <span style="color:#f92672">&lt;groupId&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
 <span style="color:#f92672">&lt;/dependency&gt;</span></code></pre></div>
 <p>You also need to include <em>one</em> of the transports:</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency</span><span style="color:#f92672">&gt;</span>
-   <span style="color:#f92672">&lt;artifactId</span><span style="color:#f92672">&gt;</span>ratis-grpc<span style="color:#f92672">&lt;/artifactId&gt;</span>
-   <span style="color:#f92672">&lt;groupId</span><span style="color:#f92672">&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency&gt;</span>
+   <span style="color:#f92672">&lt;artifactId&gt;</span>ratis-grpc<span style="color:#f92672">&lt;/artifactId&gt;</span>
+   <span style="color:#f92672">&lt;groupId&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
 <span style="color:#f92672">&lt;/dependency&gt;</span></code></pre></div>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"> <span style="color:#f92672">&lt;dependency</span><span style="color:#f92672">&gt;</span>
-   <span style="color:#f92672">&lt;artifactId</span><span style="color:#f92672">&gt;</span>ratis-netty<span style="color:#f92672">&lt;/artifactId&gt;</span>
-   <span style="color:#f92672">&lt;groupId</span><span style="color:#f92672">&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"> <span style="color:#f92672">&lt;dependency&gt;</span>
+   <span style="color:#f92672">&lt;artifactId&gt;</span>ratis-netty<span style="color:#f92672">&lt;/artifactId&gt;</span>
+   <span style="color:#f92672">&lt;groupId&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
 <span style="color:#f92672">&lt;/dependency&gt;</span></code></pre></div>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency</span><span style="color:#f92672">&gt;</span>
-   <span style="color:#f92672">&lt;artifactId</span><span style="color:#f92672">&gt;</span>ratis-hadoop<span style="color:#f92672">&lt;/artifactId&gt;</span>
-   <span style="color:#f92672">&lt;groupId</span><span style="color:#f92672">&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-xml" data-lang="xml"><span style="color:#f92672">&lt;dependency&gt;</span>
+   <span style="color:#f92672">&lt;artifactId&gt;</span>ratis-hadoop<span style="color:#f92672">&lt;/artifactId&gt;</span>
+   <span style="color:#f92672">&lt;groupId&gt;</span>org.apache.ratis<span style="color:#f92672">&lt;/groupId&gt;</span>
 <span style="color:#f92672">&lt;/dependency&gt;</span></code></pre></div>
-<p>Please note that Apache Hadoop dependencies are shaded, so it's safe to use hadoop transport with different versions of Hadoop.</p>
+<p>Please note that Apache Hadoop dependencies are shaded, so it&rsquo;s safe to use hadoop transport with different versions of Hadoop.</p>
 
             
         </div>
@@ -323,7 +333,7 @@
 <!-- raw HTML omitted -->
 <h3 id="mailing-list">Mailing list</h3>
 <h4 id="developers">Developers</h4>
-<p>If you'd like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.</p>
+<p>If you&rsquo;d like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.</p>
 <p>The Ratis developer mailing list is: <a href="mailto:dev@ratis.incubator.apache.org">dev@ratis.incubator.apache.org</a>.</p>
 <ul>
 <li>[Subscribe to List](mailto: <a href="mailto:dev-subscribe@ratis.incubator.apache.org">dev-subscribe@ratis.incubator.apache.org</a>)</li>
@@ -342,8 +352,7 @@ questions and discussion.</p>
 </ul>
 <p>To post to the list, it is necessary to subscribe to it.</p>
 <h3 id="slack">Slack</h3>
-<p>There is also a slack instance for discussion at <a href="https://apacheratisdev.slack.com">https://apacheratisdev.slack.com</a>.
-Please write to the mailing list if you need an invite.</p>
+<p>You can join the #ratis channel in Apache slack workspace <a href="http://s.apache.org/slack-invite">http://s.apache.org/slack-invite</a> for any discussions.</p>
 
             
         </div>
@@ -399,7 +408,7 @@ Only the source code from the released artifacts are checked by the Project Mana
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/index.xml
+++ b/index.xml
@@ -6,10 +6,17 @@
     <description>Recent content on Apache Ratis</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 04 Feb 2020 00:00:00 +0000</lastBuildDate>
-    
-	<atom:link href="https://ratis.incubator.apache.org/index.xml" rel="self" type="application/rss+xml" />
-    
+    <lastBuildDate>Mon, 20 Jul 2020 00:00:00 +0000</lastBuildDate><atom:link href="https://ratis.incubator.apache.org/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>GA Release 1.0.0 is available</title>
+      <link>https://ratis.incubator.apache.org/post/1.0.0.html</link>
+      <pubDate>Mon, 20 Jul 2020 00:00:00 +0000</pubDate>
+      
+      <guid>https://ratis.incubator.apache.org/post/1.0.0.html</guid>
+      <description>Download
+It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases. See the changes between 0.5.0 and 1.0.0 releases.
+It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data and to provide high availability.</description>
+    </item>
     
     <item>
       <title>Release 0.5.0 is available</title>
@@ -73,7 +80,7 @@ Key features:
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://ratis.incubator.apache.org/community.html</guid>
-      <description>Mailing list Developers If you&#39;d like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.
+      <description>Mailing list Developers If you&amp;rsquo;d like to contribute to Apache Ratis, please subscribe to the Ratis developer mailing list.
 The Ratis developer mailing list is: dev@ratis.incubator.apache.org.
  [Subscribe to List](mailto: dev-subscribe@ratis.incubator.apache.org) [Unsubscribe from List](mailto: dev-unsubscribe@ratis.incubator.apache.org) Archives  User The user@ mailing list is the preferred mailing list for end-user questions and discussion.
 Please use dev mailing list to address developers on a specific technical question.
@@ -96,7 +103,7 @@ The Ratis user mailing list is: user@ratis.</description>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
       <guid>https://ratis.incubator.apache.org/getting_started.html</guid>
-      <description>Ratis is a Raft protocol library in Java. It&#39;s not a standalone server application like Zookeeper or Consul.
+      <description>Ratis is a Raft protocol library in Java. It&amp;rsquo;s not a standalone server application like Zookeeper or Consul.
 Examples To demonstrate how to use Ratis from the code, Please look at the following examples.
   Arithmetic example: This is a simple distributed calculator that replicates the values defined and allows user to perform arithmetic operations on these replicated values.
   FileStore example: This is an example of using Ratis for reading and writing files.</description>

--- a/logservice.html
+++ b/logservice.html
@@ -235,33 +235,33 @@ but the private key is sensitive and should be protected like a password.</p>
 <p>Every component in HBase using the Ratis LogService would need to ensure that each LogService StateMachine is
 configured to use the server keystore and truststore. The LogService state machines would need to constructed
 with the appropriate configuration options to specify this TLS material:</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">RaftProperties properties <span style="color:#f92672">=</span> <span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">RaftProperties properties <span style="color:#f92672">=</span> <span style="color:#f92672">...;</span>
 
-GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">tlsEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">mutualAuthnEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">PRIVATE_KEY_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/server-private-key.pem&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">TRUST_STORE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/ca.crt&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">CERT_CHAIN_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/server.crt&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">tlsEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
+GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">mutualAuthnEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">PRIVATE_KEY_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/server-private-key.pem&#34;</span><span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">TRUST_STORE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/ca.crt&#34;</span><span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">CERT_CHAIN_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/server.crt&#34;</span><span style="color:#f92672">);</span>
 
-RaftServer<span style="color:#f92672">.</span><span style="color:#a6e22e">Builder</span> builder <span style="color:#f92672">=</span> RaftServer<span style="color:#f92672">.</span><span style="color:#a6e22e">newBuilder</span><span style="color:#f92672">(</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-<span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">.</span>
-builder<span style="color:#f92672">.</span><span style="color:#a6e22e">setProperties</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+RaftServer<span style="color:#f92672">.</span><span style="color:#a6e22e">Builder</span> builder <span style="color:#f92672">=</span> RaftServer<span style="color:#f92672">.</span><span style="color:#a6e22e">newBuilder</span><span style="color:#f92672">();</span>
+<span style="color:#f92672">...</span>
+builder<span style="color:#f92672">.</span><span style="color:#a6e22e">setProperties</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
 
-RaftServer server <span style="color:#f92672">=</span> builder<span style="color:#f92672">.</span><span style="color:#a6e22e">build</span><span style="color:#f92672">(</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+RaftServer server <span style="color:#f92672">=</span> builder<span style="color:#f92672">.</span><span style="color:#a6e22e">build</span><span style="color:#f92672">();</span>
 </code></pre></div><p>Clients to the StateMachine would construct a similar configuration:</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">RaftProperties properties <span style="color:#f92672">=</span> <span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">RaftProperties properties <span style="color:#f92672">=</span> <span style="color:#f92672">...;</span>
 
-GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">tlsEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">mutualAuthnEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">PRIVATE_KEY_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/client-private-key.pem&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">TRUST_STORE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/ca.crt&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">CERT_CHAIN_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/client.crt&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">tlsEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
+GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">mutualAuthnEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">PRIVATE_KEY_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/client-private-key.pem&#34;</span><span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">TRUST_STORE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/ca.crt&#34;</span><span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">CERT_CHAIN_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/client.crt&#34;</span><span style="color:#f92672">);</span>
 
-RaftClient<span style="color:#f92672">.</span><span style="color:#a6e22e">Builder</span> builder <span style="color:#f92672">=</span> RaftClient<span style="color:#f92672">.</span><span style="color:#a6e22e">newBuilder</span><span style="color:#f92672">(</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-<span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">.</span>
-builder<span style="color:#f92672">.</span><span style="color:#a6e22e">setProperties</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+RaftClient<span style="color:#f92672">.</span><span style="color:#a6e22e">Builder</span> builder <span style="color:#f92672">=</span> RaftClient<span style="color:#f92672">.</span><span style="color:#a6e22e">newBuilder</span><span style="color:#f92672">();</span>
+<span style="color:#f92672">...</span>
+builder<span style="color:#f92672">.</span><span style="color:#a6e22e">setProperties</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
 
-RaftClient client <span style="color:#f92672">=</span> builder<span style="color:#f92672">.</span><span style="color:#a6e22e">build</span><span style="color:#f92672">(</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+RaftClient client <span style="color:#f92672">=</span> builder<span style="color:#f92672">.</span><span style="color:#a6e22e">build</span><span style="color:#f92672">();</span>
 </code></pre></div><p>With Mutual TLS, there is no notion of a &ldquo;client&rdquo; or &ldquo;server&rdquo; only certificate. In the above example code,
 as long as the certificate and private key are generated using the same certificate authority, any
 should function.</p>
@@ -270,7 +270,7 @@ should function.</p>
 this TLS material via the HBase configuration (hbase-site.xml), passing it down into the WALProvider
 implementation. As the WALProvider is the broker that doles out readers and writers, and would also, presumably
 manage the creation of the StateMachines, it can set up the proper Ratis configuration from the HBase configuration.</p>
-<p>[1] There are scenarios with shared trust across CA's that enable other scenarios but these are ignored for the purpose
+<p>[1] There are scenarios with shared trust across CA&rsquo;s that enable other scenarios but these are ignored for the purpose
 of this document.</p>
 
 
@@ -287,7 +287,7 @@ of this document.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/index.html
+++ b/logservice/index.html
@@ -114,7 +114,7 @@ daemons provided for the LogService, but these are solely to be used for testing
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/index.xml
+++ b/logservice/index.xml
@@ -5,11 +5,7 @@
     <link>https://ratis.incubator.apache.org/logservice.html</link>
     <description>Recent content on Apache Ratis</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>en-us</language>
-    
-	<atom:link href="https://ratis.incubator.apache.org/logservice/index.xml" rel="self" type="application/rss+xml" />
-    
-    
+    <language>en-us</language><atom:link href="https://ratis.incubator.apache.org/logservice/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Lifecycle</title>
       <link>https://ratis.incubator.apache.org/logservice/lifecycle.html</link>

--- a/logservice/lifecycle.html
+++ b/logservice/lifecycle.html
@@ -165,7 +165,7 @@ an archival of a log is an export of the entire log to a specific location.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/security.html
+++ b/logservice/security.html
@@ -130,33 +130,33 @@ but the private key is sensitive and should be protected like a password.</p>
 <p>Every component in HBase using the Ratis LogService would need to ensure that each LogService StateMachine is
 configured to use the server keystore and truststore. The LogService state machines would need to constructed
 with the appropriate configuration options to specify this TLS material:</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">RaftProperties properties <span style="color:#f92672">=</span> <span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">RaftProperties properties <span style="color:#f92672">=</span> <span style="color:#f92672">...;</span>
 
-GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">tlsEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">mutualAuthnEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">PRIVATE_KEY_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/server-private-key.pem&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">TRUST_STORE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/ca.crt&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">CERT_CHAIN_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/server.crt&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">tlsEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
+GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">mutualAuthnEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">PRIVATE_KEY_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/server-private-key.pem&#34;</span><span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">TRUST_STORE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/ca.crt&#34;</span><span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">CERT_CHAIN_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/server.crt&#34;</span><span style="color:#f92672">);</span>
 
-RaftServer<span style="color:#f92672">.</span><span style="color:#a6e22e">Builder</span> builder <span style="color:#f92672">=</span> RaftServer<span style="color:#f92672">.</span><span style="color:#a6e22e">newBuilder</span><span style="color:#f92672">(</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-<span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">.</span>
-builder<span style="color:#f92672">.</span><span style="color:#a6e22e">setProperties</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+RaftServer<span style="color:#f92672">.</span><span style="color:#a6e22e">Builder</span> builder <span style="color:#f92672">=</span> RaftServer<span style="color:#f92672">.</span><span style="color:#a6e22e">newBuilder</span><span style="color:#f92672">();</span>
+<span style="color:#f92672">...</span>
+builder<span style="color:#f92672">.</span><span style="color:#a6e22e">setProperties</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
 
-RaftServer server <span style="color:#f92672">=</span> builder<span style="color:#f92672">.</span><span style="color:#a6e22e">build</span><span style="color:#f92672">(</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+RaftServer server <span style="color:#f92672">=</span> builder<span style="color:#f92672">.</span><span style="color:#a6e22e">build</span><span style="color:#f92672">();</span>
 </code></pre></div><p>Clients to the StateMachine would construct a similar configuration:</p>
-<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">RaftProperties properties <span style="color:#f92672">=</span> <span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">;</span>
+<div class="highlight"><pre style="color:#f8f8f2;background-color:#272822;-moz-tab-size:4;-o-tab-size:4;tab-size:4"><code class="language-java" data-lang="java">RaftProperties properties <span style="color:#f92672">=</span> <span style="color:#f92672">...;</span>
 
-GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">tlsEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">mutualAuthnEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">PRIVATE_KEY_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/client-private-key.pem&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">TRUST_STORE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/ca.crt&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">CERT_CHAIN_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/client.crt&#34;</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">tlsEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
+GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">mutualAuthnEnabled</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">PRIVATE_KEY_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/client-private-key.pem&#34;</span><span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">TRUST_STORE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/ca.crt&#34;</span><span style="color:#f92672">);</span>
+properties<span style="color:#f92672">.</span><span style="color:#a6e22e">set</span><span style="color:#f92672">(</span>GrpcConfigKeys<span style="color:#f92672">.</span><span style="color:#a6e22e">TLS</span><span style="color:#f92672">.</span><span style="color:#a6e22e">CERT_CHAIN_FILE_KEY</span><span style="color:#f92672">,</span> <span style="color:#e6db74">&#34;/path/to/client.crt&#34;</span><span style="color:#f92672">);</span>
 
-RaftClient<span style="color:#f92672">.</span><span style="color:#a6e22e">Builder</span> builder <span style="color:#f92672">=</span> RaftClient<span style="color:#f92672">.</span><span style="color:#a6e22e">newBuilder</span><span style="color:#f92672">(</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
-<span style="color:#f92672">.</span><span style="color:#f92672">.</span><span style="color:#f92672">.</span>
-builder<span style="color:#f92672">.</span><span style="color:#a6e22e">setProperties</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+RaftClient<span style="color:#f92672">.</span><span style="color:#a6e22e">Builder</span> builder <span style="color:#f92672">=</span> RaftClient<span style="color:#f92672">.</span><span style="color:#a6e22e">newBuilder</span><span style="color:#f92672">();</span>
+<span style="color:#f92672">...</span>
+builder<span style="color:#f92672">.</span><span style="color:#a6e22e">setProperties</span><span style="color:#f92672">(</span>properties<span style="color:#f92672">);</span>
 
-RaftClient client <span style="color:#f92672">=</span> builder<span style="color:#f92672">.</span><span style="color:#a6e22e">build</span><span style="color:#f92672">(</span><span style="color:#f92672">)</span><span style="color:#f92672">;</span>
+RaftClient client <span style="color:#f92672">=</span> builder<span style="color:#f92672">.</span><span style="color:#a6e22e">build</span><span style="color:#f92672">();</span>
 </code></pre></div><p>With Mutual TLS, there is no notion of a &ldquo;client&rdquo; or &ldquo;server&rdquo; only certificate. In the above example code,
 as long as the certificate and private key are generated using the same certificate authority, any
 should function.</p>
@@ -165,7 +165,7 @@ should function.</p>
 this TLS material via the HBase configuration (hbase-site.xml), passing it down into the WALProvider
 implementation. As the WALProvider is the broker that doles out readers and writers, and would also, presumably
 manage the creation of the StateMachines, it can set up the proper Ratis configuration from the HBase configuration.</p>
-<p>[1] There are scenarios with shared trust across CA's that enable other scenarios but these are ignored for the purpose
+<p>[1] There are scenarios with shared trust across CA&rsquo;s that enable other scenarios but these are ignored for the purpose
 of this document.</p>
 
 </div>
@@ -174,7 +174,7 @@ of this document.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/testing.html
+++ b/logservice/testing.html
@@ -179,7 +179,7 @@ scenarios. Please find more on each using the below references.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/testing/docker.html
+++ b/logservice/testing/docker.html
@@ -131,7 +131,7 @@ described above, use <code>docker exec -it &lt;name&gt; /bin/sh</code> to attach
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/testing/index.html
+++ b/logservice/testing/index.html
@@ -111,7 +111,7 @@ scenarios. Please find more on each using the below references.</p>
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/logservice/testing/index.xml
+++ b/logservice/testing/index.xml
@@ -5,11 +5,7 @@
     <link>https://ratis.incubator.apache.org/logservice/testing.html</link>
     <description>Recent content on Apache Ratis</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>en-us</language>
-    
-	<atom:link href="https://ratis.incubator.apache.org/logservice/testing/index.xml" rel="self" type="application/rss+xml" />
-    
-    
+    <language>en-us</language><atom:link href="https://ratis.incubator.apache.org/logservice/testing/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>Docker Testing</title>
       <link>https://ratis.incubator.apache.org/logservice/testing/docker.html</link>

--- a/post.html
+++ b/post.html
@@ -98,6 +98,18 @@
     <h1 id="title">Posts Archive</h1>
         <ul id="list">
             
+            <h1><a href="/post/1.0.0.html">GA Release 1.0.0 is available</a></h1>
+            <p><small>2020 Jul 20 </small></p>
+
+            <!-- raw HTML omitted -->
+<!-- raw HTML omitted -->
+<p><a href="https://ratis.incubator.apache.org/#download">Download</a></p>
+<p>It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
+See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0-rc0">changes between 0.5.0 and 1.0.0</a> releases.</p>
+<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
+
+
+            
             <h1><a href="/post/0.5.0.html">Release 0.5.0 is available</a></h1>
             <p><small>2020 Feb 4 </small></p>
 
@@ -173,7 +185,7 @@ See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.2.0..
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.1.0-alpha.html
+++ b/post/0.1.0-alpha.html
@@ -109,7 +109,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.2.0.html
+++ b/post/0.2.0.html
@@ -106,7 +106,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.3.0.html
+++ b/post/0.3.0.html
@@ -106,7 +106,7 @@ See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.2.0..
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.4.0.html
+++ b/post/0.4.0.html
@@ -106,7 +106,7 @@ See the <a href="https://github.com/apache/incubator-ratis/compare/0.3.0...ratis
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/0.5.0.html
+++ b/post/0.5.0.html
@@ -106,7 +106,7 @@ See the <a href="https://github.com/apache/incubator-ratis/compare/0.4.0-rc4...r
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/post/1.0.0.html
+++ b/post/1.0.0.html
@@ -92,16 +92,13 @@
 </div>
 
 <div class="container">
-<h1>Vagrant Testing</h1>
+<h1>GA Release 1.0.0 is available</h1>
 <!-- raw HTML omitted -->
 <!-- raw HTML omitted -->
-<p>Please refer to the <a href="https://github.com/apache/incubator-ratis/blob/master/dev-support/vagrant/README.md">documentation</a> for instructions to use the Vagrant automation.</p>
-<p>Starting from the directory <code>dev-support/vagrant/</code>:</p>
-<ul>
-<li>To build all Vagrant boxes, invoke <code>./run_all_tests.sh build</code></li>
-<li>To remove any generated data, invoke <code>./run_all_tests.sh clean</code></li>
-<li>To run the tests, invoke <code>vagrant resume ratis-servers &amp;&amp; vagrant ssh ratis-servers</code></li>
-</ul>
+<p><a href="https://ratis.incubator.apache.org/#download">Download</a></p>
+<p>It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases.
+See the <a href="https://github.com/apache/incubator-ratis/compare/ratis-0.5.0-rc0...ratis-1.0.0-rc0">changes between 0.5.0 and 1.0.0</a> releases.</p>
+<p>It has been tested with <a href="https://hadoop.apache.org/ozone/">Apache Hadoop Ozone</a> where Apache Ratis is used to replicate raw data and to provide high availability.</p>
 
 </div>
 

--- a/post/index.xml
+++ b/post/index.xml
@@ -6,10 +6,17 @@
     <description>Recent content in Posts on Apache Ratis</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Tue, 04 Feb 2020 00:00:00 +0000</lastBuildDate>
-    
-	<atom:link href="https://ratis.incubator.apache.org/post/index.xml" rel="self" type="application/rss+xml" />
-    
+    <lastBuildDate>Mon, 20 Jul 2020 00:00:00 +0000</lastBuildDate><atom:link href="https://ratis.incubator.apache.org/post/index.xml" rel="self" type="application/rss+xml" />
+    <item>
+      <title>GA Release 1.0.0 is available</title>
+      <link>https://ratis.incubator.apache.org/post/1.0.0.html</link>
+      <pubDate>Mon, 20 Jul 2020 00:00:00 +0000</pubDate>
+      
+      <guid>https://ratis.incubator.apache.org/post/1.0.0.html</guid>
+      <description>Download
+It contains around 119 improvements and bug fixes based on various Apache Hadoop Ozone use cases. See the changes between 0.5.0 and 1.0.0 releases.
+It has been tested with Apache Hadoop Ozone where Apache Ratis is used to replicate raw data and to provide high availability.</description>
+    </item>
     
     <item>
       <title>Release 0.5.0 is available</title>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,12 +4,17 @@
   
   <url>
     <loc>https://ratis.incubator.apache.org/</loc>
-    <lastmod>2020-02-04T00:00:00+00:00</lastmod>
+    <lastmod>2020-07-20T00:00:00+00:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>https://ratis.incubator.apache.org/post/1.0.0.html</loc>
+    <lastmod>2020-07-20T00:00:00+00:00</lastmod>
   </url>
   
   <url>
     <loc>https://ratis.incubator.apache.org/post.html</loc>
-    <lastmod>2020-02-04T00:00:00+00:00</lastmod>
+    <lastmod>2020-07-20T00:00:00+00:00</lastmod>
   </url>
   
   <url>

--- a/source.html
+++ b/source.html
@@ -106,7 +106,7 @@ Only the source code from the released artifacts are checked by the Project Mana
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/tags.html
+++ b/tags.html
@@ -110,7 +110,7 @@
     <div class="container">
 
         <div class="col-md-12 trademark">
-            <p>&copy; 2020 <a href="http://apache.org">The Apache Software Foundation</a>,
+            <p>&copy; 2021 <a href="http://apache.org">The Apache Software Foundation</a>,
                 Apache, Apache Ratis, the Apache feather logo, Apache Ratis logo, Apache Incubator logo are trademarks of The Apache Software Foundation.
             <p>
         </div>

--- a/tags/index.xml
+++ b/tags/index.xml
@@ -5,10 +5,6 @@
     <link>https://ratis.incubator.apache.org/tags.html</link>
     <description>Recent content in Tags on Apache Ratis</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>en-us</language>
-    
-	<atom:link href="https://ratis.incubator.apache.org/tags/index.xml" rel="self" type="application/rss+xml" />
-    
-    
+    <language>en-us</language><atom:link href="https://ratis.incubator.apache.org/tags/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are wrong link in ratis website. 

> Getting started
> 
> Ratis is a Raft protocol library in Java. It’s not a standalone server application like Zookeeper or Consul.
> 

Only need to rebuild, because asf-site-soure has fix this: https://github.com/apache/incubator-ratis/commit/57725bb419ceaa8fc08fdf20b29546b8d4614273, but did not commit asf-site.


