### PR TITLE
RATIS-1320. Handle graduated repo in Github workflow

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -149,7 +149,7 @@ jobs:
   sonar:
     name: sonar
     runs-on: ubuntu-18.04
-    if: github.repository == 'apache/incubator-ratis' && github.event_name != 'pull_request'
+    if: (github.repository == 'apache/ratis' || github.repository == 'apache/incubator-ratis') && github.event_name != 'pull_request'
     steps:
         - uses: actions/checkout@master
         - name: Cache for maven dependencies


### PR DESCRIPTION
## What changes were proposed in this pull request?

In preparation for upcoming rename, let's execute _sonar_ check in both old and new repos.

https://issues.apache.org/jira/browse/RATIS-1320

## How was this patch tested?

Workflow syntax is validated, _sonar_ skipped in fork:
https://github.com/adoroszlai/incubator-ratis/runs/1941803835