### PR TITLE
Ratis 1314. Add JaCoCo coverity tests to Github actions

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -35,15 +35,15 @@ jobs:
           restore-keys: |
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
+      - name: Delete temporary build artifacts
+        run: rm -rf ~/.m2/repository/org/apache/ratis
+        if: always()
       - name: Setup java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - name: Run a full build
         run: ./dev-support/checks/build.sh
-      - name: Delete temporary build artifacts
-        run: rm -rf ~/.m2/repository/org/apache/ratis
-        if: always()
   rat:
     name: rat
     runs-on: ubuntu-18.04
@@ -57,15 +57,15 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
         - run: ./dev-support/checks/rat.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: rat
             path: target/rat
-        - name: Delete temporary build artifacts
-          run: rm -rf ~/.m2/repository/org/apache/ratis
-          if: always()
   author:
     name: author
     runs-on: ubuntu-18.04
@@ -96,18 +96,56 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
         - run: ./dev-support/checks/unit.sh -P${{ matrix.profile }}-tests
         - name: Summary of failures
-          run: cat target/${{ github.job }}/summary.txt
+          run: cat target/unit/summary.txt
           if: ${{ !cancelled() }}
         - uses: actions/upload-artifact@master
           if: ${{ !cancelled() }}
           with:
             name: unit-${{ matrix.profile }}
             path: target/unit
-        - name: Delete temporary build artifacts
-          run: rm -rf ~/.m2/repository/org/apache/ratis
-          if: always()
+  coverity:
+    name: coverity
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        profile:
+          - grpc
+          - server
+          - misc
+    steps:
+      - uses: actions/checkout@master
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
+      - name: Delete temporary build artifacts
+        run: rm -rf ~/.m2/repository/org/apache/ratis
+        if: always()
+      - run: >-
+          ./dev-support/checks/unit.sh -P${{ matrix.profile }}-tests
+          -Djacoco.skip=false
+          -Dsurefire.rerunFailingTestsCount=3
+      - name: Merge JaCoCo results
+        run: mvn -DskipTests -Djacoco.skip=false verify
+      - name: Copy JaCoCo XML report to artifacts
+        run: cp ./ratis-coverage/target/site/jacoco-aggregate/jacoco.xml ./target/unit
+      - name: Summary of failures
+        run: cat target/unit/summary.txt
+        if: ${{ !cancelled() }}
+      - uses: actions/upload-artifact@master
+        if: ${{ !cancelled() }}
+        with:
+          name: coverity-${{ matrix.profile }}
+          path: target/unit
   checkstyle:
     name: checkstyle
     runs-on: ubuntu-18.04
@@ -121,15 +159,15 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
         - run: ./dev-support/checks/checkstyle.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: checkstyle
             path: target/checkstyle
-        - name: Delete temporary build artifacts
-          run: rm -rf ~/.m2/repository/org/apache/ratis
-          if: always()
   findbugs:
     name: findbugs
     runs-on: ubuntu-18.04
@@ -143,21 +181,24 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
         - run: ./dev-support/checks/findbugs.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: findbugs
             path: target/findbugs
-        - name: Delete temporary build artifacts
-          run: rm -rf ~/.m2/repository/org/apache/ratis
-          if: always()
   sonar:
     name: sonar
     runs-on: ubuntu-18.04
+    needs: [coverity]
     if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
     steps:
-        - uses: actions/checkout@master
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
         - name: Cache for maven dependencies
           uses: actions/cache@v2
           with:
@@ -166,6 +207,11 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+        - name: Download test artifacts for coverity analysis
+          uses: actions/download-artifact@v2
+          if: always()
         - name: Setup java 11
           uses: actions/setup-java@v1
           with:
@@ -174,6 +220,3 @@ jobs:
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - name: Delete temporary build artifacts
-          run: rm -rf ~/.m2/repository/org/apache/ratis
-          if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -80,6 +80,12 @@ jobs:
   unit:
     name: unit
     runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        profile:
+          - grpc
+          - server
+          - misc
     steps:
         - uses: actions/checkout@master
         - name: Cache for maven dependencies
@@ -90,14 +96,14 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
-        - run: ./dev-support/checks/unit.sh
+        - run: ./dev-support/checks/unit.sh -P${{ matrix.profile }}-tests
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
-          if: always()
+          if: ${{ !cancelled() }}
         - uses: actions/upload-artifact@master
-          if: always()
+          if: ${{ !cancelled() }}
           with:
-            name: unit
+            name: unit-${{ matrix.profile }}
             path: target/unit
         - name: Delete temporary build artifacts
           run: rm -rf ~/.m2/repository/org/apache/ratis

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -95,7 +95,7 @@ jobs:
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - run: ./dev-support/checks/unit.sh
+        - run: ./dev-support/checks/unit.sh -Dtest=TestVerificationTool
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -90,11 +90,6 @@ jobs:
             restore-keys: |
               maven-repo-${{ hashFiles('**/pom.xml') }}
               maven-repo-
-        - run: ./dev-support/checks/sonar.sh
-          if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
-          env:
-            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - run: ./dev-support/checks/unit.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
@@ -148,6 +143,31 @@ jobs:
           with:
             name: findbugs
             path: target/findbugs
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
+  sonar:
+    name: unit
+    runs-on: ubuntu-18.04
+    if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
+    steps:
+        - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
+        - name: Setup java 11
+          uses: actions/setup-java@v1
+          with:
+            java-version: 11
+        - run: ./dev-support/checks/sonar.sh
+          env:
+            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - name: Delete temporary build artifacts
           run: rm -rf ~/.m2/repository/org/apache/ratis
           if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -147,7 +147,7 @@ jobs:
           run: rm -rf ~/.m2/repository/org/apache/ratis
           if: always()
   sonar:
-    name: unit
+    name: sonar
     runs-on: ubuntu-18.04
     if: github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -149,7 +149,7 @@ jobs:
   sonar:
     name: unit
     runs-on: ubuntu-18.04
-    if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     steps:
         - uses: actions/checkout@master
         - name: Cache for maven dependencies
@@ -166,7 +166,7 @@ jobs:
             java-version: 11
         - run: ./dev-support/checks/sonar.sh
           env:
-            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+            SONAR_TOKEN: no-token-just-testing
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - name: Delete temporary build artifacts
           run: rm -rf ~/.m2/repository/org/apache/ratis

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -27,12 +27,21 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-repo-
       - name: Setup java
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - name: Run a full build
         run: ./dev-support/checks/build.sh
+      - name: Delete temporary build artifacts
+        run: rm -rf ~/.m2/repository/org/apache/ratis
+        if: always()
   rat:
     name: rat
     runs-on: ubuntu-18.04
@@ -60,6 +69,12 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/sonar.sh
           if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
           env:
@@ -74,25 +89,46 @@ jobs:
           with:
             name: unit
             path: target/unit
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   checkstyle:
     name: checkstyle
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/checkstyle.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: checkstyle
             path: target/checkstyle
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   findbugs:
     name: findbugs
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}
+            restore-keys: maven-repo-
         - run: ./dev-support/checks/findbugs.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: findbugs
             path: target/findbugs
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -149,7 +149,7 @@ jobs:
   sonar:
     name: sonar
     runs-on: ubuntu-18.04
-    if: github.event_name != 'pull_request'
+    if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
     steps:
         - uses: actions/checkout@master
         - name: Cache for maven dependencies
@@ -166,7 +166,7 @@ jobs:
             java-version: 11
         - run: ./dev-support/checks/sonar.sh
           env:
-            SONAR_TOKEN: no-token-just-testing
+            SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         - name: Delete temporary build artifacts
           run: rm -rf ~/.m2/repository/org/apache/ratis

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -31,8 +31,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}
-          restore-keys: maven-repo-
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
       - name: Setup java
         uses: actions/setup-java@v1
         with:
@@ -47,12 +49,23 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
         - uses: actions/checkout@master
+        - name: Cache for maven dependencies
+          uses: actions/cache@v2
+          with:
+            path: ~/.m2/repository
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/rat.sh
         - uses: actions/upload-artifact@master
           if: always()
           with:
             name: rat
             path: target/rat
+        - name: Delete temporary build artifacts
+          run: rm -rf ~/.m2/repository/org/apache/ratis
+          if: always()
   author:
     name: author
     runs-on: ubuntu-18.04
@@ -73,8 +86,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/sonar.sh
           if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
           env:
@@ -101,8 +116,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/checkstyle.sh
         - uses: actions/upload-artifact@master
           if: always()
@@ -121,8 +138,10 @@ jobs:
           uses: actions/cache@v2
           with:
             path: ~/.m2/repository
-            key: maven-repo-${{ hashFiles('**/pom.xml') }}
-            restore-keys: maven-repo-
+            key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ github.job }}
+            restore-keys: |
+              maven-repo-${{ hashFiles('**/pom.xml') }}
+              maven-repo-
         - run: ./dev-support/checks/findbugs.sh
         - uses: actions/upload-artifact@master
           if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -95,7 +95,7 @@ jobs:
           env:
             SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        - run: ./dev-support/checks/unit.sh -Dtest=TestVerificationTool
+        - run: ./dev-support/checks/unit.sh
         - name: Summary of failures
           run: cat target/${{ github.job }}/summary.txt
           if: always()

--- a/dev-support/checks/findbugs.sh
+++ b/dev-support/checks/findbugs.sh
@@ -20,19 +20,19 @@ MAVEN_OPTIONS='-B -fae'
 
 if ! type unionBugs >/dev/null 2>&1 || ! type convertXmlToText >/dev/null 2>&1; then
   #shellcheck disable=SC2086
-  mvn ${MAVEN_OPTIONS} compile findbugs:check
+  mvn ${MAVEN_OPTIONS} compile spotbugs:check
   exit $?
 fi
 
 #shellcheck disable=SC2086
-mvn ${MAVEN_OPTIONS} compile findbugs:findbugs
+mvn ${MAVEN_OPTIONS} compile spotbugs:spotbugs
 rc=$?
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/findbugs"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-find ratis* -name findbugsXml.xml -print0 | xargs -0 unionBugs -output "${REPORT_DIR}"/summary.xml
+find ratis* -name spotbugsXml.xml -print0 | xargs -0 unionBugs -output "${REPORT_DIR}"/summary.xml
 convertXmlToText "${REPORT_DIR}"/summary.xml | tee "${REPORT_FILE}"
 convertXmlToText -html:fancy-hist.xsl "${REPORT_DIR}"/summary.xml "${REPORT_DIR}"/summary.html
 

--- a/dev-support/checks/findbugs.sh
+++ b/dev-support/checks/findbugs.sh
@@ -16,25 +16,24 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../.." || exit 1
 
-REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/findbugs"}
-mkdir -p "$REPORT_DIR"
-REPORT_FILE="$REPORT_DIR/summary.txt"
-
-touch "$REPORT_FILE"
-
 MAVEN_OPTIONS='-B -fae'
 
 if ! type unionBugs >/dev/null 2>&1 || ! type convertXmlToText >/dev/null 2>&1; then
   #shellcheck disable=SC2086
-  mvn ${MAVEN_OPTIONS} compile findbugs:check | tee "$REPORT_FILE"
+  mvn ${MAVEN_OPTIONS} compile findbugs:check
   exit $?
 fi
 
 #shellcheck disable=SC2086
-mvn ${MAVEN_OPTIONS} compile findbugs:check
+mvn ${MAVEN_OPTIONS} compile findbugs:findbugs
+rc=$?
 
-find $DIR -name spotbugsXml.xml -print0 | xargs -0 unionBugs -output "${REPORT_DIR}"/summary.xml
-convertXmlToText "${REPORT_DIR}"/summary.xml | tee -a "${REPORT_FILE}"
+REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/findbugs"}
+mkdir -p "$REPORT_DIR"
+REPORT_FILE="$REPORT_DIR/summary.txt"
+
+find ratis* -name findbugsXml.xml -print0 | xargs -0 unionBugs -output "${REPORT_DIR}"/summary.xml
+convertXmlToText "${REPORT_DIR}"/summary.xml | tee "${REPORT_FILE}"
 convertXmlToText -html:fancy-hist.xsl "${REPORT_DIR}"/summary.xml "${REPORT_DIR}"/summary.html
 
 wc -l "$REPORT_FILE" | awk '{print $1}'> "$REPORT_DIR/failures"
@@ -42,3 +41,5 @@ wc -l "$REPORT_FILE" | awk '{print $1}'> "$REPORT_DIR/failures"
 if [[ -s "${REPORT_FILE}" ]]; then
    exit 1
 fi
+
+exit ${rc}

--- a/dev-support/checks/findbugs.sh
+++ b/dev-support/checks/findbugs.sh
@@ -20,12 +20,12 @@ MAVEN_OPTIONS='-B -fae'
 
 if ! type unionBugs >/dev/null 2>&1 || ! type convertXmlToText >/dev/null 2>&1; then
   #shellcheck disable=SC2086
-  mvn ${MAVEN_OPTIONS} compile spotbugs:check
+  mvn ${MAVEN_OPTIONS} test-compile spotbugs:check
   exit $?
 fi
 
 #shellcheck disable=SC2086
-mvn ${MAVEN_OPTIONS} compile spotbugs:spotbugs
+mvn ${MAVEN_OPTIONS} test-compile spotbugs:spotbugs
 rc=$?
 
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../target/findbugs"}

--- a/dev-support/checks/sonar.sh
+++ b/dev-support/checks/sonar.sh
@@ -20,4 +20,7 @@ if [ ! "$SONAR_TOKEN" ]; then
   echo "SONAR_TOKEN environment variable should be set"
   exit 1
 fi
-mvn -B verify -DskipShade -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-ratis
+mvn -B verify -DskipShade -DskipTests org.sonarsource.scanner.maven:sonar-maven-plugin:3.6.0.1398:sonar \
+-Dsonar.host.url=https://sonarcloud.io \
+-Dsonar.coverage.jacoco.xmlReportPaths=$(find "$(pwd)" -path '*jacoco.xml' | tr '\n' ',') \
+-Dsonar.organization=apache -Dsonar.projectKey=apache_incubator-ratis

--- a/dev-support/checks/unit.sh
+++ b/dev-support/checks/unit.sh
@@ -26,7 +26,7 @@ export MAVEN_OPTS="-Xmx4096m"
 mvn -B -fae test "$@" | tee "${REPORT_DIR}/output.log"
 rc=$?
 
-# shellcheck source=hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
+# shellcheck source=dev-support/checks/_mvn_unit_report.sh
 source "$DIR/_mvn_unit_report.sh"
 
 if [[ -s "$REPORT_DIR/summary.txt" ]] ; then

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <module>ratis-resource-bundle</module>
     <module>ratis-grpc</module>
     <module>ratis-netty</module>
+    <module>ratis-coverage</module>
     <module>ratis-hadoop</module>
 
     <module>ratis-test</module>
@@ -249,6 +250,8 @@
     <!-- LOG4J version -->
     <log4j.version>1.2.17</log4j.version>
 
+    <!-- Skip JaCoCo coverity reports by default -->
+    <jacoco.skip>true</jacoco.skip>
   </properties>
 
   <dependencyManagement>
@@ -703,7 +706,7 @@
             <reuseForks>false</reuseForks>
             <trimStackTrace>false</trimStackTrace>
             <forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
-            <argLine>-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError</argLine>
+            <argLine>@{argLine} -Xmx2048m -XX:+HeapDumpOnOutOfMemoryError</argLine>
             <systemPropertyVariables>
               <ratis.log.dir>${project.build.directory}/log</ratis.log.dir>
               <ratis.tmp.dir>${project.build.directory}/tmp</ratis.tmp.dir>
@@ -885,6 +888,18 @@
               <outputDirectory>target/classes</outputDirectory>
               <outputName>ratis-version.properties</outputName>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
     <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-    <findbugs.version>3.0.0</findbugs.version>
+    <findbugs.version>3.0.5</findbugs.version>
     <wagon-ssh.version>1.0</wagon-ssh.version>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>

--- a/pom.xml
+++ b/pom.xml
@@ -1082,5 +1082,55 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>grpc-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>org.apache.ratis.grpc.**</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>server-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>org.apache.ratis.server.**</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>misc-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <excludes>
+                <exclude>org.apache.ratis.grpc.**</exclude>
+                <exclude>org.apache.ratis.server.**</exclude>
+              </excludes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1108,6 +1108,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <includes>
+                <include>org.apache.ratis.datastream.**</include>
                 <include>org.apache.ratis.server.**</include>
               </includes>
             </configuration>
@@ -1124,6 +1125,7 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <excludes>
+                <exclude>org.apache.ratis.datastream.**</exclude>
                 <exclude>org.apache.ratis.grpc.**</exclude>
                 <exclude>org.apache.ratis.server.**</exclude>
               </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,8 @@
     <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
     <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-    <findbugs.version>3.0.5</findbugs.version>
+    <spotbugs.version>4.2.1</spotbugs.version>
+    <spotbugs-plugin.version>4.2.0</spotbugs-plugin.version>
     <wagon-ssh.version>1.0</wagon-ssh.version>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
@@ -497,6 +498,13 @@
         <artifactId>javax.annotation-api</artifactId>
         <version>1.2</version>
       </dependency>
+
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-annotations</artifactId>
+        <version>${spotbugs.version}</version>
+        <optional>true</optional>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -563,9 +571,20 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>${findbugs.version}</version>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${spotbugs-plugin.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.github.spotbugs</groupId>
+              <artifactId>spotbugs</artifactId>
+              <version>${spotbugs.version}</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <fork>true</fork>
+            <maxHeap>2048</maxHeap>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -774,8 +793,8 @@
 
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -116,15 +116,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <configuration>
-          <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
-          <fork>true</fork>
-          <maxHeap>2048</maxHeap>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <!--Else will use ratis-assembly as final name.-->

--- a/ratis-common/pom.xml
+++ b/ratis-common/pom.xml
@@ -48,5 +48,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/conf/ConfUtils.java
@@ -266,6 +266,10 @@ public interface ConfUtils {
 
   static void printField(Class<?> confClass, Consumer<Object> out, Field f) {
     final int modifiers = f.getModifiers();
+    // Ignore synthetic fields. Required by JaCoCo coverity reports
+    if (f.isSynthetic()) {
+      return;
+    }
     if (!Modifier.isStatic(modifiers)) {
       throw new IllegalStateException("Found non-static field " + f);
     }

--- a/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamRequestByteBuffer.java
+++ b/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamRequestByteBuffer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.datastream.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.protocol.DataStreamRequest;
 import org.apache.ratis.protocol.DataStreamRequestHeader;
@@ -39,6 +40,7 @@ public class DataStreamRequestByteBuffer extends DataStreamPacketByteBuffer impl
   }
 
   @Override
+  @SuppressFBWarnings("EI_EXPOSE_REP")
   public WriteOption[] getWriteOptions() {
     return options;
   }

--- a/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamRequestFilePositionCount.java
+++ b/ratis-common/src/main/java/org/apache/ratis/datastream/impl/DataStreamRequestFilePositionCount.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.datastream.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.io.FilePositionCount;
 import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.protocol.DataStreamRequest;
@@ -48,6 +49,7 @@ public class DataStreamRequestFilePositionCount extends DataStreamPacketImpl imp
   }
 
   @Override
+  @SuppressFBWarnings("EI_EXPOSE_REP")
   public WriteOption[] getWriteOptions() {
     return options;
   }

--- a/ratis-common/src/main/java/org/apache/ratis/io/MD5Hash.java
+++ b/ratis-common/src/main/java/org/apache/ratis/io/MD5Hash.java
@@ -18,6 +18,8 @@
 
 package org.apache.ratis.io;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -51,6 +53,7 @@ public class MD5Hash {
   }
 
   /** Constructs an MD5Hash with a specified value. */
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public MD5Hash(byte[] digest) {
     if (digest.length != MD5_LEN) {
       throw new IllegalArgumentException("Wrong length: " + digest.length);
@@ -79,6 +82,7 @@ public class MD5Hash {
   }
 
   /** Returns the digest bytes. */
+  @SuppressFBWarnings("EI_EXPOSE_REP")
   public byte[] getDigest() {
     return digest;
   }

--- a/ratis-common/src/main/java/org/apache/ratis/protocol/DataStreamRequestHeader.java
+++ b/ratis-common/src/main/java/org/apache/ratis/protocol/DataStreamRequestHeader.java
@@ -18,6 +18,7 @@
 
 package org.apache.ratis.protocol;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.io.StandardWriteOption;
 import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.proto.RaftProtos.DataStreamPacketHeaderProto;
@@ -73,6 +74,7 @@ public class DataStreamRequestHeader extends DataStreamPacketHeader implements D
 
   private final WriteOption[] options;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public DataStreamRequestHeader(ClientId clientId, Type type, long streamId, long streamOffset, long dataLength,
       WriteOption... options) {
     super(clientId, type, streamId, streamOffset, dataLength);
@@ -80,6 +82,7 @@ public class DataStreamRequestHeader extends DataStreamPacketHeader implements D
   }
 
   @Override
+  @SuppressFBWarnings("EI_EXPOSE_REP")
   public WriteOption[] getWriteOptions() {
     return options;
   }

--- a/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/FileUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.util.function.CheckedSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -187,6 +188,7 @@ public interface FileUtils {
 
   // Rename a file by appending .corrupt to file name. This function does not guarantee
   // that the rename operation is successful.
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
   static void renameFileToCorrupt(File tmpSnapshotFile) {
     File corruptedTempFile = new File(tmpSnapshotFile.getPath() + ".corrupt");
     tmpSnapshotFile.renameTo(corruptedTempFile);

--- a/ratis-common/src/main/java/org/apache/ratis/util/JavaUtils.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/JavaUtils.java
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
-import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
@@ -50,7 +49,6 @@ import java.util.function.Supplier;
 public interface JavaUtils {
   Logger LOG = LoggerFactory.getLogger(JavaUtils.class);
 
-  DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS");
   CompletableFuture[] EMPTY_COMPLETABLE_FUTURE_ARRAY = {};
 
   ConcurrentMap<Class<?>, String> CLASS_SIMPLE_NAMES = new ConcurrentHashMap<>();
@@ -59,7 +57,7 @@ public interface JavaUtils {
   }
 
   static String date() {
-    return DATE_FORMAT.format(new Date());
+    return new SimpleDateFormat("yyyy-MM-dd hh:mm:ss,SSS").format(new Date());
   }
 
   /**

--- a/ratis-common/src/main/java/org/apache/ratis/util/PureJavaCrc32C.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/PureJavaCrc32C.java
@@ -20,6 +20,8 @@
  */
 package org.apache.ratis.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.zip.Checksum;
 
 /**
@@ -49,6 +51,7 @@ public class PureJavaCrc32C implements Checksum {
   }
 
   @Override
+  @SuppressFBWarnings("SF_SWITCH_NO_DEFAULT")
   public void update(byte[] b, int off, int len) {
     int localCrc = crc;
 

--- a/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
+++ b/ratis-common/src/main/java/org/apache/ratis/util/SlidingWindow.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.util;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.protocol.exceptions.AlreadyClosedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -213,6 +214,7 @@ public interface SlidingWindow {
     public Client(Object name) {
       this.requests = new RequestMap<REQUEST, REPLY>(getName(getClass(), name)) {
         @Override
+        @SuppressFBWarnings("IA_AMBIGUOUS_INVOCATION_OF_INHERITED_OR_OUTER_METHOD")
         synchronized void log() {
           LOG.debug(toString());
           for (REQUEST r : requests) {
@@ -376,7 +378,7 @@ public interface SlidingWindow {
       request.fail(new AlreadyClosedException(requests.getName() + " is closed.", e));
     }
 
-    public boolean isFirst(long seqNum) {
+    public synchronized boolean isFirst(long seqNum) {
       return seqNum == (firstSeqNum != -1 ? firstSeqNum : requests.firstSeqNum());
     }
   }

--- a/ratis-coverage/pom.xml
+++ b/ratis-coverage/pom.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>ratis</artifactId>
+        <groupId>org.apache.ratis</groupId>
+        <version>1.1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>report</artifactId>
+    <name>Apache Ratis Coverity Report</name>
+
+
+    <dependencies>
+        <!-- Intra-project dependencies -->
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-thirdparty-misc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-resource-bundle</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-docs</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-proto</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-common</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-common</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <artifactId>ratis-client</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-client</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-server</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-server</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <artifactId>ratis-grpc</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-grpc</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <artifactId>ratis-netty</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-netty</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <artifactId>ratis-hadoop</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-hadoop</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <artifactId>ratis-test</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-test</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <artifactId>ratis-examples</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-examples</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <artifactId>ratis-replicated-map</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-replicated-map</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <artifactId>ratis-logservice</artifactId>
+            <groupId>org.apache.ratis</groupId>
+        </dependency>
+        <dependency>
+            <artifactId>ratis-logservice</artifactId>
+            <groupId>org.apache.ratis</groupId>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-metrics</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-tools</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/ratis-examples/pom.xml
+++ b/ratis-examples/pom.xml
@@ -134,6 +134,12 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/NullValue.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/arithmetic/expression/NullValue.java
@@ -34,7 +34,7 @@ public final class NullValue implements Expression {
   @Override
   public int toBytes(byte[] buf, int offset) {
     Preconditions.assertTrue(offset + length() <= buf.length);
-    buf[offset++] = Type.NULL.byteValue();
+    buf[offset] = Type.NULL.byteValue();
     return length();
   }
 

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/counter/CounterCommon.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/counter/CounterCommon.java
@@ -23,6 +23,7 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftPeer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -30,12 +31,14 @@ import java.util.UUID;
  * Common Constant across servers and client
  */
 public final class CounterCommon {
-  public static final List<RaftPeer> PEERS = new ArrayList<>(3);
+  public static final List<RaftPeer> PEERS;
 
   static {
-    PEERS.add(RaftPeer.newBuilder().setId("n1").setAddress("127.0.0.1:6000").build());
-    PEERS.add(RaftPeer.newBuilder().setId("n2").setAddress("127.0.0.1:6001").build());
-    PEERS.add(RaftPeer.newBuilder().setId("n3").setAddress("127.0.0.1:6002").build());
+    List<RaftPeer> peers = new ArrayList<>(3);
+    peers.add(RaftPeer.newBuilder().setId("n1").setAddress("127.0.0.1:6000").build());
+    peers.add(RaftPeer.newBuilder().setId("n2").setAddress("127.0.0.1:6001").build());
+    peers.add(RaftPeer.newBuilder().setId("n3").setAddress("127.0.0.1:6002").build());
+    PEERS = Collections.unmodifiableList(peers);
   }
 
   private CounterCommon() {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/counter/client/CounterClient.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/counter/client/CounterClient.java
@@ -18,6 +18,7 @@
 
 package org.apache.ratis.examples.counter.client;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
@@ -46,6 +47,7 @@ public final class CounterClient {
   private CounterClient(){
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
   public static void main(String[] args)
       throws IOException, InterruptedException {
     //indicate the number of INCREMENT command, set 10 if no parameter passed
@@ -59,7 +61,7 @@ public final class CounterClient {
     ExecutorService executorService = Executors.newFixedThreadPool(10);
 
     //send INCREMENT commands concurrently
-    System.out.printf("Sending %d increment command...\n", increment);
+    System.out.printf("Sending %d increment command...%n", increment);
     for (int i = 0; i < increment; i++) {
       executorService.submit(() ->
           raftClient.io().send(Message.valueOf("INCREMENT")));

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/counter/server/CounterServer.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/counter/server/CounterServer.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Scanner;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Simplest Ratis server, use a simple state machine {@link CounterStateMachine}
  * which maintain a counter across multi server.
@@ -45,7 +47,7 @@ public final class CounterServer {
   private CounterServer(){
   }
 
-  public static void main(String[] args) throws IOException, InterruptedException {
+  public static void main(String[] args) throws IOException {
     if (args.length < 1) {
       System.err.println("Usage: java -cp *.jar org.apache.ratis.examples.counter.server.CounterServer {serverIndex}");
       System.err.println("{serverIndex} could be 1, 2 or 3");
@@ -81,7 +83,7 @@ public final class CounterServer {
     server.start();
 
     //exit when any input entered
-    Scanner scanner = new Scanner(System.in);
+    Scanner scanner = new Scanner(System.in, UTF_8.name());
     scanner.nextLine();
     server.close();
   }

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileInfo.java
@@ -273,7 +273,7 @@ abstract class FileInfo {
         committedSize += size;
 
         if (close) {
-          closeFunction.apply(this);
+          ReadOnly ignored = closeFunction.apply(this);
           writeInfos.remove(index);
         }
         info.getCommitFuture().complete(size);

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStore.java
@@ -278,7 +278,7 @@ public class FileStore implements Closeable {
   CompletableFuture<?> streamLink(DataStream dataStream) {
     return CompletableFuture.supplyAsync(() -> {
       if (dataStream == null) {
-        return JavaUtils.completeExceptionally(new IllegalStateException("Null stream: entry=" + dataStream));
+        return JavaUtils.completeExceptionally(new IllegalStateException("Null stream"));
       }
       if (dataStream.getDataChannel().isOpen()) {
         return JavaUtils.completeExceptionally(

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/FileStoreStateMachine.java
@@ -153,7 +153,7 @@ public class FileStoreStateMachine extends BaseStateMachine {
     return reply.thenApply(ExamplesProtos.ReadReplyProto::getData);
   }
 
-  class LocalStream implements DataStream {
+  static class LocalStream implements DataStream {
     private final DataChannel dataChannel;
 
     LocalStream(DataChannel dataChannel) {

--- a/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
+++ b/ratis-examples/src/main/java/org/apache/ratis/examples/filestore/cli/Client.java
@@ -18,6 +18,7 @@
 package org.apache.ratis.examples.filestore.cli;
 
 import com.beust.jcommander.Parameter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.client.RaftClientConfigKeys;
@@ -128,7 +129,7 @@ public abstract class Client extends SubCommandBase {
     operation(client);
   }
 
-
+  @SuppressFBWarnings("DM_EXIT")
   protected void stop(RaftClient client) throws IOException {
     client.close();
     System.exit(0);

--- a/ratis-grpc/pom.xml
+++ b/ratis-grpc/pom.xml
@@ -80,5 +80,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientStreamer.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/client/GrpcClientStreamer.java
@@ -337,8 +337,7 @@ public class GrpcClientStreamer implements Closeable {
     refreshLeader(nle.getSuggestedLeader().getId(), oldLeader);
   }
 
-  private void handleError(Throwable t, ResponseHandler handler) {
-    Preconditions.assertTrue(Thread.holdsLock(GrpcClientStreamer.this));
+  private synchronized void handleError(Throwable t, ResponseHandler handler) {
     final IOException e = GrpcUtil.unwrapIOException(t);
 
     exceptionAndRetry.addException(handler.targetId, e);

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerCallListener.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/metrics/intercept/server/MetricServerCallListener.java
@@ -18,10 +18,12 @@
 
 package org.apache.ratis.grpc.metrics.intercept.server;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.thirdparty.io.grpc.ForwardingServerCallListener;
 import org.apache.ratis.thirdparty.io.grpc.ServerCall;
 import org.apache.ratis.grpc.metrics.MessageMetrics;
 
+@SuppressFBWarnings("URF_UNREAD_FIELD")
 public class MetricServerCallListener<R> extends ForwardingServerCallListener<R> {
   private final ServerCall.Listener<R> delegate;
   private final String metricNamePrefix;

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcLogAppender.java
@@ -546,7 +546,7 @@ public class GrpcLogAppender extends LogAppenderBase {
     }
 
     synchronized (this) {
-      if (isRunning() && !responseHandler.isDone()) {
+      while (isRunning() && !responseHandler.isDone()) {
         try {
           wait();
         } catch (InterruptedException ignored) {

--- a/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
+++ b/ratis-grpc/src/main/java/org/apache/ratis/grpc/server/GrpcServerProtocolService.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.grpc.server;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.grpc.GrpcUtil;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.RaftServer;
@@ -41,7 +42,7 @@ import java.util.function.Supplier;
 class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
   public static final Logger LOG = LoggerFactory.getLogger(GrpcServerProtocolService.class);
 
-  class PendingServerRequest<REQUEST> {
+  static class PendingServerRequest<REQUEST> {
     private final REQUEST request;
     private final CompletableFuture<Void> future = new CompletableFuture<>();
 
@@ -105,6 +106,7 @@ class GrpcServerProtocolService extends RaftServerProtocolServiceImplBase {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     public void onNext(REQUEST request) {
       if (!replyInOrder(request)) {
         try {

--- a/ratis-hadoop/dev-support/findbugsExcludeFile.xml
+++ b/ratis-hadoop/dev-support/findbugsExcludeFile.xml
@@ -1,0 +1,21 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<FindBugsFilter>
+  <Match>
+    <Package name="org.apache.ratis.proto.hadoop"/>
+  </Match>
+</FindBugsFilter>

--- a/ratis-hadoop/pom.xml
+++ b/ratis-hadoop/pom.xml
@@ -92,6 +92,12 @@
       <artifactId>guava</artifactId>
       <version>11.0.2</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>
@@ -123,6 +129,13 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${project.basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
         </configuration>
       </plugin>
     </plugins>

--- a/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolServerSideTranslatorPB.java
+++ b/ratis-hadoop/src/main/java/org/apache/ratis/hadooprpc/client/CombinedClientProtocolServerSideTranslatorPB.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.ServiceException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.ratis.client.impl.ClientProtoUtils;
 import org.apache.ratis.proto.hadoop.HadoopCompatibilityProtos.ClientReplyProto;
@@ -52,6 +53,7 @@ public class CombinedClientProtocolServerSideTranslatorPB
   }
 
   @Override
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
   public ClientReplyProto sendClient(RpcController unused, ClientRequestProto req) throws ServiceException {
     ByteBuffer buf = req.getRequest().asReadOnlyByteBuffer();
     GeneratedMessageV3 response = null;

--- a/ratis-logservice/dev-support/findbugsExcludeFile.xml
+++ b/ratis-logservice/dev-support/findbugsExcludeFile.xml
@@ -1,0 +1,21 @@
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<FindBugsFilter>
+  <Match>
+    <Package name="org.apache.ratis.logservice.proto"/>
+  </Match>
+</FindBugsFilter>

--- a/ratis-logservice/pom.xml
+++ b/ratis-logservice/pom.xml
@@ -119,6 +119,13 @@
           </replacements>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${project.basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -311,6 +318,12 @@
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 </project>

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogMessage.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogMessage.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.logservice.api;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.protocol.Message;
 
 public abstract class LogMessage implements Message {
@@ -24,6 +25,7 @@ public abstract class LogMessage implements Message {
   /*
    * Log name
    */
+  @SuppressFBWarnings("UWF_UNWRITTEN_FIELD")
   private LogName logName;
 
   /**

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogServiceClient.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/api/LogServiceClient.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.apache.ratis.logservice.util.LogServiceProtoUtil.toChangeStateRequestProto;
 import static org.apache.ratis.logservice.util.LogServiceUtils.getPeersFromQuorum;
 
 
@@ -256,12 +257,8 @@ public class LogServiceClient implements AutoCloseable {
      */
     // TODO this name sucks, confusion WRT the Java Closeable interface.
     public void closeLog(LogName name) throws IOException {
-        try (RaftClient client = getRaftClient(getLogInfo(name))) {
-            RaftClientReply reply = client.io().send(
-                () -> LogServiceProtoUtil.toChangeStateRequestProto(name, State.CLOSED)
-                    .toByteString());
-            LogServiceProtos.ChangeStateReplyProto message =
-                LogServiceProtos.ChangeStateReplyProto.parseFrom(reply.getMessage().getContent());
+        try (RaftClient logClient = getRaftClient(getLogInfo(name))) {
+            logClient.io().send(() -> toChangeStateRequestProto(name, State.CLOSED).toByteString());
         }
     }
 

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/impl/ArchivedLogStreamImpl.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/impl/ArchivedLogStreamImpl.java
@@ -59,9 +59,7 @@ public class ArchivedLogStreamImpl implements LogStream {
 
   public ArchivedLogStreamImpl(LogName name, LogServiceConfiguration config) {
     this(name, config.get(Constants.LOG_SERVICE_ARCHIVAL_LOCATION_KEY));
-    if(config!=null) {
-      this.config = config;
-    }
+    this.config = config;
     init();
   }
 

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/impl/LogReaderImpl.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/impl/LogReaderImpl.java
@@ -93,7 +93,6 @@ public class LogReaderImpl implements LogReader {
       currentRecordId++;
 
       if (proto.getLogRecordCount() > 0) {
-        proto.getLogRecord(0);
         return ByteBuffer.wrap(proto.getLogRecord(0).toByteArray());
       } else {
         return null;

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/LogStateMachine.java
@@ -55,7 +55,6 @@ import org.apache.ratis.logservice.proto.LogServiceProtos;
 import org.apache.ratis.logservice.proto.LogServiceProtos.AppendLogEntryRequestProto;
 import org.apache.ratis.logservice.proto.LogServiceProtos.GetLogLengthRequestProto;
 import org.apache.ratis.logservice.proto.LogServiceProtos.GetLogSizeRequestProto;
-import org.apache.ratis.logservice.proto.LogServiceProtos.GetStateRequestProto;
 import org.apache.ratis.logservice.proto.LogServiceProtos.LogServiceRequestProto;
 import org.apache.ratis.logservice.proto.LogServiceProtos.ReadLogRequestProto;
 import org.apache.ratis.logservice.util.LogServiceProtoUtil;
@@ -285,7 +284,7 @@ public class LogStateMachine extends BaseStateMachine {
         case GETSTATE:
           return recordTime(getStateTimer, new Task(){
             @Override public CompletableFuture<Message> run() {
-              return processGetStateRequest(logServiceRequestProto);
+              return processGetStateRequest();
             }
           });
         case LASTINDEXQUERY:
@@ -306,7 +305,7 @@ public class LogStateMachine extends BaseStateMachine {
             return processArchiveLog(logServiceRequestProto);
           }});
       case EXPORTINFO:
-        return processExportInfo(logServiceRequestProto);
+        return processExportInfo();
       default:
           // TODO
           throw new RuntimeException(
@@ -320,15 +319,11 @@ public class LogStateMachine extends BaseStateMachine {
 
   }
 
-  private CompletableFuture<Message> processExportInfo(
-      LogServiceRequestProto logServiceRequestProto) {
-    LogServiceProtos.GetExportInfoRequestProto exportInfoRequestProto =
-        logServiceRequestProto.getExportInfo();
+  private CompletableFuture<Message> processExportInfo() {
     LogServiceProtos.GetExportInfoReplyProto.Builder exportBuilder =
         LogServiceProtos.GetExportInfoReplyProto.newBuilder();
-    exportMap.values().stream().map(
-        archInfo -> exportBuilder.addInfo(LogServiceProtoUtil.toExportInfoProto(archInfo)))
-            .collect(Collectors.toList());
+    exportMap.values().forEach(
+        archInfo -> exportBuilder.addInfo(LogServiceProtoUtil.toExportInfoProto(archInfo)));
 
     return CompletableFuture.completedFuture(Message.valueOf(exportBuilder.build().toByteString()));
   }
@@ -568,9 +563,7 @@ public class LogStateMachine extends BaseStateMachine {
         .valueOf(LogServiceProtos.ChangeStateReplyProto.newBuilder().build().toByteString()));
   }
 
-  private CompletableFuture<Message> processGetStateRequest(
-      LogServiceRequestProto logServiceRequestProto) {
-    GetStateRequestProto getState = logServiceRequestProto.getGetState();
+  private CompletableFuture<Message> processGetStateRequest() {
     return CompletableFuture.completedFuture(Message
         .valueOf(LogServiceProtoUtil.toGetStateReplyProto(state).toByteString()));
   }

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/server/MetaStateMachine.java
@@ -29,6 +29,7 @@ import java.util.stream.IntStream;
 import java.util.stream.StreamSupport;
 
 import com.codahale.metrics.Timer;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.logservice.api.LogInfo;
@@ -127,6 +128,7 @@ public class MetaStateMachine extends BaseStateMachine {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
     public TransactionContext applyTransactionSerial(TransactionContext trx) {
         RaftProtos.LogEntryProto x = trx.getLogEntry();
         MetaSMRequestProto req = null;
@@ -201,6 +203,7 @@ public class MetaStateMachine extends BaseStateMachine {
     }
 
     @Override
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
     public CompletableFuture<Message> query(Message request) {
         Timer.Context timerContext = null;
         MetaServiceProtos.MetaServiceRequestProto.TypeCase type = null;
@@ -403,7 +406,7 @@ public class MetaStateMachine extends BaseStateMachine {
     }
 
 
-    class PeerGroups implements Comparable{
+    static class PeerGroups implements Comparable{
         private RaftPeer peer;
         private Set<RaftGroup> groups = new HashSet<>();
 
@@ -420,6 +423,7 @@ public class MetaStateMachine extends BaseStateMachine {
         }
 
         @Override
+        @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
         public int compareTo(Object o) {
             return groups.size() - ((PeerGroups) o).groups.size();
         }

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ReadLogCommand.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/shell/commands/ReadLogCommand.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.logservice.api.LogName;
 import org.apache.ratis.logservice.api.LogReader;
 import org.apache.ratis.logservice.api.LogStream;
@@ -36,6 +37,7 @@ public class ReadLogCommand implements Command {
   }
 
   @Override
+  @SuppressFBWarnings("REC_CATCH_EXCEPTION")
   public void run(Terminal terminal, LineReader lineReader, LogServiceClient client, String[] args) {
     if (args.length != 1) {
       terminal.writer().println("ERROR - Usage: read <name>");

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/tool/VerificationTool.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/tool/VerificationTool.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.logservice.api.LogInfo;
 import org.apache.ratis.logservice.api.LogName;
 import org.apache.ratis.logservice.api.LogReader;
@@ -185,7 +186,8 @@ public class VerificationTool {
       return LogName.of(LOG_NAME_PREFIX + id);
     }
 
-    private static void waitForCompletion(List<Future<?>> futures) {
+  @SuppressFBWarnings("DM_EXIT")
+  private static void waitForCompletion(List<Future<?>> futures) {
         for (Future<?> future : futures) {
             try {
                 Object object = future.get();
@@ -385,6 +387,7 @@ public class VerificationTool {
           super(logName, client, numRecords, logFreq, valueSize);
       }
 
+        @SuppressFBWarnings("DM_EXIT")
         public void run() {
             try {
                 LogStream logStream = getClient().getLog(getLogName());

--- a/ratis-logservice/src/main/java/org/apache/ratis/logservice/util/LogServiceUtils.java
+++ b/ratis-logservice/src/main/java/org/apache/ratis/logservice/util/LogServiceUtils.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.ratis.logservice.api.LogName;
 import org.apache.ratis.protocol.RaftPeer;
 
+import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.util.Set;
@@ -48,7 +49,7 @@ public final class LogServiceUtils {
         try (DatagramSocket socket = new DatagramSocket()) {
             socket.connect(InetAddress.getByName("8.8.8.8"), 10002);
             return socket.getLocalAddress().getHostName();
-        } catch (Exception e) {
+        } catch (IOException e) {
             return "localhost";
         }
 
@@ -63,7 +64,7 @@ public final class LogServiceUtils {
     }
 
     public static Integer getRecordIdFromRolledArchiveFile(Path path) {
-        String[] splits = path.getName().toString().split("_recordId_");
+        String[] splits = path.getName().split("_recordId_");
         if (splits.length != 2) {
             //currently written file, should be read last
             return Integer.MAX_VALUE;

--- a/ratis-netty/pom.xml
+++ b/ratis-netty/pom.xml
@@ -72,5 +72,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamManagement.java
@@ -18,6 +18,7 @@
 
 package org.apache.ratis.netty.server;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.client.AsyncRpcApi;
 import org.apache.ratis.client.DataStreamOutputRpc;
 import org.apache.ratis.client.impl.ClientProtoUtils;
@@ -105,6 +106,7 @@ public class DataStreamManagement {
     private final LocalStream local;
     private final Set<RemoteStream> remotes;
     private final RaftServer server;
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     private final AtomicReference<CompletableFuture<Void>> previous
         = new AtomicReference<>(CompletableFuture.completedFuture(null));
 

--- a/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamRequestByteBuf.java
+++ b/ratis-netty/src/main/java/org/apache/ratis/netty/server/DataStreamRequestByteBuf.java
@@ -18,6 +18,7 @@
 
 package org.apache.ratis.netty.server;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.datastream.impl.DataStreamPacketImpl;
 import org.apache.ratis.io.WriteOption;
 import org.apache.ratis.protocol.ClientId;
@@ -36,6 +37,7 @@ public class DataStreamRequestByteBuf extends DataStreamPacketImpl implements Da
   private final ByteBuf buf;
   private final WriteOption[] options;
 
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
   public DataStreamRequestByteBuf(ClientId clientId, Type type, long streamId, long streamOffset, WriteOption[] options,
       ByteBuf buf) {
     super(clientId, type, streamId, streamOffset);
@@ -58,6 +60,7 @@ public class DataStreamRequestByteBuf extends DataStreamPacketImpl implements Da
   }
 
   @Override
+  @SuppressFBWarnings("EI_EXPOSE_REP")
   public WriteOption[] getWriteOptions() {
     return options;
   }

--- a/ratis-proto/pom.xml
+++ b/ratis-proto/pom.xml
@@ -25,6 +25,7 @@
 
   <properties>
     <maven.javadoc.skip>true</maven.javadoc.skip>
+    <spotbugs.skip>true</spotbugs.skip>
   </properties>
 
   <build>

--- a/ratis-server-api/pom.xml
+++ b/ratis-server-api/pom.xml
@@ -47,5 +47,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/server/leader/LogAppender.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.leader;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -127,6 +128,7 @@ public interface LogAppender {
    * (2) log indices changed, or
    * (3) a snapshot installation completed.
    */
+  @SuppressFBWarnings("NN_NAKED_NOTIFY")
   default void notifyLogAppender() {
     synchronized (this) {
       notify();

--- a/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
+++ b/ratis-server-api/src/main/java/org/apache/ratis/statemachine/StateMachine.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.statemachine;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.proto.RaftProtos.RaftConfigurationProto;
@@ -69,6 +70,7 @@ public interface StateMachine extends Closeable {
      *
      * @return a future for the read task.
      */
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     default CompletableFuture<ByteString> read(LogEntryProto entry) {
       return CompletableFuture.completedFuture(null);
     }
@@ -78,6 +80,7 @@ public interface StateMachine extends Closeable {
      *
      * @return a future for the write task
      */
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     default CompletableFuture<?> write(LogEntryProto entry) {
       return CompletableFuture.completedFuture(null);
     }
@@ -88,6 +91,7 @@ public interface StateMachine extends Closeable {
      *
      * @return a future of the stream.
      */
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     default CompletableFuture<DataStream> stream(RaftClientRequest request) {
       return CompletableFuture.completedFuture(null);
     }
@@ -102,6 +106,7 @@ public interface StateMachine extends Closeable {
      * @param entry the log entry to be linked.
      * @return a future for the link task.
      */
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     default CompletableFuture<?> link(DataStream stream, LogEntryProto entry) {
       return CompletableFuture.completedFuture(null);
     }
@@ -112,6 +117,7 @@ public interface StateMachine extends Closeable {
      * @param logIndex The log index to flush.
      * @return a future for the flush task.
      */
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     default CompletableFuture<Void> flush(long logIndex) {
       return CompletableFuture.completedFuture(null);
     }
@@ -123,6 +129,7 @@ public interface StateMachine extends Closeable {
      * @param logIndex The last log index after truncation.
      * @return a future for truncate task.
      */
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     default CompletableFuture<Void> truncate(long logIndex) {
       return CompletableFuture.completedFuture(null);
     }
@@ -230,6 +237,7 @@ public interface StateMachine extends Closeable {
      * @param firstTermIndexInLog The term-index of the first append entry available in the leader's log.
      * @return return the last term-index in the snapshot after the snapshot installation.
      */
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     default CompletableFuture<TermIndex> notifyInstallSnapshotFromLeader(
         RoleInfoProto roleInfoProto, TermIndex firstTermIndexInLog) {
       return CompletableFuture.completedFuture(null);

--- a/ratis-server/pom.xml
+++ b/ratis-server/pom.xml
@@ -90,5 +90,11 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderElection.java
@@ -191,7 +191,6 @@ class LeaderElection implements Runnable {
     this.lifeCycle = new LifeCycle(this);
     this.daemon = new Daemon(this);
     this.server = server;
-    RaftServerProxy proxy = server.getRaftServer();
     this.skipPreVote = skipPreVote ||
         !RaftServerConfigKeys.LeaderElection.preVote(
             server.getRaftServer().getProperties());

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/LeaderStateImpl.java
@@ -889,7 +889,7 @@ class LeaderStateImpl implements LeaderState {
                 "is higher than leader's:{} and leader's lastEntry is null",
             this, followerID, currentTerm, followerPriority, leaderPriority);
 
-        sendStartLeaderElectionToHigherPriorityPeer(followerID, leaderLastEntry);
+        sendStartLeaderElectionToHigherPriorityPeer(followerID, null);
         return;
       }
 

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequest.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/PendingRequest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.proto.RaftProtos.RaftClientRequestProto.TypeCase;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.protocol.*;
@@ -101,6 +102,7 @@ public class PendingRequest implements Comparable<PendingRequest> {
   }
 
   @Override
+  @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
   public int compareTo(PendingRequest that) {
     return Long.compare(this.index, that.index);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/StateMachineUpdater.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.CommitInfoProto;
 import org.apache.ratis.protocol.Message;
@@ -155,6 +156,7 @@ class StateMachineUpdater implements Runnable {
     notifyUpdater();
   }
 
+  @SuppressFBWarnings("NN_NAKED_NOTIFY")
   synchronized void notifyUpdater() {
     notifyAll();
   }

--- a/ratis-server/src/main/java/org/apache/ratis/server/impl/WatchRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/impl/WatchRequests.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.proto.RaftProtos.WatchRequestTypeProto;
@@ -135,6 +136,7 @@ class WatchRequests {
       return true;
     }
 
+    @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
     synchronized void updateIndex(final long newIndex) {
       if (newIndex <= getIndex()) { // compare again synchronized
         return;
@@ -185,6 +187,7 @@ class WatchRequests {
     Arrays.stream(ReplicationLevel.values()).forEach(r -> queues.put(r, new WatchQueue(r, elementLimit)));
   }
 
+  @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
   CompletableFuture<Void> add(RaftClientRequest request) {
     final WatchRequestTypeProto watch = request.getType().getWatch();
     final WatchQueue queue = queues.get(watch.getReplication());

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/InstallSnapshotRequests.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.leader;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.proto.RaftProtos.FileChunkProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotRequestProto.SnapshotChunkProto;
@@ -77,6 +78,7 @@ class InstallSnapshotRequests implements Iterable<InstallSnapshotRequestProto> {
       }
 
       @Override
+      @SuppressFBWarnings("IT_NO_SUCH_ELEMENT")
       public InstallSnapshotRequestProto next() {
         return nextInstallSnapshotRequestProto();
       }

--- a/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/leader/LogAppenderDefault.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.leader;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
 import org.apache.ratis.proto.RaftProtos.InstallSnapshotReplyProto;
@@ -42,6 +43,7 @@ class LogAppenderDefault extends LogAppenderBase {
   }
 
   /** Send an appendEntries RPC; retry indefinitely. */
+  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_OF_NULL_VALUE")
   private AppendEntriesReplyProto sendAppendEntriesWithRetries()
       throws InterruptedException, InterruptedIOException, RaftLogIOException {
     int retry = 0;

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegment.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.raftlog.segmented;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.proto.RaftProtos.LogEntryProto;
 import org.apache.ratis.server.RaftServerConfigKeys.Log.CorruptionPolicy;
 import org.apache.ratis.server.metrics.SegmentedRaftLogMetrics;
@@ -397,6 +398,7 @@ public final class LogSegment implements Comparable<Long> {
   }
 
   @Override
+  @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
   public int compareTo(Long l) {
     return (l >= getStartIndex() && l <= getEndIndex()) ? 0 :
         (this.getEndIndex() < l ? -1 : 1);

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegmentPath.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/LogSegmentPath.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.server.raftlog.segmented;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.server.storage.RaftStorage;
 import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
@@ -57,6 +58,7 @@ public final class LogSegmentPath implements Comparable<LogSegmentPath> {
   }
 
   @Override
+  @SuppressFBWarnings("EQ_COMPARETO_USE_OBJECT_EQUALS")
   public int compareTo(LogSegmentPath that) {
     return Comparator.comparing(LogSegmentPath::getStartEnd).compare(this, that);
   }
@@ -98,6 +100,7 @@ public final class LogSegmentPath implements Comparable<LogSegmentPath> {
     return Optional.ofNullable(matchCloseSegment(path)).orElseGet(() -> matchOpenSegment(path));
   }
 
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
   private static LogSegmentPath matchCloseSegment(Path path) {
     final Matcher matcher = LogSegmentStartEnd.getClosedSegmentPattern().matcher(path.getFileName().toString());
     if (matcher.matches()) {
@@ -107,6 +110,7 @@ public final class LogSegmentPath implements Comparable<LogSegmentPath> {
     return null;
   }
 
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
   private static LogSegmentPath matchOpenSegment(Path path) {
     final Matcher matcher = LogSegmentStartEnd.getOpenSegmentPattern().matcher(path.getFileName().toString());
     if (matcher.matches()) {

--- a/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/raftlog/segmented/SegmentedRaftLogWorker.java
@@ -19,6 +19,7 @@ package org.apache.ratis.server.raftlog.segmented;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Timer;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.proto.RaftProtos.StateMachineLogEntryProto;
 import org.apache.ratis.protocol.ClientInvocationId;
@@ -344,6 +345,7 @@ class SegmentedRaftLogWorker {
         (pendingFlushNum > 0 && queue.isEmpty());
   }
 
+  @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
   private void flushWrites() throws IOException {
     if (out != null) {
       LOG.debug("{}: flush {}", name, out);

--- a/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
+++ b/ratis-server/src/main/java/org/apache/ratis/server/storage/SnapshotManager.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.UUID;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.io.CorruptedFileException;
 import org.apache.ratis.io.MD5Hash;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -54,6 +55,7 @@ public class SnapshotManager {
     this.selfId = selfId;
   }
 
+  @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_BAD_PRACTICE")
   public void installSnapshot(StateMachine stateMachine,
       InstallSnapshotRequestProto request) throws IOException {
     final InstallSnapshotRequestProto.SnapshotChunkProto snapshotChunkRequest =

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/BaseStateMachine.java
@@ -19,6 +19,7 @@
 package org.apache.ratis.statemachine.impl;
 
 import com.codahale.metrics.Timer;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientRequest;
@@ -130,6 +131,7 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
     updateLastAppliedTermIndex(term, index);
   }
 
+  @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
   protected boolean updateLastAppliedTermIndex(long term, long index) {
     final TermIndex newTI = TermIndex.valueOf(term, index);
     final TermIndex oldTI = lastAppliedTermIndex.getAndSet(newTI);
@@ -192,6 +194,7 @@ public class BaseStateMachine implements StateMachine, StateMachine.DataApi,
   }
 
   @Override
+  @SuppressFBWarnings("NP_NULL_PARAM_DEREF")
   public CompletableFuture<Message> query(Message request) {
     return CompletableFuture.completedFuture(null);
   }

--- a/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
+++ b/ratis-server/src/main/java/org/apache/ratis/statemachine/impl/SimpleStateMachineStorage.java
@@ -17,6 +17,7 @@
  */
 package org.apache.ratis.statemachine.impl;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.ratis.io.MD5Hash;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.server.storage.FileInfo;
@@ -73,6 +74,7 @@ public class SimpleStateMachineStorage implements StateMachineStorage {
   }
 
   @Override
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
   public void cleanupOldSnapshots(SnapshotRetentionPolicy snapshotRetentionPolicy) throws IOException {
     if (snapshotRetentionPolicy != null && snapshotRetentionPolicy.getNumSnapshotsRetained() > 0) {
 
@@ -137,6 +139,7 @@ public class SimpleStateMachineStorage implements StateMachineStorage {
     return new File(smDir, getCorruptSnapshotFileName(term, endIndex));
   }
 
+  @SuppressFBWarnings("NP_NULL_ON_SOME_PATH")
   public SingleFileSnapshotInfo findLatestSnapshot() throws IOException {
     SingleFileSnapshotInfo latest = null;
     try (DirectoryStream<Path> stream =
@@ -179,6 +182,7 @@ public class SimpleStateMachineStorage implements StateMachineStorage {
 /**
  * Compare snapshot files based on transaction indexes.
  */
+@SuppressFBWarnings("SE_COMPARATOR_SHOULD_BE_SERIALIZABLE")
 class SnapshotFileComparator implements Comparator<SingleFileSnapshotInfo> {
   @Override
   public int compare(SingleFileSnapshotInfo file1, SingleFileSnapshotInfo file2) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add support for JaCoCo coverity analysis, run analysis during CI and upload results to SonarCloud for easy viewing.

(This is based on @adoroszlai #419 and #422 to reduce conflicts and take advantage of other recent Sonar analysis advancements)

## What is the link to the Apache JIRA

[https://issues.apache.org/jira/browse/RATIS-1314](https://issues.apache.org/jira/browse/RATIS-1314)

## How was this patch tested?

This patch has been manually tested. Preliminary results can be seen from the following links:
[https://github.com/softgitron/incubator-ratis/actions/runs/566463295](https://github.com/softgitron/incubator-ratis/actions/runs/566463295)
[https://sonarcloud.io/dashboard?id=softgitron_incubator-ratis](https://sonarcloud.io/dashboard?id=softgitron_incubator-ratis)


