### PR TITLE
RATIS-1315. Fix child module ratis-server-api does not exist.

### DIFF
--- a/ratis-assembly/pom.xml
+++ b/ratis-assembly/pom.xml
@@ -205,6 +205,10 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
+      <artifactId>ratis-server-api</artifactId>
+      <groupId>org.apache.ratis</groupId>
+    </dependency>
+    <dependency>
       <artifactId>ratis-server</artifactId>
       <groupId>org.apache.ratis</groupId>
     </dependency>

--- a/ratis-assembly/src/main/assembly/bin.xml
+++ b/ratis-assembly/src/main/assembly/bin.xml
@@ -38,6 +38,7 @@
         <include>org.apache.ratis:ratis-netty</include>
         <include>org.apache.ratis:ratis-proto</include>
         <include>org.apache.ratis:ratis-replicated-map</include>
+        <include>org.apache.ratis:ratis-server-api</include>
         <include>org.apache.ratis:ratis-server</include>
         <include>org.apache.ratis:ratis-test</include>
         <include>org.apache.ratis:ratis-metrics</include>

--- a/ratis-assembly/src/main/assembly/src.xml
+++ b/ratis-assembly/src/main/assembly/src.xml
@@ -40,6 +40,7 @@
         <include>org.apache.ratis:ratis-proto</include>
         <include>org.apache.ratis:ratis-docs</include>
         <include>org.apache.ratis:ratis-replicated-map</include>
+        <include>org.apache.ratis:ratis-server-api</include>
         <include>org.apache.ratis:ratis-server</include>
         <include>org.apache.ratis:ratis-test</include>
         <include>org.apache.ratis:ratis-metrics</include>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/RATIS-1315