### PR TITLE
RATIS-1297. Adjust Github nofications settings to use issues@ mailing list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,6 +26,6 @@ github:
     rebase:  false
 notifications:
   commits:      commits@ratis.apache.org
-  issues:       dev@ratis.apache.org
-  pullrequests: dev@ratis.apache.org
+  issues:       issues@ratis.apache.org
+  pullrequests: issues@ratis.apache.org
   jira_options: link label worklog


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/RATIS-1297

## What changes were proposed in this pull request?

As discussed in 

https://lists.apache.org/thread.html/r3f50ee6cf72e678eb53c3b47d48c34c4272000aba6abaaf879cc560d%40%3Cdev.ratis.apache.org%3E

the notifications can be forwarded to issues@ mailing list instead of dev@ to make it easier to follow the archive of dev@
 
