### PR TITLE
RATIS-1303. Upgrade Ratis Thirdparty to 0.6.0 - addendum

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,8 +226,8 @@
     <ratis.thirdparty.version>0.6.0</ratis.thirdparty.version>
 
     <!-- Need these for the protobuf compiler. *MUST* match what is in ratis-thirdparty -->
-    <shaded.protobuf.version>3.11.0</shaded.protobuf.version>
-    <shaded.grpc.version>1.29.0</shaded.grpc.version>
+    <shaded.protobuf.version>3.12.0</shaded.protobuf.version>
+    <shaded.grpc.version>1.33.0</shaded.grpc.version>
 
     <hadoop.protobuf.version>2.5.0</hadoop.protobuf.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Match `protobuf` and `grpc` versions from `ratis-thirdparty`.

https://issues.apache.org/jira/browse/RATIS-1303