### PR TITLE
RATIS-1303. Upgrade Ratis Thirdparty to 0.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
     <maven.min.version>3.3.9</maven.min.version>
 
     <!-- Contains all shaded thirdparty dependencies -->
-    <ratis.thirdparty.version>0.6.0-SNAPSHOT</ratis.thirdparty.version>
+    <ratis.thirdparty.version>0.6.0</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
     <shaded.protobuf.version>3.11.0</shaded.protobuf.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade `ratis-thirdparty` to recently released `0.6.0`, because `0.6.0-SNAPSHOT` [is no longer in the repo](https://repository.apache.org/content/repositories/snapshots/org/apache/ratis/ratis-thirdparty-misc/0.6.0-SNAPSHOT).

https://issues.apache.org/jira/browse/RATIS-1303

## How was this patch tested?

Compiled successfully:
https://github.com/adoroszlai/incubator-ratis/actions/runs/525010715