### PR TITLE
RATIS-1299. Fix version 0.4.0 can not download

### DIFF
--- a/layouts/custompage/downloads.html
+++ b/layouts/custompage/downloads.html
@@ -80,14 +80,14 @@ The binaries are also uploaded to the maven central for convenience. (See the ge
        <td>0.4.0</td>
        <td>2019 Sep 12 </td>
        <td>
-         <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-src.tar.gz">source</a>
-         (<a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-src.tar.gz.mds">checksum</a>
-         <a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-src.tar.gz.asc">signature</a>)
+         <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz">source</a>
+         (<a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz.mds">checksum</a>
+         <a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-src.tar.gz.asc">signature</a>)
         </td>
         <td>
-          <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-bin.tar.gz">binary</a>
-          (<a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-bin.tar.gz.mds">checksum</a>
-          <a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-bin.tar.gz.asc">signature</a>)
+          <a href="https://www.apache.org/dyn/closer.cgi/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz">binary</a>
+          (<a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz.mds">checksum</a>
+          <a href="https://downloads.apache.org/incubator/ratis/0.4.0/apache-ratis-incubating-0.4.0-rc4-bin.tar.gz.asc">signature</a>)
          </td>
          <td>
            <a href="post/0.4.0.html">Announcement</a>


### PR DESCRIPTION
0.4.0 -> 0.4.0-rc4
