### PR TITLE
RATIS-1311. Upgrade Java for Sonar check

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -95,7 +95,7 @@ jobs:
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - run: ./dev-support/checks/unit.sh
+        - run: ./dev-support/checks/unit.sh -Dtest=TestVerificationTool
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -90,11 +90,6 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
-        - run: ./dev-support/checks/sonar.sh
-          if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
-          env:
-            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - run: ./dev-support/checks/unit.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
@@ -148,6 +143,31 @@ jobs:
           with:
             name: findbugs
             path: target/findbugs
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
+  sonar:
+    name: unit
+    runs-on: ubuntu-18.04
+    if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
+    steps:
+        - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
+        - name: Setup java 11
+          uses: actions/setup-java@v1
+          with:
+            java-version: 11
+        - run: ./dev-support/checks/sonar.sh
+          env:
+            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - name: Delete temporary build artifacts
           run: rm -rf ~/.m2/repository/org/apache/ratis
           if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -147,7 +147,7 @@ jobs:
           run: rm -rf ~/.m2/repository/org/apache/ratis
           if: always()
   sonar:
-    name: unit
+    name: sonar
     runs-on: ubuntu-18.04
     if: github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -149,7 +149,7 @@ jobs:
   sonar:
     name: unit
     runs-on: ubuntu-18.04
-    if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     steps:
         - uses: actions/checkout@master
         - name: Cache for maven dependencies
@@ -166,7 +166,7 @@ jobs:
             java-version: 11
         - run: ./dev-support/checks/sonar.sh
           env:
-            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+            SONAR_TOKEN: no-token-just-testing
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - name: Delete temporary build artifacts
           run: rm -rf ~/.m2/repository/org/apache/ratis

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -27,12 +27,21 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-repo-
       - name: Setup java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - name: Run a full build
         run: ./dev-support/checks/build.sh
+      - name: Delete temporary build artifacts
+        run: rm -rf ~/.m2/repository/org/apache/ratis
+        if: always()
   rat:
     name: rat
     runs-on: ubuntu-18.04
@@ -60,6 +69,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/sonar.sh
           if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
           env:
@@ -74,25 +89,46 @@ jobs:
           with:
             name: unit
             path: target/unit
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   checkstyle:
     name: checkstyle
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/checkstyle.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: checkstyle
             path: target/checkstyle
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   findbugs:
     name: findbugs
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/findbugs.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: findbugs
             path: target/findbugs
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -149,7 +149,7 @@ jobs:
   sonar:
     name: sonar
     runs-on: ubuntu-18.04
-    if: github.event_name != 'pull_request'
+    if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
     steps:
         - uses: actions/checkout@master
         - name: Cache for maven dependencies
@@ -166,7 +166,7 @@ jobs:
             java-version: 11
         - run: ./dev-support/checks/sonar.sh
           env:
-            SONAR_TOKEN: no-token-just-testing
+            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - name: Delete temporary build artifacts
           run: rm -rf ~/.m2/repository/org/apache/ratis

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -31,8 +31,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-repo-
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
       - name: Setup java
         uses: actions/setup-java@v1
         with:
@@ -47,12 +49,23 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/rat.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: rat
             path: target/rat
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   author:
     name: author
     runs-on: ubuntu-18.04
@@ -73,8 +86,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/sonar.sh
           if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
           env:
@@ -101,8 +116,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/checkstyle.sh
         - uses: actions/upload-artifact@master
           if: always()
@@ -121,8 +138,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/findbugs.sh
         - uses: actions/upload-artifact@master
           if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -95,7 +95,7 @@ jobs:
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - run: ./dev-support/checks/unit.sh -Dtest=TestVerificationTool
+        - run: ./dev-support/checks/unit.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sonar no longer accepts reports created using Java 8.  This change upgrades to Java 11.  Check is split from unit to avoid affecting that one, and also to let them execute concurrently.

https://issues.apache.org/jira/browse/RATIS-1311

## How was this patch tested?

Tested in own fork with temporarily removed repo name comparison: https://github.com/adoroszlai/incubator-ratis/actions/runs/540063075

The check was skipped in subsequent run with repo name comparison restored: https://github.com/adoroszlai/incubator-ratis/runs/1838364223