### PR TITLE
RATIS-1307. Cache Maven dependencies in CI workflow

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -95,7 +95,7 @@ jobs:
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - run: ./dev-support/checks/unit.sh
+        - run: ./dev-support/checks/unit.sh -Dtest=TestVerificationTool
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -27,12 +27,21 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-repo-
       - name: Setup java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - name: Run a full build
         run: ./dev-support/checks/build.sh
+      - name: Delete temporary build artifacts
+        run: rm -rf ~/.m2/repository/org/apache/ratis
+        if: always()
   rat:
     name: rat
     runs-on: ubuntu-18.04
@@ -60,6 +69,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/sonar.sh
           if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
           env:
@@ -74,25 +89,46 @@ jobs:
           with:
             name: unit
             path: target/unit
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   checkstyle:
     name: checkstyle
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/checkstyle.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: checkstyle
             path: target/checkstyle
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   findbugs:
     name: findbugs
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/findbugs.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: findbugs
             path: target/findbugs
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -31,8 +31,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-repo-
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
       - name: Setup java
         uses: actions/setup-java@v1
         with:
@@ -47,12 +49,23 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/rat.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: rat
             path: target/rat
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   author:
     name: author
     runs-on: ubuntu-18.04
@@ -73,8 +86,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/sonar.sh
           if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
           env:
@@ -101,8 +116,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/checkstyle.sh
         - uses: actions/upload-artifact@master
           if: always()
@@ -121,8 +138,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/findbugs.sh
         - uses: actions/upload-artifact@master
           if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -95,7 +95,7 @@ jobs:
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - run: ./dev-support/checks/unit.sh -Dtest=TestVerificationTool
+        - run: ./dev-support/checks/unit.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Save time in CI by caching the local Maven repository (dependencies downloaded during the build).

https://issues.apache.org/jira/browse/RATIS-1307

## How was this patch tested?

2-7 minutes per job saved [with the patch](https://github.com/adoroszlai/incubator-ratis/actions/runs/539952212) compared to [previous successful run](https://github.com/apache/incubator-ratis/actions/runs/538951717).  (Unit check is not comparable, because I limited the run to a single test.)