### PR TITLE
RATIS-1290. Allow separate admin and client service

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
@@ -56,9 +56,23 @@ public final class RaftPeer {
     return new Builder();
   }
 
+  /** @return a new builder initialized from {@code peer} */
+  public static Builder newBuilder(RaftPeer peer) {
+    Objects.requireNonNull(peer, "peer == null");
+    return newBuilder()
+        .setId(peer.getId())
+        .setAddress(peer.getAddress())
+        .setAdminAddress(peer.getAdminAddress())
+        .setClientAddress(peer.getClientAddress())
+        .setDataStreamAddress(peer.getDataStreamAddress())
+        .setPriority(peer.getPriority());
+  }
+
   public static class Builder {
     private RaftPeerId id;
     private String address;
+    private String adminAddress;
+    private String clientAddress;
     private String dataStreamAddress;
     private int priority;
 
@@ -84,6 +98,24 @@ public final class RaftPeer {
       return setAddress(NetUtils.address2String(address));
     }
 
+    public Builder setAdminAddress(String addr) {
+      this.adminAddress = addr;
+      return this;
+    }
+
+    public Builder setAdminAddress(InetSocketAddress addr) {
+      return setAdminAddress(NetUtils.address2String(addr));
+    }
+
+    public Builder setClientAddress(String addr) {
+      this.clientAddress = addr;
+      return this;
+    }
+
+    public Builder setClientAddress(InetSocketAddress addr) {
+      return setClientAddress(NetUtils.address2String(addr));
+    }
+
     public Builder setDataStreamAddress(String dataStreamAddress) {
       this.dataStreamAddress = dataStreamAddress;
       return this;
@@ -104,7 +136,7 @@ public final class RaftPeer {
     public RaftPeer build() {
       return new RaftPeer(
           Objects.requireNonNull(id, "The 'id' field is not initialized."),
-          address, dataStreamAddress, priority);
+          address, adminAddress, clientAddress, dataStreamAddress, priority);
     }
   }
 
@@ -112,6 +144,8 @@ public final class RaftPeer {
   private final RaftPeerId id;
   /** The RPC address of the peer. */
   private final String address;
+  private final String adminAddress;
+  private final String clientAddress;
   /** The DataStream address of the peer. */
   private final String dataStreamAddress;
   /** The priority of the peer. */
@@ -119,10 +153,14 @@ public final class RaftPeer {
 
   private final Supplier<RaftPeerProto> raftPeerProto;
 
-  private RaftPeer(RaftPeerId id, String address, String dataStreamAddress, int priority) {
+  private RaftPeer(RaftPeerId id,
+      String address, String adminAddress, String clientAddress, String dataStreamAddress,
+      int priority) {
     this.id = Objects.requireNonNull(id, "id == null");
     this.address = address;
     this.dataStreamAddress = dataStreamAddress;
+    this.adminAddress = adminAddress;
+    this.clientAddress = clientAddress;
     this.priority = priority;
     this.raftPeerProto = JavaUtils.memoize(this::buildRaftPeerProto);
   }
@@ -132,6 +170,8 @@ public final class RaftPeer {
         .setId(getId().toByteString());
     Optional.ofNullable(getAddress()).ifPresent(builder::setAddress);
     Optional.ofNullable(getDataStreamAddress()).ifPresent(builder::setDataStreamAddress);
+    Optional.ofNullable(getClientAddress()).ifPresent(builder::setClientAddress);
+    Optional.ofNullable(getAdminAddress()).ifPresent(builder::setAdminAddress);
     builder.setPriority(priority);
     return builder.build();
   }
@@ -141,9 +181,19 @@ public final class RaftPeer {
     return id;
   }
 
-  /** @return The RPC address of the peer. */
+  /** @return The RPC address of the peer for server-server communication. */
   public String getAddress() {
     return address;
+  }
+
+  /** @return The RPC address of the peer for admin operations. */
+  public String getAdminAddress() {
+    return adminAddress != null ? adminAddress : address;
+  }
+
+  /** @return The RPC address of the peer for client operations. */
+  public String getClientAddress() {
+    return clientAddress != null ? clientAddress : address;
   }
 
   /** @return The data stream address of the peer. */
@@ -163,9 +213,13 @@ public final class RaftPeer {
   @Override
   public String toString() {
     final String rpc = address != null? "|rpc:" + address: "";
+    final String admin = adminAddress != null && !Objects.equals(address, adminAddress)
+        ? "|admin:" + adminAddress : "";
+    final String client = clientAddress != null && !Objects.equals(address, clientAddress)
+        ? "|client:" + clientAddress : "";
     final String data = dataStreamAddress != null? "|dataStream:" + dataStreamAddress: "";
     final String p = "|priority:" +  priority;
-    return id + rpc + data + p;
+    return id + rpc + admin + client + data + p;
   }
 
   @Override

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftPeer.java
@@ -186,14 +186,16 @@ public final class RaftPeer {
     return address;
   }
 
-  /** @return The RPC address of the peer for admin operations. */
+  /** @return The RPC address of the peer for admin operations.
+   * May be {@code null}, in which case {@link #getAddress()} should be used. */
   public String getAdminAddress() {
-    return adminAddress != null ? adminAddress : address;
+    return adminAddress;
   }
 
-  /** @return The RPC address of the peer for client operations. */
+  /** @return The RPC address of the peer for client operations.
+   * May be {@code null}, in which case {@link #getAddress()} should be used. */
   public String getClientAddress() {
-    return clientAddress != null ? clientAddress : address;
+    return clientAddress;
   }
 
   /** @return The data stream address of the peer. */

--- a/ratis-common/src/main/java/org/apache/ratis/util/ProtoUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/ProtoUtils.java
@@ -117,6 +117,8 @@ public interface ProtoUtils {
         .setId(RaftPeerId.valueOf(p.getId()))
         .setAddress(p.getAddress())
         .setDataStreamAddress(p.getDataStreamAddress())
+        .setClientAddress(p.getClientAddress())
+        .setAdminAddress(p.getAdminAddress())
         .setPriority(p.getPriority())
         .build();
   }

--- a/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
+++ b/ratis-common/src/test/java/org/apache/ratis/BaseTest.java
@@ -74,7 +74,7 @@ public abstract class BaseTest {
       RaftPeer peer = peers.get(i);
       final int priority = peer.equals(suggestedLeader)? 2: 1;
       peersWithPriority.add(
-          RaftPeer.newBuilder().setId(peer.getId()).setAddress(peer.getAddress()).setPriority(priority).build());
+          RaftPeer.newBuilder(peer).setPriority(priority).build());
     }
     return peersWithPriority;
   }

--- a/ratis-common/src/test/java/org/apache/ratis/util/TestNetUtils.java
+++ b/ratis-common/src/test/java/org/apache/ratis/util/TestNetUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.util;
+
+import org.junit.Test;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestNetUtils {
+
+  @Test
+  public void createsUniqueAddresses() {
+    for (int i = 0; i < 10; i++) {
+      List<InetSocketAddress> addresses = NetUtils.createLocalServerAddress(100);
+      assertEquals(addresses.stream().distinct().collect(Collectors.toList()), addresses);
+    }
+  }
+}

--- a/ratis-examples/src/main/bin/common.sh
+++ b/ratis-examples/src/main/bin/common.sh
@@ -38,7 +38,7 @@ fi
 
 echo "Found ${ARTIFACT}"
 
-QUORUM_OPTS="--peers n0:localhost:6000:6010:6020:6030,n1:localhost:6001:6011:6021:6031,n2:localhost:6002:6012:6022:6032"
+QUORUM_OPTS="--peers n0:localhost:6000,n1:localhost:6001,n2:localhost:6002"
 
 CONF_DIR="$DIR/../conf"
 if [[ -d "${CONF_DIR}" ]]; then

--- a/ratis-examples/src/main/bin/common.sh
+++ b/ratis-examples/src/main/bin/common.sh
@@ -38,7 +38,7 @@ fi
 
 echo "Found ${ARTIFACT}"
 
-QUORUM_OPTS="--peers n0:localhost:6000,n1:localhost:6001,n2:localhost:6002"
+QUORUM_OPTS="--peers n0:localhost:6000:6010:6020:6030,n1:localhost:6001:6011:6021:6031,n2:localhost:6002:6012:6022:6032"
 
 CONF_DIR="$DIR/../conf"
 if [[ -d "${CONF_DIR}" ]]; then

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/cli/Server.java
@@ -35,6 +35,7 @@ import org.apache.ratis.util.NetUtils;
 
 import java.io.File;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -59,6 +60,12 @@ public class Server extends SubCommandBase {
 
     final int port = NetUtils.createSocketAddr(getPeer(peerId).getAddress()).getPort();
     GrpcConfigKeys.Server.setPort(properties, port);
+
+    Optional.ofNullable(getPeer(peerId).getClientAddress()).ifPresent(address ->
+        GrpcConfigKeys.Client.setPort(properties, NetUtils.createSocketAddr(address).getPort()));
+    Optional.ofNullable(getPeer(peerId).getAdminAddress()).ifPresent(address ->
+        GrpcConfigKeys.Admin.setPort(properties, NetUtils.createSocketAddr(address).getPort()));
+
     properties.setInt(GrpcConfigKeys.OutputStream.RETRY_TIMES_KEY, Integer.MAX_VALUE);
     RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(storageDir));
     StateMachine stateMachine = new ArithmeticStateMachine();

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/common/SubCommandBase.java
@@ -36,8 +36,8 @@ public abstract class SubCommandBase {
   private String raftGroupId = "demoRaftGroup123";
 
   @Parameter(names = {"--peers", "-r"}, description =
-      "Raft peers (format: name:host:port:dataStreamPort,"
-          + "name:host:port)", required = true)
+      "Raft peers (format: name:host:port:dataStreamPort:clientPort:adminPort,"
+          + "...)", required = true)
   private String peers;
 
   public static RaftPeer[] parsePeers(String peers) {
@@ -45,8 +45,14 @@ public abstract class SubCommandBase {
       String[] addressParts = address.split(":");
       RaftPeer.Builder builder = RaftPeer.newBuilder();
       builder.setId(addressParts[0]).setAddress(addressParts[1] + ":" + addressParts[2]);
-      if (addressParts.length == 4) {
-        builder.setDataStreamAddress(addressParts[1] + ":" + addressParts[3]).build();
+      if (addressParts.length >= 4) {
+        builder.setDataStreamAddress(addressParts[1] + ":" + addressParts[3]);
+        if (addressParts.length >= 5) {
+          builder.setClientAddress(addressParts[1] + ":" + addressParts[4]);
+          if (addressParts.length >= 6) {
+            builder.setAdminAddress(addressParts[1] + ":" + addressParts[5]);
+          }
+        }
       }
       return builder.build();
     }).toArray(RaftPeer[]::new);

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Server.java
@@ -44,6 +44,7 @@ import org.apache.ratis.util.TimeDuration;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -84,6 +85,12 @@ public class Server extends SubCommandBase {
 
     final int port = NetUtils.createSocketAddr(getPeer(peerId).getAddress()).getPort();
     GrpcConfigKeys.Server.setPort(properties, port);
+
+    Optional.ofNullable(getPeer(peerId).getClientAddress()).ifPresent(address ->
+        GrpcConfigKeys.Client.setPort(properties, NetUtils.createSocketAddr(address).getPort()));
+    Optional.ofNullable(getPeer(peerId).getAdminAddress()).ifPresent(address ->
+        GrpcConfigKeys.Admin.setPort(properties, NetUtils.createSocketAddr(address).getPort()));
+
     String dataStreamAddress = getPeer(peerId).getDataStreamAddress();
     if (dataStreamAddress != null) {
       final int dataStreamport = NetUtils.createSocketAddr(dataStreamAddress).getPort();

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcConfigKeys.java
@@ -96,6 +96,54 @@ public interface GrpcConfigKeys {
     }
   }
 
+  interface Admin {
+    String PREFIX = GrpcConfigKeys.PREFIX + ".admin";
+
+    String PORT_KEY = PREFIX + ".port";
+    int PORT_DEFAULT = -1;
+    static int port(RaftProperties properties) {
+      final int port = getInt(properties::getInt,
+          PORT_KEY, PORT_DEFAULT, getDefaultLog(), requireMin(-1), requireMax(65536));
+      return port != PORT_DEFAULT ? port : Server.port(properties);
+    }
+    static void setPort(RaftProperties properties, int port) {
+      setInt(properties::setInt, PORT_KEY, port);
+    }
+
+    String TLS_CONF_PARAMETER = PREFIX + ".tls.conf";
+    Class<GrpcTlsConfig> TLS_CONF_CLASS = TLS.CONF_CLASS;
+    static GrpcTlsConfig tlsConf(Parameters parameters) {
+      return parameters != null ? parameters.get(TLS_CONF_PARAMETER, TLS_CONF_CLASS): null;
+    }
+    static void setTlsConf(Parameters parameters, GrpcTlsConfig conf) {
+      parameters.put(TLS_CONF_PARAMETER, conf, TLS_CONF_CLASS);
+    }
+  }
+
+  interface Client {
+    String PREFIX = GrpcConfigKeys.PREFIX + ".client";
+
+    String PORT_KEY = PREFIX + ".port";
+    int PORT_DEFAULT = -1;
+    static int port(RaftProperties properties) {
+      final int port = getInt(properties::getInt,
+          PORT_KEY, PORT_DEFAULT, getDefaultLog(), requireMin(-1), requireMax(65536));
+      return port != PORT_DEFAULT ? port : Server.port(properties);
+    }
+    static void setPort(RaftProperties properties, int port) {
+      setInt(properties::setInt, PORT_KEY, port);
+    }
+
+    String TLS_CONF_PARAMETER = PREFIX + ".tls.conf";
+    Class<GrpcTlsConfig> TLS_CONF_CLASS = TLS.CONF_CLASS;
+    static GrpcTlsConfig tlsConf(Parameters parameters) {
+      return parameters != null ? parameters.get(TLS_CONF_PARAMETER, TLS_CONF_CLASS): null;
+    }
+    static void setTlsConf(Parameters parameters, GrpcTlsConfig conf) {
+      parameters.put(TLS_CONF_PARAMETER, conf, TLS_CONF_CLASS);
+    }
+  }
+
   interface Server {
     String PREFIX = GrpcConfigKeys.PREFIX + ".server";
 
@@ -107,6 +155,15 @@ public interface GrpcConfigKeys {
     }
     static void setPort(RaftProperties properties, int port) {
       setInt(properties::setInt, PORT_KEY, port);
+    }
+
+    String TLS_CONF_PARAMETER = PREFIX + ".tls.conf";
+    Class<GrpcTlsConfig> TLS_CONF_CLASS = TLS.CONF_CLASS;
+    static GrpcTlsConfig tlsConf(Parameters parameters) {
+      return parameters != null ? parameters.get(TLS_CONF_PARAMETER, TLS_CONF_CLASS): null;
+    }
+    static void setTlsConf(Parameters parameters, GrpcTlsConfig conf) {
+      parameters.put(TLS_CONF_PARAMETER, conf, TLS_CONF_CLASS);
     }
 
     String LEADER_OUTSTANDING_APPENDS_MAX_KEY = PREFIX + ".leader.outstanding.appends.max";

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcFactory.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcFactory.java
@@ -65,18 +65,19 @@ public class GrpcFactory implements ServerFactory, ClientFactory {
 
   public GrpcFactory(Parameters parameters) {
     this(
+        GrpcConfigKeys.TLS.conf(parameters),
         GrpcConfigKeys.Admin.tlsConf(parameters),
         GrpcConfigKeys.Client.tlsConf(parameters),
-        GrpcConfigKeys.Server.tlsConf(parameters),
-        GrpcConfigKeys.TLS.conf(parameters));
+        GrpcConfigKeys.Server.tlsConf(parameters)
+    );
   }
 
   public GrpcFactory(GrpcTlsConfig tlsConfig) {
-    this(null, null, null, tlsConfig);
+    this(tlsConfig, null, null, null);
   }
 
-  private GrpcFactory(GrpcTlsConfig adminTlsConfig, GrpcTlsConfig clientTlsConfig,
-      GrpcTlsConfig serverTlsConfig, GrpcTlsConfig tlsConfig) {
+  private GrpcFactory(GrpcTlsConfig tlsConfig, GrpcTlsConfig adminTlsConfig,
+      GrpcTlsConfig clientTlsConfig, GrpcTlsConfig serverTlsConfig) {
     this.tlsConfig = tlsConfig;
     this.adminTlsConfig = adminTlsConfig;
     this.clientTlsConfig = clientTlsConfig;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcFactory.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/GrpcFactory.java
@@ -53,6 +53,9 @@ public class GrpcFactory implements ServerFactory, ClientFactory {
   }
 
   private final GrpcTlsConfig tlsConfig;
+  private final GrpcTlsConfig adminTlsConfig;
+  private final GrpcTlsConfig clientTlsConfig;
+  private final GrpcTlsConfig serverTlsConfig;
 
   public static Parameters newRaftParameters(GrpcTlsConfig conf) {
     final Parameters p = new Parameters();
@@ -61,15 +64,39 @@ public class GrpcFactory implements ServerFactory, ClientFactory {
   }
 
   public GrpcFactory(Parameters parameters) {
-    this(GrpcConfigKeys.TLS.conf(parameters));
+    this(
+        GrpcConfigKeys.Admin.tlsConf(parameters),
+        GrpcConfigKeys.Client.tlsConf(parameters),
+        GrpcConfigKeys.Server.tlsConf(parameters),
+        GrpcConfigKeys.TLS.conf(parameters));
   }
 
   public GrpcFactory(GrpcTlsConfig tlsConfig) {
+    this(null, null, null, tlsConfig);
+  }
+
+  private GrpcFactory(GrpcTlsConfig adminTlsConfig, GrpcTlsConfig clientTlsConfig,
+      GrpcTlsConfig serverTlsConfig, GrpcTlsConfig tlsConfig) {
     this.tlsConfig = tlsConfig;
+    this.adminTlsConfig = adminTlsConfig;
+    this.clientTlsConfig = clientTlsConfig;
+    this.serverTlsConfig = serverTlsConfig;
   }
 
   public GrpcTlsConfig getTlsConfig() {
     return tlsConfig;
+  }
+
+  public GrpcTlsConfig getAdminTlsConfig() {
+    return adminTlsConfig != null ? adminTlsConfig : tlsConfig;
+  }
+
+  public GrpcTlsConfig getClientTlsConfig() {
+    return clientTlsConfig != null ? clientTlsConfig : tlsConfig;
+  }
+
+  public GrpcTlsConfig getServerTlsConfig() {
+    return serverTlsConfig != null ? serverTlsConfig : tlsConfig;
   }
 
   @Override
@@ -87,13 +114,16 @@ public class GrpcFactory implements ServerFactory, ClientFactory {
     checkPooledByteBufAllocatorUseCacheForAllThreads(LOG::info);
     return GrpcService.newBuilder()
         .setServer(server)
-        .setTlsConfig(tlsConfig)
+        .setAdminTlsConfig(getAdminTlsConfig())
+        .setServerTlsConfig(getServerTlsConfig())
+        .setClientTlsConfig(getClientTlsConfig())
         .build();
   }
 
   @Override
   public GrpcClientRpc newRaftClientRpc(ClientId clientId, RaftProperties properties) {
     checkPooledByteBufAllocatorUseCacheForAllThreads(LOG::debug);
-    return new GrpcClientRpc(clientId, properties, getTlsConfig());
+    return new GrpcClientRpc(clientId, properties,
+        getAdminTlsConfig(), getClientTlsConfig());
   }
 }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
@@ -101,8 +101,10 @@ public class GrpcClientProtocolClient implements Closeable {
     final SizeInBytes maxMessageSize = GrpcConfigKeys.messageSizeMax(properties, LOG::debug);
     final MetricClientInterceptor monitoringInterceptor = new MetricClientInterceptor(getName());
 
-    final String clientAddress = Optional.ofNullable(target.getClientAddress()).orElse(target.getAddress());
-    final String adminAddress = Optional.ofNullable(target.getAdminAddress()).orElse(target.getAddress());
+    final String clientAddress = Optional.ofNullable(target.getClientAddress())
+        .filter(x -> !x.isEmpty()).orElse(target.getAddress());
+    final String adminAddress = Optional.ofNullable(target.getAdminAddress())
+        .filter(x -> !x.isEmpty()).orElse(target.getAddress());
     final boolean separateAdminChannel = !Objects.equals(clientAddress, adminAddress);
 
     clientChannel = buildChannel(clientAddress, clientTlsConfig,

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
@@ -101,8 +101,8 @@ public class GrpcClientProtocolClient implements Closeable {
     final SizeInBytes maxMessageSize = GrpcConfigKeys.messageSizeMax(properties, LOG::debug);
     final MetricClientInterceptor monitoringInterceptor = new MetricClientInterceptor(getName());
 
-    final String clientAddress = target.getClientAddress();
-    final String adminAddress = target.getAdminAddress();
+    final String clientAddress = Optional.ofNullable(target.getClientAddress()).orElse(target.getAddress());
+    final String adminAddress = Optional.ofNullable(target.getAdminAddress()).orElse(target.getAddress());
     final boolean separateAdminChannel = !Objects.equals(clientAddress, adminAddress);
 
     clientChannel = buildChannel(clientAddress, clientTlsConfig,

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolClient.java
@@ -40,7 +40,6 @@ import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
 import org.apache.ratis.proto.grpc.AdminProtocolServiceGrpc;
 import org.apache.ratis.proto.grpc.AdminProtocolServiceGrpc.AdminProtocolServiceBlockingStub;
 import org.apache.ratis.proto.grpc.RaftClientProtocolServiceGrpc;
-import org.apache.ratis.proto.grpc.RaftClientProtocolServiceGrpc.RaftClientProtocolServiceBlockingStub;
 import org.apache.ratis.proto.grpc.RaftClientProtocolServiceGrpc.RaftClientProtocolServiceStub;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.apache.ratis.protocol.ClientId;
@@ -65,6 +64,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -79,13 +79,13 @@ public class GrpcClientProtocolClient implements Closeable {
 
   private final Supplier<String> name;
   private final RaftPeer target;
-  private final ManagedChannel channel;
+  private final ManagedChannel clientChannel;
+  private final ManagedChannel adminChannel;
 
   private final TimeDuration requestTimeoutDuration;
   private final TimeDuration watchRequestTimeoutDuration;
   private final TimeoutScheduler scheduler = TimeoutScheduler.getInstance();
 
-  private final RaftClientProtocolServiceBlockingStub blockingStub;
   private final RaftClientProtocolServiceStub asyncStub;
   private final AdminProtocolServiceBlockingStub adminBlockingStub;
 
@@ -93,15 +93,39 @@ public class GrpcClientProtocolClient implements Closeable {
 
   private final AtomicReference<AsyncStreamObservers> unorderedStreamObservers = new AtomicReference<>();
 
-  GrpcClientProtocolClient(ClientId id, RaftPeer target, RaftProperties properties, GrpcTlsConfig tlsConf) {
+  GrpcClientProtocolClient(ClientId id, RaftPeer target, RaftProperties properties,
+      GrpcTlsConfig adminTlsConfig, GrpcTlsConfig clientTlsConfig) {
     this.name = JavaUtils.memoize(() -> id + "->" + target.getId());
     this.target = target;
     final SizeInBytes flowControlWindow = GrpcConfigKeys.flowControlWindow(properties, LOG::debug);
     final SizeInBytes maxMessageSize = GrpcConfigKeys.messageSizeMax(properties, LOG::debug);
-    NettyChannelBuilder channelBuilder =
-        NettyChannelBuilder.forTarget(target.getAddress());
+    final MetricClientInterceptor monitoringInterceptor = new MetricClientInterceptor(getName());
 
-    if (tlsConf!= null) {
+    final String clientAddress = target.getClientAddress();
+    final String adminAddress = target.getAdminAddress();
+    final boolean separateAdminChannel = !Objects.equals(clientAddress, adminAddress);
+
+    clientChannel = buildChannel(clientAddress, clientTlsConfig,
+        flowControlWindow, maxMessageSize, monitoringInterceptor);
+    adminChannel = separateAdminChannel
+        ? buildChannel(adminAddress, adminTlsConfig,
+            flowControlWindow, maxMessageSize, monitoringInterceptor)
+        : clientChannel;
+
+    asyncStub = RaftClientProtocolServiceGrpc.newStub(clientChannel);
+    adminBlockingStub = AdminProtocolServiceGrpc.newBlockingStub(adminChannel);
+    this.requestTimeoutDuration = RaftClientConfigKeys.Rpc.requestTimeout(properties);
+    this.watchRequestTimeoutDuration =
+        RaftClientConfigKeys.Rpc.watchRequestTimeout(properties);
+  }
+
+  private ManagedChannel buildChannel(String address, GrpcTlsConfig tlsConf,
+      SizeInBytes flowControlWindow, SizeInBytes maxMessageSize,
+      MetricClientInterceptor monitoringInterceptor) {
+    NettyChannelBuilder channelBuilder =
+        NettyChannelBuilder.forTarget(address);
+
+    if (tlsConf != null) {
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
       if (tlsConf.isFileBasedConfig()) {
         sslContextBuilder.trustManager(tlsConf.getTrustStoreFile());
@@ -127,19 +151,10 @@ public class GrpcClientProtocolClient implements Closeable {
       channelBuilder.negotiationType(NegotiationType.PLAINTEXT);
     }
 
-    MetricClientInterceptor monitoringInterceptor = new MetricClientInterceptor(getName());
-
-    channel = channelBuilder.flowControlWindow(flowControlWindow.getSizeInt())
+    return channelBuilder.flowControlWindow(flowControlWindow.getSizeInt())
         .maxInboundMessageSize(maxMessageSize.getSizeInt())
         .intercept(monitoringInterceptor)
         .build();
-
-    blockingStub = RaftClientProtocolServiceGrpc.newBlockingStub(channel);
-    asyncStub = RaftClientProtocolServiceGrpc.newStub(channel);
-    adminBlockingStub = AdminProtocolServiceGrpc.newBlockingStub(channel);
-    this.requestTimeoutDuration = RaftClientConfigKeys.Rpc.requestTimeout(properties);
-    this.watchRequestTimeoutDuration =
-        RaftClientConfigKeys.Rpc.watchRequestTimeout(properties);
   }
 
   String getName() {
@@ -150,7 +165,10 @@ public class GrpcClientProtocolClient implements Closeable {
   public void close() {
     Optional.ofNullable(orderedStreamObservers.getAndSet(null)).ifPresent(AsyncStreamObservers::close);
     Optional.ofNullable(unorderedStreamObservers.getAndSet(null)).ifPresent(AsyncStreamObservers::close);
-    GrpcUtil.shutdownManagedChannel(channel);
+    GrpcUtil.shutdownManagedChannel(clientChannel);
+    if (clientChannel != adminChannel) {
+      GrpcUtil.shutdownManagedChannel(adminChannel);
+    }
     scheduler.close();
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolProxy.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientProtocolProxy.java
@@ -37,7 +37,7 @@ public class GrpcClientProtocolProxy implements Closeable {
   public GrpcClientProtocolProxy(ClientId clientId, RaftPeer target,
       Function<RaftPeer, CloseableStreamObserver> responseHandlerCreation,
       RaftProperties properties, GrpcTlsConfig tlsConfig) {
-    proxy = new GrpcClientProtocolClient(clientId, target, properties, tlsConfig);
+    proxy = new GrpcClientProtocolClient(clientId, target, properties, tlsConfig, tlsConfig);
     this.responseHandlerCreation = responseHandlerCreation;
   }
 

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientRpc.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientRpc.java
@@ -50,14 +50,13 @@ public class GrpcClientRpc extends RaftClientRpcWithProxy<GrpcClientProtocolClie
 
   private final ClientId clientId;
   private final int maxMessageSize;
-  private final GrpcTlsConfig tlsConfig;
 
-  public GrpcClientRpc(ClientId clientId, RaftProperties properties, GrpcTlsConfig tlsConfig) {
+  public GrpcClientRpc(ClientId clientId, RaftProperties properties,
+      GrpcTlsConfig adminTlsConfig, GrpcTlsConfig clientTlsConfig) {
     super(new PeerProxyMap<>(clientId.toString(),
-        p -> new GrpcClientProtocolClient(clientId, p, properties, tlsConfig)));
+        p -> new GrpcClientProtocolClient(clientId, p, properties, adminTlsConfig, clientTlsConfig)));
     this.clientId = clientId;
     this.maxMessageSize = GrpcConfigKeys.messageSizeMax(properties, LOG::debug).getSizeInt();
-    this.tlsConfig = tlsConfig;
   }
 
   @Override

--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
@@ -23,10 +23,14 @@ import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.server.GrpcService;
 import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.impl.DelayLocalExecutionInjection;
 import org.apache.ratis.server.impl.MiniRaftCluster;
+import org.apache.ratis.util.NetUtils;
+
+import java.util.Optional;
 
 /**
  * A {@link MiniRaftCluster} with {{@link SupportedRpcType#GRPC}} and data stream disabled.
@@ -58,6 +62,10 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
   @Override
   protected Parameters setPropertiesAndInitParameters(RaftPeerId id, RaftGroup group, RaftProperties properties) {
     GrpcConfigKeys.Server.setPort(properties, getPort(id, group));
+    Optional.ofNullable(getAddress(id, group, RaftPeer::getClientAddress)).ifPresent(address ->
+        GrpcConfigKeys.Client.setPort(properties, NetUtils.createSocketAddr(address).getPort()));
+    Optional.ofNullable(getAddress(id, group, RaftPeer::getAdminAddress)).ifPresent(address ->
+        GrpcConfigKeys.Admin.setPort(properties, NetUtils.createSocketAddr(address).getPort()));
     return null;
   }
 

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -26,6 +26,8 @@ message RaftPeerProto {
   string address = 2; // e.g. address of the RPC server
   uint32 priority = 3; // priority of the peer
   string dataStreamAddress = 4; // address of the data stream server
+  string clientAddress = 5; // address of the client RPC server
+  string adminAddress = 6; // address of the admin RPC server
 }
 
 message RaftPeerIdProto {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/RaftServerRpc.java
@@ -35,8 +35,17 @@ public interface RaftServerRpc extends RaftServerProtocol, RpcType.Get, RaftPeer
   /** Start the RPC service. */
   void start() throws IOException;
 
-  /** @return the address where this RPC server is listening to. */
+  /** @return the address where this RPC server is listening */
   InetSocketAddress getInetSocketAddress();
+
+  /** @return the address where this RPC server is listening for client requests */
+  default InetSocketAddress getClientServerAddress() {
+    return getInetSocketAddress();
+  }
+  /** @return the address where this RPC server is listening for admin requests */
+  default InetSocketAddress getAdminServerAddress() {
+    return getInetSocketAddress();
+  }
 
   /** Handle the given exception.  For example, try reconnecting. */
   void handleException(RaftPeerId serverId, Exception e, boolean reconnect);

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftServerProxy.java
@@ -296,6 +296,8 @@ class RaftServerProxy implements RaftServer {
         .setId(getId())
         .setAddress(getServerRpc().getInetSocketAddress())
         .setDataStreamAddress(getDataStreamServerRpc().getInetSocketAddress())
+        .setClientAddress(getServerRpc().getClientServerAddress())
+        .setAdminAddress(getServerRpc().getAdminServerAddress())
         .build();
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/RaftReconfigurationBaseTest.java
@@ -106,7 +106,7 @@ public abstract class RaftReconfigurationBaseTest<CLUSTER extends MiniRaftCluste
       for (int i = 0; i < peers.size(); i++) {
         RaftPeer peer = peers.get(i);
         peersWithPriority.add(
-            RaftPeer.newBuilder().setId(peer.getId()).setAddress(peer.getAddress()).setPriority(i).build());
+            RaftPeer.newBuilder(peer).setPriority(i).build());
       }
 
       final RaftGroup newGroup = RaftGroup.valueOf(RaftGroupId.randomId(), peersWithPriority);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make it possible to expose client, server and admin services on different ports and with different TLS configuration.

https://issues.apache.org/jira/browse/RATIS-1290

## How was this patch tested?

* unit test coverage: updated `MiniRaftCluster` to use different ports
* examples: tested with arithmetic and filestore
* integrated with Ozone (locally for now)