### PR TITLE
RATIS-1301. LeaderElection works when learners are in RaftGroup

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroup.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/RaftGroup.java
@@ -43,17 +43,27 @@ public final class RaftGroup {
     return new RaftGroup(groupId, peers);
   }
 
+  public static RaftGroup valueOf(RaftGroupId groupId, Collection<RaftPeer> peers, Collection<RaftPeer> learners) {
+    return new RaftGroup(groupId, peers, learners);
+  }
+
   /** The group id */
   private final RaftGroupId groupId;
   /** The group of raft peers */
   private final Map<RaftPeerId, RaftPeer> peers;
+  private final Map<RaftPeerId, RaftPeer> learners;
 
   private RaftGroup() {
     this.groupId = RaftGroupId.emptyGroupId();
     this.peers = Collections.emptyMap();
+    this.learners = Collections.emptyMap();
   }
 
   private RaftGroup(RaftGroupId groupId, Collection<RaftPeer> peers) {
+    this(groupId, peers, Collections.emptyList());
+  }
+
+  private RaftGroup(RaftGroupId groupId, Collection<RaftPeer> peers, Collection<RaftPeer> learners) {
     this.groupId = Objects.requireNonNull(groupId, "groupId == null");
     Preconditions.assertTrue(!groupId.equals(EMPTY_GROUP.getGroupId()),
         () -> "Group Id " + groupId + " is reserved for the empty group.");
@@ -65,6 +75,14 @@ public final class RaftGroup {
       peers.forEach(p -> map.put(p.getId(), p));
       this.peers = Collections.unmodifiableMap(map);
     }
+
+    if (learners == null || learners.isEmpty()) {
+      this.learners = Collections.emptyMap();
+    } else {
+      final Map<RaftPeerId, RaftPeer> map = new HashMap<>();
+      learners.forEach(p -> map.put(p.getId(), p));
+      this.learners = Collections.unmodifiableMap(map);
+    }
   }
 
   public RaftGroupId getGroupId() {
@@ -75,9 +93,21 @@ public final class RaftGroup {
     return peers.values();
   }
 
+  public Collection<RaftPeer> getLearners() {
+    return learners.values();
+  }
+
   /** @return the peer with the given id if it is in this group; otherwise, return null. */
   public RaftPeer getPeer(RaftPeerId id) {
     return peers.get(Objects.requireNonNull(id, "id == null"));
+  }
+
+  public RaftPeer getLearner(RaftPeerId id) {
+    return learners.get(Objects.requireNonNull(id, "id == null"));
+  }
+
+  public boolean isLearner(RaftPeerId id) {
+    return learners.containsKey(id);
   }
 
   @Override

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/LearningOnlyException.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/exceptions/LearningOnlyException.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ratis.protocol.exceptions;
+
+import org.apache.ratis.protocol.RaftGroupMemberId;
+
+public class LearningOnlyException extends RaftException {
+  public LearningOnlyException(RaftGroupMemberId id) {
+    super(id + " is in LEARNER state.");
+  }
+}

--- a/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
+++ b/ratis-grpc/src/test/java/org/apache/ratis/grpc/MiniRaftClusterWithGrpc.java
@@ -39,9 +39,9 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
   public static final Factory<MiniRaftClusterWithGrpc> FACTORY
       = new Factory<MiniRaftClusterWithGrpc>() {
     @Override
-    public MiniRaftClusterWithGrpc newCluster(String[] ids, RaftProperties prop) {
+    public MiniRaftClusterWithGrpc newCluster(String[] ids, String[] idOfLearners, RaftProperties prop) {
       RaftConfigKeys.Rpc.setType(prop, SupportedRpcType.GRPC);
-      return new MiniRaftClusterWithGrpc(ids, prop);
+      return new MiniRaftClusterWithGrpc(ids, idOfLearners, prop);
     }
   };
 
@@ -54,6 +54,10 @@ public class MiniRaftClusterWithGrpc extends MiniRaftCluster.RpcBase {
 
   public static final DelayLocalExecutionInjection sendServerRequestInjection =
       new DelayLocalExecutionInjection(GrpcService.GRPC_SEND_SERVER_REQUEST);
+
+  protected MiniRaftClusterWithGrpc(String[] ids, String[] idOfLearners, RaftProperties properties) {
+    super(ids, idOfLearners, properties, null);
+  }
 
   protected MiniRaftClusterWithGrpc(String[] ids, RaftProperties properties) {
     super(ids, properties, null);

--- a/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/MiniRaftClusterWithHadoopRpc.java
+++ b/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/MiniRaftClusterWithHadoopRpc.java
@@ -44,7 +44,7 @@ public class MiniRaftClusterWithHadoopRpc extends MiniRaftCluster.RpcBase {
     }
 
     @Override
-    public MiniRaftClusterWithHadoopRpc newCluster(String[] ids, RaftProperties prop) {
+    public MiniRaftClusterWithHadoopRpc newCluster(String[] ids, String[] idOfLearners, RaftProperties prop) {
       final Configuration conf = new Configuration();
       return newCluster(ids, prop, conf);
     }
@@ -55,10 +55,15 @@ public class MiniRaftClusterWithHadoopRpc extends MiniRaftCluster.RpcBase {
     }
 
     public MiniRaftClusterWithHadoopRpc newCluster(
-        String[] ids, RaftProperties prop, Configuration conf) {
+        String[] ids, String[] idOfLearners, RaftProperties prop, Configuration conf) {
       RaftConfigKeys.Rpc.setType(prop, SupportedRpcType.HADOOP);
       HadoopConfigKeys.Ipc.setAddress(conf, "0.0.0.0:0");
-      return new MiniRaftClusterWithHadoopRpc(ids, prop, conf);
+      return new MiniRaftClusterWithHadoopRpc(ids, idOfLearners, prop, conf);
+    }
+
+    public MiniRaftClusterWithHadoopRpc newCluster(
+        String[] ids, RaftProperties prop, Configuration conf) {
+      return newCluster(ids, new String[]{}, prop, conf);
     }
   }
 
@@ -69,9 +74,9 @@ public class MiniRaftClusterWithHadoopRpc extends MiniRaftCluster.RpcBase {
 
   private final Configuration hadoopConf;
 
-  private MiniRaftClusterWithHadoopRpc(String[] ids, RaftProperties properties,
+  private MiniRaftClusterWithHadoopRpc(String[] ids, String[] idOfLearners, RaftProperties properties,
       Configuration hadoopConf) {
-    super(ids, properties, HadoopFactory.newRaftParameters(hadoopConf));
+    super(ids, idOfLearners, properties, HadoopFactory.newRaftParameters(hadoopConf));
     this.hadoopConf = hadoopConf;
   }
 

--- a/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/TestRaftWithHadoopRpc.java
+++ b/ratis-hadoop/src/test/java/org/apache/ratis/hadooprpc/TestRaftWithHadoopRpc.java
@@ -43,8 +43,8 @@ public class TestRaftWithHadoopRpc
   static final MiniRaftCluster.Factory<MiniRaftClusterWithHadoopRpc> FACTORY
       = new MiniRaftClusterWithHadoopRpc.Factory() {
     @Override
-    public MiniRaftClusterWithHadoopRpc newCluster(String[] ids, RaftProperties prop) {
-      return newCluster(ids, prop, CONF);
+    public MiniRaftClusterWithHadoopRpc newCluster(String[] ids, String[] idsOfLearners, RaftProperties prop) {
+      return newCluster(ids, idsOfLearners, prop, CONF);
     }
   };
 

--- a/ratis-netty/src/test/java/org/apache/ratis/netty/MiniRaftClusterWithNetty.java
+++ b/ratis-netty/src/test/java/org/apache/ratis/netty/MiniRaftClusterWithNetty.java
@@ -35,9 +35,9 @@ public class MiniRaftClusterWithNetty extends MiniRaftCluster.RpcBase {
   public static final Factory<MiniRaftClusterWithNetty> FACTORY
       = new Factory<MiniRaftClusterWithNetty>() {
     @Override
-    public MiniRaftClusterWithNetty newCluster(String[] ids, RaftProperties prop) {
+    public MiniRaftClusterWithNetty newCluster(String[] ids, String[] idOfLearners, RaftProperties prop) {
       RaftConfigKeys.Rpc.setType(prop, SupportedRpcType.NETTY);
-      return new MiniRaftClusterWithNetty(ids, prop);
+      return new MiniRaftClusterWithNetty(ids, idOfLearners, prop);
     }
   };
 
@@ -50,6 +50,10 @@ public class MiniRaftClusterWithNetty extends MiniRaftCluster.RpcBase {
 
   public static final DelayLocalExecutionInjection sendServerRequest
       = new DelayLocalExecutionInjection(NettyRpcService.SEND_SERVER_REQUEST);
+
+  protected MiniRaftClusterWithNetty(String[] ids, String[] idOfLearners, RaftProperties properties) {
+    super(ids, idOfLearners, properties, null);
+  }
 
   protected MiniRaftClusterWithNetty(String[] ids, RaftProperties properties) {
     super(ids, properties, null);

--- a/ratis-proto/src/main/proto/Raft.proto
+++ b/ratis-proto/src/main/proto/Raft.proto
@@ -260,6 +260,7 @@ enum RaftPeerRole {
   LEADER = 0;
   CANDIDATE = 1;
   FOLLOWER = 2;
+  LEARNER = 3;
 }
 
 message WriteRequestTypeProto {

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionInfo.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/DivisionInfo.java
@@ -34,6 +34,11 @@ public interface DivisionInfo {
     return getCurrentRole() == RaftPeerRole.FOLLOWER;
   }
 
+  /** Is this server division currently a learner? */
+  default boolean isLearner() {
+    return getCurrentRole() == RaftPeerRole.LEARNER;
+  }
+
   /** Is this server division currently a candidate? */
   default boolean isCandidate() {
     return getCurrentRole() == RaftPeerRole.CANDIDATE;

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PeerConfiguration.java
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The peer configuration of a raft cluster.
@@ -36,21 +38,44 @@ import java.util.Objects;
  */
 class PeerConfiguration {
   private final Map<RaftPeerId, RaftPeer> peers;
+  private final Map<RaftPeerId, RaftPeer> learners;
 
   PeerConfiguration(Iterable<RaftPeer> peers) {
+    this(peers, Collections.emptyList());
+  }
+
+  PeerConfiguration(Iterable<RaftPeer> peers, Iterable<RaftPeer> learners) {
     Objects.requireNonNull(peers);
-    Map<RaftPeerId, RaftPeer> map = new HashMap<>();
+    Objects.requireNonNull(learners);
+    Map<RaftPeerId, RaftPeer> peerMap = new HashMap<>();
     for(RaftPeer p : peers) {
-      final RaftPeer previous = map.putIfAbsent(p.getId(), p);
+      final RaftPeer previous = peerMap.putIfAbsent(p.getId(), p);
       if (previous != null) {
         throw new IllegalArgumentException("Found duplicated ids " + p.getId() + " in peers " + peers);
       }
     }
-    this.peers = Collections.unmodifiableMap(map);
+    this.peers = Collections.unmodifiableMap(peerMap);
+
+    Map<RaftPeerId, RaftPeer> learnerMap = new HashMap<>();
+    for(RaftPeer p : learners) {
+      final RaftPeer previous = learnerMap.putIfAbsent(p.getId(), p);
+      if (previous != null) {
+        throw new IllegalArgumentException("Found duplicated ids " + p.getId() + " in learners " + learners);
+      }
+    }
+    this.learners = Collections.unmodifiableMap(learnerMap);
   }
 
   Collection<RaftPeer> getPeers() {
     return Collections.unmodifiableCollection(peers.values());
+  }
+
+  Collection<RaftPeer> getAllPeers() {
+    Stream<RaftPeer> combinedStream = Stream.of(peers.values(), learners.values())
+        .flatMap(Collection::stream);
+    Collection<RaftPeer> peersCombined =
+        combinedStream.collect(Collectors.toList());
+    return Collections.unmodifiableCollection(peersCombined);
   }
 
   int size() {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RaftConfigurationImpl.java
@@ -65,6 +65,10 @@ final class RaftConfigurationImpl implements RaftConfiguration {
       return setConf(new PeerConfiguration(peers));
     }
 
+    Builder setConf(Iterable<RaftPeer> peers, Iterable<RaftPeer> learners) {
+      return setConf(new PeerConfiguration(peers, learners));
+    }
+
     Builder setConf(RaftConfigurationImpl transitionalConf) {
       Objects.requireNonNull(transitionalConf);
       Preconditions.assertTrue(transitionalConf.isTransitional());
@@ -185,12 +189,12 @@ final class RaftConfigurationImpl implements RaftConfiguration {
 
   @Override
   public Collection<RaftPeer> getAllPeers() {
-    final Collection<RaftPeer> peers = new ArrayList<>(conf.getPeers());
+    final Collection<RaftPeer> allPeers = new ArrayList<>(conf.getAllPeers());
     if (oldConf != null) {
-      oldConf.getPeers().stream().filter(p -> !peers.contains(p))
-          .forEach(peers::add);
+      oldConf.getAllPeers().stream().filter(p -> !allPeers.contains(p))
+          .forEach(allPeers::add);
     }
-    return peers;
+    return allPeers;
   }
 
   /**

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/RoleInfo.java
@@ -37,6 +37,7 @@ class RoleInfo {
   public static final Logger LOG = LoggerFactory.getLogger(RoleInfo.class);
 
   private final RaftPeerId id;
+  private final boolean isLearner;
   private volatile RaftPeerRole role;
   /** Used when the peer is leader */
   private final AtomicReference<LeaderStateImpl> leaderState = new AtomicReference<>();
@@ -47,9 +48,14 @@ class RoleInfo {
 
   private final AtomicReference<Timestamp> transitionTime;
 
-  RoleInfo(RaftPeerId id) {
+  RoleInfo(RaftPeerId id, boolean isLearner) {
     this.id = id;
+    this.isLearner = isLearner;
     this.transitionTime = new AtomicReference<>(Timestamp.currentTime());
+  }
+
+  boolean isLearner() {
+    return this.isLearner;
   }
 
   void transitionRole(RaftPeerRole newRole) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/ServerState.java
@@ -100,7 +100,8 @@ class ServerState implements Closeable {
       throws IOException {
     this.memberId = RaftGroupMemberId.valueOf(id, group.getGroupId());
     this.server = server;
-    final RaftConfigurationImpl initialConf = RaftConfigurationImpl.newBuilder().setConf(group.getPeers()).build();
+    final RaftConfigurationImpl initialConf =
+        RaftConfigurationImpl.newBuilder().setConf(group.getPeers(), group.getLearners()).build();
     configurationManager = new ConfigurationManager(initialConf);
     LOG.info("{}: {}", getMemberId(), configurationManager);
 

--- a/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/impl/LeaderElectionTests.java
@@ -58,10 +58,7 @@ import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LAST_LEADER_
 import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECTION_COUNT_METRIC;
 import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECTION_TIME_TAKEN;
 import static org.apache.ratis.server.metrics.LeaderElectionMetrics.LEADER_ELECTION_TIMEOUT_COUNT_METRIC;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -402,6 +399,21 @@ public abstract class LeaderElectionTests<CLUSTER extends MiniRaftCluster>
         Assert.assertTrue(reply.isSuccess());
       }
 
+      cluster.shutdown();
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testLearnerInLeaderElection() {
+    try (final MiniRaftCluster cluster = newCluster(3, 1)) {
+      cluster.start();
+      RaftServer.Division leader = waitForLeader(cluster);
+      assertNotNull(leader);
+      for (RaftPeer learner : cluster.learners.values()) {
+        assertNotEquals(learner.getId(), learner.getId());
+      }
       cluster.shutdown();
     } catch (Exception e) {
       fail(e.getMessage());

--- a/ratis-server/src/test/java/org/apache/ratis/server/simulation/MiniRaftClusterWithSimulatedRpc.java
+++ b/ratis-server/src/test/java/org/apache/ratis/server/simulation/MiniRaftClusterWithSimulatedRpc.java
@@ -41,7 +41,7 @@ public class MiniRaftClusterWithSimulatedRpc extends MiniRaftCluster {
       = new Factory<MiniRaftClusterWithSimulatedRpc>() {
     @Override
     public MiniRaftClusterWithSimulatedRpc newCluster(
-        String[] ids, RaftProperties prop) {
+        String[] ids, String[] idsOfLearners, RaftProperties prop) {
       RaftConfigKeys.Rpc.setType(prop, SimulatedRpc.INSTANCE);
       if (ThreadLocalRandom.current().nextBoolean()) {
         // turn off simulate latency half of the times.
@@ -54,7 +54,7 @@ public class MiniRaftClusterWithSimulatedRpc extends MiniRaftCluster {
           = new SimulatedRequestReply<>(simulateLatencyMs);
       final SimulatedClientRpc client2serverRequestReply
           = new SimulatedClientRpc(simulateLatencyMs);
-      return new MiniRaftClusterWithSimulatedRpc(ids, prop,
+      return new MiniRaftClusterWithSimulatedRpc(ids, idsOfLearners, prop,
           serverRequestReply, client2serverRequestReply);
     }
   };
@@ -70,10 +70,10 @@ public class MiniRaftClusterWithSimulatedRpc extends MiniRaftCluster {
   private final SimulatedClientRpc client2serverRequestReply;
 
   private MiniRaftClusterWithSimulatedRpc(
-      String[] ids, RaftProperties properties,
+      String[] ids, String[] idOfLearners, RaftProperties properties,
       SimulatedRequestReply<RaftServerRequest, RaftServerReply> serverRequestReply,
       SimulatedClientRpc client2serverRequestReply) {
-    super(ids, properties,
+    super(ids, idOfLearners, properties,
         SimulatedRpc.Factory.newRaftParameters(serverRequestReply, client2serverRequestReply));
     this.serverRequestReply = serverRequestReply;
     this.client2serverRequestReply = client2serverRequestReply;

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty.java
@@ -34,7 +34,7 @@ public class MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty extends MiniRa
   public static final Factory<MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty> FACTORY
       = new Factory<MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty>() {
     @Override
-    public MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty newCluster(String[] ids, RaftProperties prop) {
+    public MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty newCluster(String[] ids, String[] idOfLearners, RaftProperties prop) {
       RaftConfigKeys.Rpc.setType(prop, SupportedRpcType.GRPC);
       RaftConfigKeys.DataStream.setType(prop, SupportedDataStreamType.NETTY);
       return new MiniRaftClusterWithRpcTypeGrpcAndDataStreamTypeNetty(ids, prop);

--- a/ratis-test/src/test/java/org/apache/ratis/datastream/MiniRaftClusterWithRpcTypeNettyAndDataStreamTypeNetty.java
+++ b/ratis-test/src/test/java/org/apache/ratis/datastream/MiniRaftClusterWithRpcTypeNettyAndDataStreamTypeNetty.java
@@ -34,7 +34,7 @@ public class MiniRaftClusterWithRpcTypeNettyAndDataStreamTypeNetty extends MiniR
   public static final Factory<MiniRaftClusterWithRpcTypeNettyAndDataStreamTypeNetty> FACTORY
       = new Factory<MiniRaftClusterWithRpcTypeNettyAndDataStreamTypeNetty>() {
     @Override
-    public MiniRaftClusterWithRpcTypeNettyAndDataStreamTypeNetty newCluster(String[] ids, RaftProperties prop) {
+    public MiniRaftClusterWithRpcTypeNettyAndDataStreamTypeNetty newCluster(String[] ids, String[] idOfLearners, RaftProperties prop) {
       RaftConfigKeys.Rpc.setType(prop, SupportedRpcType.NETTY);
       RaftConfigKeys.DataStream.setType(prop, SupportedDataStreamType.NETTY);
       return new MiniRaftClusterWithRpcTypeNettyAndDataStreamTypeNetty(ids, prop);


### PR DESCRIPTION
## What changes were proposed in this pull request?
1. Support learner role in RaftServerImpl.
2. Add Learners in MiniRaftCluster
3. Add learners in RaftGroup
4. Make sure leader election can succeed even learners are in RaftGroup. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/RATIS-1301

## How was this patch tested?
UT