### PR TITLE
RATIS-1304. Do not print error if ratis log is not yet created

### DIFF
--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageImpl.java
@@ -144,9 +144,9 @@ public class RaftStorageImpl implements RaftStorage {
       LogEntryProto confProto = LogEntryProto.newBuilder().mergeFrom(fio).build();
       return LogProtoUtils.toRaftConfiguration(confProto);
     } catch (FileNotFoundException e) {
-
       return null;
     } catch (Exception e) {
+      LOG.error("Failed reading configuration from file:" + confFile, e);
       return null;
     }
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/RaftStorageImpl.java
@@ -143,8 +143,10 @@ public class RaftStorageImpl implements RaftStorage {
     try (FileInputStream fio = new FileInputStream(confFile)) {
       LogEntryProto confProto = LogEntryProto.newBuilder().mergeFrom(fio).build();
       return LogProtoUtils.toRaftConfiguration(confProto);
+    } catch (FileNotFoundException e) {
+
+      return null;
     } catch (Exception e) {
-      LOG.error("Failed reading configuration from file:" + confFile, e);
       return null;
     }
   }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/RATIS-1304

I found that Ozone prints out a lot of errors related to missing ratis-meta.conf, even if everything works well.

The related code path seems to be prepared to this case, but still prints out errors.