### PR TITLE
RATIS-1305. Leader stuck in infinite install snapshot cycle when logs have been purged

### DIFF
--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -562,17 +562,23 @@ public class GrpcLogAppender extends LogAppenderBase {
    * @return the first available log's start term index
    */
   private TermIndex shouldNotifyToInstallSnapshot() {
-    final long leaderStartIndex = getRaftLog().getStartIndex();
-    if (getFollower().getNextIndex() < leaderStartIndex) {
-      // The Leader does not have the logs from the Follower's last log
-      // index onwards. And install snapshot is disabled. So the Follower
-      // should be notified to install the latest snapshot through its
-      // State Machine.
-      return getRaftLog().getTermIndex(leaderStartIndex);
-    } else if (leaderStartIndex == RaftLog.INVALID_LOG_INDEX) {
-      // Leader has no logs to check from, hence return next index.
-      return TermIndex.valueOf(getServer().getInfo().getCurrentTerm(),
-          getRaftLog().getNextIndex());
+    final long followerNextIndex = getFollower().getNextIndex();
+    final long leaderNextIndex = getRaftLog().getNextIndex();
+
+    if (followerNextIndex < leaderNextIndex) {
+      final long leaderStartIndex = getRaftLog().getStartIndex();
+
+      if (followerNextIndex < leaderStartIndex) {
+        // The Leader does not have the logs from the Follower's last log
+        // index onwards. And install snapshot is disabled. So the Follower
+        // should be notified to install the latest snapshot through its
+        // State Machine.
+        return getRaftLog().getTermIndex(leaderStartIndex);
+      } else if (leaderStartIndex == RaftLog.INVALID_LOG_INDEX) {
+        // Leader has no logs to check from, hence return next index.
+        return TermIndex.valueOf(getServer().getInfo().getCurrentTerm(),
+            leaderNextIndex);
+      }
     }
     return null;
   }

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -565,21 +565,24 @@ public class GrpcLogAppender extends LogAppenderBase {
     final long followerNextIndex = getFollower().getNextIndex();
     final long leaderNextIndex = getRaftLog().getNextIndex();
 
-    if (followerNextIndex < leaderNextIndex) {
-      final long leaderStartIndex = getRaftLog().getStartIndex();
-
-      if (followerNextIndex < leaderStartIndex) {
-        // The Leader does not have the logs from the Follower's last log
-        // index onwards. And install snapshot is disabled. So the Follower
-        // should be notified to install the latest snapshot through its
-        // State Machine.
-        return getRaftLog().getTermIndex(leaderStartIndex);
-      } else if (leaderStartIndex == RaftLog.INVALID_LOG_INDEX) {
-        // Leader has no logs to check from, hence return next index.
-        return TermIndex.valueOf(getServer().getInfo().getCurrentTerm(),
-            leaderNextIndex);
-      }
+    if (followerNextIndex >= leaderNextIndex) {
+      return null;
     }
+
+    final long leaderStartIndex = getRaftLog().getStartIndex();
+
+    if (followerNextIndex < leaderStartIndex) {
+      // The Leader does not have the logs from the Follower's last log
+      // index onwards. And install snapshot is disabled. So the Follower
+      // should be notified to install the latest snapshot through its
+      // State Machine.
+      return getRaftLog().getTermIndex(leaderStartIndex);
+    } else if (leaderStartIndex == RaftLog.INVALID_LOG_INDEX) {
+      // Leader has no logs to check from, hence return next index.
+      return TermIndex.valueOf(getServer().getInfo().getCurrentTerm(),
+          leaderNextIndex);
+    }
+
     return null;
   }
 

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -251,7 +251,8 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
 
   private void testInstallSnapshotNotificationCount(CLUSTER cluster) throws Exception {
     leaderSnapshotInfoRef.set(null);
-    final List<LogSegmentPath> logs;
+    numSnapshotRequests.set(0);
+
     int i = 0;
     try {
       RaftTestUtil.waitForLeader(cluster);

--- a/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
+++ b/ratis-server/src/test/java/org/apache/ratis/InstallSnapshotNotificationTests.java
@@ -243,15 +243,10 @@ public abstract class InstallSnapshotNotificationTests<CLUSTER extends MiniRaftC
     }, 10, ONE_SECOND, "followerNextIndex", LOG);
   }
 
-
-
-
-
   @Test
   public void testInstallSnapshotNotificationCount() throws Exception {
     runWithNewCluster(3, this::testInstallSnapshotNotificationCount);
   }
-
 
 
   private void testInstallSnapshotNotificationCount(CLUSTER cluster) throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

After RATIS-1241, a leader with no logs will send install snapshot notifications to followers on every heartbeat, regardless of whether or not they are behind. Fix this so that followers only get install snapshot notifications when they are actually behind.

## What is the link to the Apache JIRA

[RATIS-1305](https://issues.apache.org/jira/browse/RATIS-1305)

## How was this patch tested?

Integration test added. The test still has an issue that is marked with a TODO. Leaving this PR as a draft while I fix this.
