### PR TITLE
RATIS-1302. JvmPauseMonitor logs multi-line message

### DIFF
--- a/ratis-common/src/main/java/org/apache/ratis/util/JvmPauseMonitor.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/JvmPauseMonitor.java
@@ -65,7 +65,7 @@ public class JvmPauseMonitor {
   static String toString(Map<String, GcInfo> beforeSleep, TimeDuration extraSleepTime, Map<String, GcInfo> afterSleep) {
     final StringBuilder b = new StringBuilder("Detected pause in JVM or host machine (eg GC): pause of approximately ")
         .append(extraSleepTime)
-        .append(System.lineSeparator());
+        .append('.');
 
     boolean detected = false;
     for(Map.Entry<String, GcInfo> before: beforeSleep.entrySet()) {
@@ -82,7 +82,7 @@ public class JvmPauseMonitor {
     }
 
     if (!detected) {
-      b.append(System.lineSeparator()).append("No GCs detected");
+      b.append(" No GCs detected.");
     }
     return b.toString();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Get rid of empty line in JvmPauseMonitor message.
2. Collapse message into a single line if `No GCs detected`.

ie. change this:

```
om_1 | 2021-01-29 14:59:37,955 [org.apache.ratis.util.JvmPauseMonitor$$Lambda$364/0x0000000840497c40@47272cd3] WARN util.JvmPauseMonitor: JvmPauseMonitor-om1: Detected pause in JVM or host machine (eg GC): pause of approximately 188209400ns
om_1 |
om_1 | No GCs detected
```

to this:

```
om_1 | 2021-01-29 16:47:26,546 [org.apache.ratis.util.JvmPauseMonitor$$Lambda$346/0x000000084047f040@6b9fdbc6] WARN util.JvmPauseMonitor: JvmPauseMonitor-om1: Detected pause in JVM or host machine (eg GC): pause of approximately 160745200ns. No GCs detected.
```

Also verified that pools are still printed to separate lines:

```
datanode_2  | 2021-01-29 17:03:17,098 [org.apache.ratis.util.JvmPauseMonitor$$Lambda$270/0x0000000840439440@53ff61d0] WARN util.JvmPauseMonitor: JvmPauseMonitor-044e6390-0280-452f-a4cf-93c19da78e6f: Detected pause in JVM or host machine (eg GC): pause of approximately 163103600ns.
datanode_2  | GC pool 'ParNew' had collection(s): count=2 time=245ms
datanode_2  | GC pool 'ConcurrentMarkSweep' had collection(s): count=1 time=1ms
```

https://issues.apache.org/jira/browse/RATIS-1302
https://github.com/adoroszlai/incubator-ratis/actions/runs/521470577